### PR TITLE
RF: use callback mechanism of pyout to process files in parallel

### DIFF
--- a/dandi/cli/command.py
+++ b/dandi/cli/command.py
@@ -54,20 +54,40 @@ def get_files(paths, recursive=True, recurion_limit=None):
     return paths
 
 
-# TODO: RF to use as a callback. For some reason just hanged
-def get_metadata_pyout(path):
-    rec = {}
-    try:
-        meta = get_metadata(path)
-        # normalize some fields and remove completely empty
-        for f, v in meta.items():
-            if isinstance(v, (tuple, list)):
-                v = ', '.join(v)
-            if v:
-                rec[f] = v
-    except Exception as exc:
-        # lgr.error('Failed to get metadata from %s: %s', f, exc)
-        pass
+def get_metadata_pyout(path, callback=True):
+    """Return a metadata record for pyout
+
+    Parameters
+    ----------
+    path
+    callback: bool, optional
+      Either to provide a record only with the path and other fields
+      to be populated via a callback?
+
+    Returns
+    -------
+    dict
+    """
+    def _get_metadata_callback():
+        rec = {}
+        try:
+            meta = get_metadata(path)
+            # normalize some fields and remove completely empty
+            for f, v in meta.items():
+                if isinstance(v, (tuple, list)):
+                    v = ', '.join(v)
+                if v:
+                    rec[f] = v
+        except Exception as exc:
+            # lgr.error('Failed to get metadata from %s: %s', f, exc)
+            pass
+        return rec
+
+    rec = {'path': path}
+    if callback:
+        rec['session_id'] = _get_metadata_callback
+    else:
+        rec.update(_get_metadata_callback())
     return rec
 
 


### PR DESCRIPTION
unfortunately it stalls for unknown reason with first file record never populated

    $> dandi ls /home/yoh/proj/dandi/nwb-datasets/najafi-2018-nwb/data/FN_dataSharing/nwb/mouse1_fni16_15081{7,8}*nwb
    PATH                                                          SIZE     EXPERIMENTER    SESSION_ID   SESSION_START_TIME   KEYWORDS
    ...use1_fni16_150817_001_ch2-PnevPanResults-170808-190057.nwb 302.9 MB
    ...use1_fni16_150818_001_ch2-PnevPanResults-170808-180842.nwb 227.7 MB Farzaneh Najafi 170808180842 2015-08-17/20:00:00

that sample dataset could be obtained from

   https://github.com/dandi/najafi-2018-nwb

with nwb data hosted on

   http://datasets.datalad.org/?dir=/labs/churchland/najafi-2018-nwb

and linked to that github repo as autoenabled special remote.