### PR TITLE
RF: use explicit example  datetime with tzinfo set to tzutc()

### DIFF
--- a/dandi/tests/test_pynwb_utils.py
+++ b/dandi/tests/test_pynwb_utils.py
@@ -1,4 +1,9 @@
-from datetime import datetime
+from datetime import (
+    datetime,
+)
+from dateutil.tz import tzutc
+
+import pytz
 
 import pynwb
 
@@ -17,7 +22,10 @@ def simple1_nwb_metadata(tmpdir_factory):
     # very simple assignment with the same values as the key with 1 as suffix
     metadata = {f: "{}1".format(f) for f in metadata_fields}
     # tune specific ones:
-    metadata['session_start_time'] = datetime.today()
+    # Needs an explicit time zone since otherwise pynwb would add one
+    # But then comparison breaks anyways any ways yoh have tried to set it
+    # for datetime.now.  Taking example from pynwb tests
+    metadata['session_start_time'] = datetime(2017, 4, 15, 12, tzinfo=tzutc())
     metadata['keywords'] = ['keyword1', 'keyword 2']
     return metadata
 


### PR DESCRIPTION
Unfortunately test is still not passing, I am no longer certain with what version of pynwb/hdmf tandem I saw the test pass (besides the tzinfo), but when I use older one I see only `None` values. And with current `dev` of pynwb and hdmf I see that it loads some fields as "tuples":
```
(git)hopa:~/proj/dandi/dandi-cli[enh-ls]git
$> python -m pytest -s -vv dandi/tests/test_pynwb_utils.py
==================================================================== test session starts =====================================================================
platform linux -- Python 3.7.3rc1, pytest-3.10.1, py-1.7.0, pluggy-0.8.0 -- /home/yoh/proj/dandi/dandi-cli/venvs/dev3/bin/python
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/home/yoh/proj/dandi/dandi-cli/.hypothesis/examples')
rootdir: /home/yoh/proj/dandi/dandi-cli, inifile:
plugins: localserver-0.5.0, cov-2.6.0, hypothesis-3.71.11
collected 2 items                                                                                                                                            

dandi/tests/test_pynwb_utils.py::test_get_metadata FAILED
dandi/tests/test_pynwb_utils.py::test_pynwb_io PASSED

========================================================================== FAILURES ==========================================================================
_____________________________________________________________________ test_get_metadata ______________________________________________________________________

simple1_nwb = '/home/yoh/.tmp/pytest-of-yoh/pytest-44/data0/simple1.nwb'
simple1_nwb_metadata = {'experiment_description': 'experiment_description1', 'experimenter': 'experimenter1', 'identifier': 'identifier1', 'institution': 'institution1', ...}

    def test_get_metadata(simple1_nwb, simple1_nwb_metadata):
        target_metadata = simple1_nwb_metadata.copy()
        # we will also get some counts
        target_metadata['number_of_electrodes'] = 0
        target_metadata['number_of_units'] = 0
        # subject_id is also nohow specified in that file yet
        target_metadata['subject_id'] = None
>       assert target_metadata == get_metadata(str(simple1_nwb))
E       AssertionError: assert {'experiment_...tution1', ...} == {'experiment_d...tution1', ...}
E         Common items:
E         {'experiment_description': 'experiment_description1',
E          'identifier': 'identifier1',
E          'institution': 'institution1',
E          'keywords': ['keyword1', 'keyword 2'],
E          'lab': 'lab1',
E          'number_of_electrodes': 0,
E          'number_of_units': 0,
E          'session_description': 'session_description1',
E          'session_id': 'session_id1',
E          'session_start_time': datetime.datetime(2017, 4, 15, 12, 0, tzinfo=tzutc()),
E          'subject_id': None}
E         Differing items:
E         {'related_publications': 'related_publications1'} != {'related_publications': ('related_publications1',)}
E         {'experimenter': 'experimenter1'} != {'experimenter': ('experimenter1',)}
E         Full diff:
E         {'experiment_description': 'experiment_description1',
E         -  'experimenter': 'experimenter1',
E         +  'experimenter': ('experimenter1',),
E         ?                  +                ++
E         'identifier': 'identifier1',
E         'institution': 'institution1',
E         'keywords': ['keyword1', 'keyword 2'],
E         'lab': 'lab1',
E         'number_of_electrodes': 0,
E         'number_of_units': 0,
E         -  'related_publications': 'related_publications1',
E         +  'related_publications': ('related_publications1',),
E         ?                          +                        ++
E         'session_description': 'session_description1',
E         'session_id': 'session_id1',
E         'session_start_time': datetime.datetime(2017, 4, 15, 12, 0, tzinfo=tzutc()),
E         'subject_id': None}
```

@bendichter do you know if that is intended (i.e. feature) too?