### PR TITLE
ENH: ls - list NWB (version), lab, subject_id  where available; ignore warnings upon validate

### DIFF
--- a/dandi/cli/command.py
+++ b/dandi/cli/command.py
@@ -147,9 +147,10 @@ def ls(paths):
             'path',
             'size',
             #'experiment_description',
-            #'lab',
+            'lab',
             'experimenter',
             'session_id',
+            'subject_id',
             'session_start_time',
             #'identifier',  # note: required arg2 of NWBFile
             #'institution',

--- a/dandi/cli/command.py
+++ b/dandi/cli/command.py
@@ -73,10 +73,10 @@ def get_metadata_pyout(path):
 
     if 'nwb_version' not in rec:
         # Let's at least get that one
-        rec['NWB'] = get_nwb_version(path)
+        rec['NWB'] = get_nwb_version(path) or ''
     else:
         # renames for more concise ls
-        rec['NWB'] = rec.pop('nwb_version', None)
+        rec['NWB'] = rec.pop('nwb_version', '')
     return rec
 
 

--- a/dandi/cli/command.py
+++ b/dandi/cli/command.py
@@ -116,7 +116,8 @@ def ls(paths):
                 underline=True,
                 width=dict(
                     truncate='left',
-                    max=max_filename_len + 1
+                    #min=max_filename_len + 4 #  .../
+                    #min=0.3  # not supported yet by pyout, https://github.com/pyout/pyout/issues/85
                 ),
                 aggregate=lambda _: "Summary:"
                 # TODO: seems to be wrong

--- a/dandi/cli/command.py
+++ b/dandi/cli/command.py
@@ -16,7 +16,10 @@ from .. import get_logger
 
 from collections import OrderedDict
 
-from ..pynwb_utils import get_metadata
+from ..pynwb_utils import (
+    get_metadata,
+    get_nwb_version,
+)
 from ..support import pyout as pyouts
 
 lgr = get_logger()
@@ -66,8 +69,14 @@ def get_metadata_pyout(path):
             if v:
                 rec[f] = v
     except Exception as exc:
-        # lgr.error('Failed to get metadata from %s: %s', f, exc)
-        pass
+        lgr.debug('Failed to get metadata from %s: %s', path, exc)
+
+    if 'nwb_version' not in rec:
+        # Let's at least get that one
+        rec['NWB'] = get_nwb_version(path)
+    else:
+        # renames for more concise ls
+        rec['NWB'] = rec.pop('nwb_version', None)
     return rec
 
 
@@ -145,6 +154,7 @@ def ls(paths):
     out = pyout.Tabular(
         columns=[
             'path',
+            'NWB',
             'size',
             #'experiment_description',
             'lab',

--- a/dandi/cli/command.py
+++ b/dandi/cli/command.py
@@ -73,7 +73,11 @@ def get_metadata_pyout(path):
 
     if 'nwb_version' not in rec:
         # Let's at least get that one
-        rec['NWB'] = get_nwb_version(path) or ''
+        try:
+            rec['NWB'] = get_nwb_version(path) or ''
+        except Exception as exc:
+            rec['NWB'] = 'ERROR'
+            lgr.debug('Failed to get even nwb_version from %s: %s', path, exc)
     else:
         # renames for more concise ls
         rec['NWB'] = rec.pop('nwb_version', '')

--- a/dandi/cli/command.py
+++ b/dandi/cli/command.py
@@ -195,6 +195,18 @@ def validate(paths):
     """
     files = get_files(paths)
     import pynwb
+    import warnings
+
+    # below we are using load_namespaces but it causes HDMF to whine if there
+    # is no cached name spaces in the file.  It is benign but not really useful
+    # at this point, so we ignore it although ideally there should be a formal
+    # way to get relevant warnings (not errors) from PyNWB
+    #   See https://github.com/dandi/dandi-cli/issues/14 for more info
+    for s in (
+            "No cached namespaces found .*",
+            "ignoring namespace 'core' because it already exists"
+    ):
+        warnings.filterwarnings('ignore', s, UserWarning)
 
     errors = {}
     for path in files:


### PR DESCRIPTION
Commit comment in 1fd302325803f442162e3757414b5fc90ac1d502 summarizes situation with nwb_version a bit:

    ENH: obtain also "nwb_version", ls it as NWB field in the table
    
    I went for a shorter name in  ls  command since space is scarse.
    
    Unfortunately I could not immediately figure out how to even populate
    that field e.g. using NWBFile.  And PyNWB does not populate it
    either ATM: https://github.com/NeurodataWithoutBorders/pynwb/issues/1085
    
    The only example I found quickly with nwb_version field populated was from
    ///crcns/ssc-7 dataset -- and in particular
    data/L4E_whole_cell/Exp_2015-09-05_001_0001-0162.nwb
    file there.
    
    I really think we should come up with some good, and not that large collection
    of sample .nwb files to test on.  Unfortunately any "real" .nwb file seems to be
    quite large

Closes #13 