### PR TITLE
ENH: ls - hide empty columns; --format to choose output format

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - windows-2019,
+          - windows-2019
           - ubuntu-18.04
         python:
           - 3.6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install ".[tests]"
+        pip install ".[test]"
     - name: ${{ matrix.module }} tests
       run: |
         python -m pytest -s -v --cov=dandi dandi

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 pip-wheel-metadata/
 sandbox/
 venvs/
+.coverage

--- a/dandi/__init__.py
+++ b/dandi/__init__.py
@@ -1,5 +1,5 @@
 import logging
-
+import os
 from . import _version
 
 __version__ = _version.get_versions()["version"]
@@ -16,10 +16,23 @@ def get_logger(name=None):
     return logging.getLogger("dandi" + (".%s" % name if name else ""))
 
 
+def set_logger_level(lgr, level):
+    if isinstance(level, int):
+        pass
+    elif level.isnumeric():
+        level = int(level)
+    elif level.isalpha():
+        level = getattr(logging, level)
+    else:
+        lgr.warning("Do not know how to treat loglevel %s" % level)
+        return
+    lgr.setLevel(level)
+
+
 _DEFAULT_LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 
 lgr = get_logger()
 # Basic settings for output, for now just basic
-lgr.setLevel(logging.INFO)
+set_logger_level(lgr, os.environ.get("DANDI_LOG_LEVEL", logging.INFO))
 FORMAT = "%(asctime)-15s [%(levelname)8s] %(message)s"
 logging.basicConfig(format=FORMAT)

--- a/dandi/cli/command.py
+++ b/dandi/cli/command.py
@@ -180,11 +180,10 @@ def ls(paths, fields=None, format="auto"):
     with out:
         for path in files:
             rec = {}
-            if fields and "path" in fields:
-                rec["path"] = path
+            rec["path"] = path
 
             try:
-                if fields and "size" in fields:
+                if not fields or "size" in fields:
                     rec["size"] = os.stat(path).st_size
 
                 if async_keys:

--- a/dandi/cli/command.py
+++ b/dandi/cli/command.py
@@ -10,7 +10,7 @@ import click
 from click_didyoumean import DYMGroup
 
 import logging
-from .. import get_logger
+from .. import get_logger, set_logger_level
 
 from collections import OrderedDict
 
@@ -48,7 +48,7 @@ def print_version(ctx, param, value):
 )
 @click.option("--pdb", help="Fall into pdb if errors out", is_flag=True)
 def main(log_level, pdb=False):
-    get_logger().setLevel(log_level)  # common one
+    set_logger_level(get_logger(), log_level)  # common one
     if pdb:
         from ..utils import setup_exceptionhook
 

--- a/dandi/cli/command.py
+++ b/dandi/cli/command.py
@@ -179,9 +179,14 @@ def ls(paths, fields=None, format="auto"):
 
     with out:
         for path in files:
-            rec = {"path": path}
+            rec = {}
+            if fields and "path" in fields:
+                rec["path"] = path
+
             try:
-                rec["size"] = os.stat(path).st_size
+                if fields and "size" in fields:
+                    rec["size"] = os.stat(path).st_size
+
                 if async_keys:
                     cb = get_metadata_pyout(path, async_keys)
                     if format == "pyout":
@@ -195,9 +200,6 @@ def ls(paths, fields=None, format="auto"):
                 lgr.debug("File is not available: %s", exc)
             except Exception as exc:
                 lgr.debug("Problem obtaining metadata for %s: %s", path, exc)
-            if fields:
-                # strip away those few which we hard set
-                rec = {k: v for k, v in rec.items() if k in fields}
             if not rec:
                 lgr.debug("Skipping a record for %s since emtpy", path)
                 continue

--- a/dandi/cli/formatter.py
+++ b/dandi/cli/formatter.py
@@ -22,9 +22,9 @@ class Formatter(object):
 
 
 class JSONFormatter(Formatter):
-    def __init__(self, indent=None, out=sys.stdout):
+    def __init__(self, indent=None, out=None):
+        self.out = out or sys.stdout
         self.indent = indent
-        self.out = out
 
     @staticmethod
     def _serializer(o):
@@ -41,8 +41,8 @@ class JSONFormatter(Formatter):
 
 
 class YAMLFormatter(Formatter):
-    def __init__(self, out=sys.stdout):
-        self.out = out
+    def __init__(self, out=None):
+        self.out = out or sys.stdout
         self.records = []
 
     def __exit__(self, exc_type, exc_value, traceback):

--- a/dandi/cli/formatter.py
+++ b/dandi/cli/formatter.py
@@ -1,0 +1,44 @@
+import datetime
+import sys
+
+
+class JSONFormatter(object):
+    def __init__(self, indent=None, out=sys.stdout):
+        self.indent = indent
+        self.out = out
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        pass
+
+    @staticmethod
+    def _serializer(o):
+        if isinstance(o, datetime.datetime):
+            return o.__str__()
+        return o
+
+    def __call__(self, rec):
+        import json
+
+        self.out.write(
+            json.dumps(rec, indent=self.indent, default=self._serializer) + "\n"
+        )
+
+
+class YAMLFormatter(object):
+    def __init__(self, out=sys.stdout):
+        self.out = out
+        self.records = []
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        import yaml
+
+        self.out.write(yaml.dump(self.records))
+
+    def __call__(self, rec):
+        self.records.append(rec)

--- a/dandi/cli/formatter.py
+++ b/dandi/cli/formatter.py
@@ -1,17 +1,30 @@
 import datetime
+import os.path as op
 import sys
 
+import pyout
+from ..support import pyout as pyouts
 
-class JSONFormatter(object):
-    def __init__(self, indent=None, out=sys.stdout):
-        self.indent = indent
-        self.out = out
+from .. import get_logger
 
+lgr = get_logger()
+
+
+class Formatter(object):
     def __enter__(self):
         pass
 
     def __exit__(self, exc_type, exc_value, traceback):
         pass
+
+    def __call__(self, rec):
+        pass
+
+
+class JSONFormatter(Formatter):
+    def __init__(self, indent=None, out=sys.stdout):
+        self.indent = indent
+        self.out = out
 
     @staticmethod
     def _serializer(o):
@@ -27,13 +40,10 @@ class JSONFormatter(object):
         )
 
 
-class YAMLFormatter(object):
+class YAMLFormatter(Formatter):
     def __init__(self, out=sys.stdout):
         self.out = out
         self.records = []
-
-    def __enter__(self):
-        pass
 
     def __exit__(self, exc_type, exc_value, traceback):
         import yaml
@@ -42,3 +52,89 @@ class YAMLFormatter(object):
 
     def __call__(self, rec):
         self.records.append(rec)
+
+
+PYOUT_SHORT_NAMES = {
+    # shortening for some fields
+    "nwb_version": "NWB",
+    "number_of_electrodes": "#electrodes",
+    "number_of_units": "#units",
+    # 'annex_local_size': 'annex(present)',
+    # 'annex_worktree_size': 'annex(worktree)',
+}
+# For reverse lookup
+PYOUT_SHORT_NAMES_rev = {v.lower(): k for k, v in PYOUT_SHORT_NAMES.items()}
+
+
+class PYOUTFormatter(pyout.Tabular):
+    def __init__(self, files, fields):
+        max_filename_len = max(map(lambda x: len(op.basename(x)), files))
+        # Needs to stay here due to use of  counts/mapped_counts
+        PYOUT_STYLE = {
+            "summary_": {"bold": True},
+            "header_": dict(
+                bold=True, transform=lambda x: PYOUT_SHORT_NAMES.get(x, x).upper()
+            ),
+            "default_": dict(missing=""),
+            "path": dict(
+                bold=True,
+                align="left",
+                underline=True,
+                width=dict(
+                    truncate="left",
+                    # min=max_filename_len + 4 #  .../
+                    # min=0.3  # not supported yet by pyout,
+                    # https://github.com/pyout/pyout/issues/85
+                ),
+                aggregate=lambda _: "Summary:"
+                # TODO: seems to be wrong
+                # width='auto'
+                # summary=lambda x: "TOTAL: %d" % len(x)
+            ),
+            # ('type', dict(
+            #     transform=lambda s: "%s" % s,
+            #     aggregate=counts,
+            #     missing='-',
+            #     # summary=summary_counts
+            # )),
+            # ('describe', dict(
+            #     transform=empty_for_none)),
+            # ('clean', dict(
+            #     color='green',
+            #     transform=fancy_bool,
+            #     aggregate=mapped_counts({False: fancy_bool(False),
+            #                              True: fancy_bool(True)}),
+            #     delayed="group-git"
+            # )),
+            "size": dict(pyouts.size_style),
+            "nwb_version": {},  # Just to establish the order
+            "session_start_time": dict(
+                transform=pyouts.datefmt,
+                aggregate=pyouts.summary_dates,
+                # summary=summary_dates
+            ),
+        }
+        # To just quickly switch for testing released or not released (with
+        # hide)
+        # pyout
+        if "hide" in pyout.elements.schema["definitions"]:
+            lgr.debug("pyout with 'hide' support detected")
+            PYOUT_STYLE["default_"]["hide"] = "if_missing" if not fields else False
+            for f in "path", "size":
+                PYOUT_STYLE[f]["hide"] = False
+        else:
+            lgr.warning("pyout without 'hide' support. Expect too many columns")
+
+        if not sys.stdout.isatty():
+            # TODO: ATM width in the final mode is hardcoded
+            #  https://github.com/pyout/pyout/issues/70
+            # and depending on how it would be resolved, there might be a
+            # need to specify it here as "max" or smth like that.
+            # For now hardcoding to hopefully wide enough 200 if stdout is not
+            # a tty
+            PYOUT_STYLE["width_"] = 200
+
+        kw = dict(style=PYOUT_STYLE)
+        if fields:
+            kw["columns"] = fields
+        super().__init__(**kw)

--- a/dandi/cli/tests/test_command.py
+++ b/dandi/cli/tests/test_command.py
@@ -10,13 +10,13 @@ import pytest
 @pytest.mark.parametrize("command", (ls, validate))
 def test_smoke(simple1_nwb, command):
     runner = CliRunner()
-    result = runner.invoke(command, [simple1_nwb])
-    assert result.exit_code == 0
-    # we would need to redirect pyout for its analysis
+    r = runner.invoke(command, [simple1_nwb])
+    assert r.exit_code == 0, f"Exited abnormally. out={r.stdout}"
+    assert r.stdout, "There were no output whatsoever"
 
     # empty invocation should not crash
-    result = runner.invoke(command, [])
-    assert result.exit_code == 0
+    r = runner.invoke(command, [])
+    assert r.exit_code == 0, f"Exited abnormally. out={r.stdout}"
 
 
 def test_no_heavy_imports():

--- a/dandi/cli/tests/test_ls.py
+++ b/dandi/cli/tests/test_ls.py
@@ -21,7 +21,7 @@ def test_smoke(simple1_nwb_metadata, simple1_nwb, format):
         import yaml
 
         def load(s):
-            obj = yaml.load(s)
+            obj = yaml.load(s, Loader=yaml.BaseLoader)
             assert len(obj) == 1  # will be a list with a single elem
             return obj[0]
 

--- a/dandi/cli/tests/test_ls.py
+++ b/dandi/cli/tests/test_ls.py
@@ -1,0 +1,27 @@
+from click.testing import CliRunner
+import pytest
+
+from ..command import ls
+
+
+@pytest.mark.parametrize("format", ("auto", "json", "json_pp", "yaml", "pyout"))
+def test_smoke(simple1_nwb, format):
+    runner = CliRunner()
+    result = runner.invoke(ls, ["-f", format, simple1_nwb])
+    # import pdb; pdb.set_trace()
+    assert result.exit_code == 0
+    # we would need to redirect pyout for its analysis
+    out = result.stdout
+    # Something is off:
+    #   When I run only test_smoke[yaml] -- there is out, otherwise it is empty
+    return  # TODO - fix up
+    if format.startswith("json"):
+        import json
+
+        assert json.loads(out)
+    elif format == "yaml":
+        print("OUT:", out)
+        import yaml
+
+        obj = yaml.load(out)
+        assert obj

--- a/dandi/cli/tests/test_ls.py
+++ b/dandi/cli/tests/test_ls.py
@@ -7,11 +7,10 @@ from ..command import ls
 @pytest.mark.parametrize("format", ("auto", "json", "json_pp", "yaml", "pyout"))
 def test_smoke(simple1_nwb, format):
     runner = CliRunner()
-    result = runner.invoke(ls, ["-f", format, simple1_nwb])
-    # import pdb; pdb.set_trace()
-    assert result.exit_code == 0
+    r = runner.invoke(ls, ["-f", format, simple1_nwb])
+    assert r.exit_code == 0, f"Exited abnormally. out={r.stdout}"
     # we would need to redirect pyout for its analysis
-    out = result.stdout
+    out = r.stdout
     # Something is off:
     #   When I run only test_smoke[yaml] -- there is out, otherwise it is empty
     return  # TODO - fix up

--- a/dandi/cli/tests/test_ls.py
+++ b/dandi/cli/tests/test_ls.py
@@ -2,25 +2,35 @@ from click.testing import CliRunner
 import pytest
 
 from ..command import ls
+from ...pynwb_utils import metadata_fields
 
 
 @pytest.mark.parametrize("format", ("auto", "json", "json_pp", "yaml", "pyout"))
-def test_smoke(simple1_nwb, format):
+def test_smoke(simple1_nwb_metadata, simple1_nwb, format):
     runner = CliRunner()
     r = runner.invoke(ls, ["-f", format, simple1_nwb])
     assert r.exit_code == 0, f"Exited abnormally. out={r.stdout}"
     # we would need to redirect pyout for its analysis
     out = r.stdout
-    # Something is off:
-    #   When I run only test_smoke[yaml] -- there is out, otherwise it is empty
-    return  # TODO - fix up
+
     if format.startswith("json"):
         import json
 
-        assert json.loads(out)
+        load = json.loads
     elif format == "yaml":
-        print("OUT:", out)
         import yaml
 
-        obj = yaml.load(out)
-        assert obj
+        def load(s):
+            obj = yaml.load(s)
+            assert len(obj) == 1  # will be a list with a single elem
+            return obj[0]
+
+    else:
+        return
+
+    metadata = load(out)
+    assert metadata
+    # check a few fields
+    assert metadata.pop("nwb_version").startswith("2.")
+    for f in ["session_id", "experiment_description"]:
+        assert metadata[f] == simple1_nwb_metadata[f]

--- a/dandi/consts.py
+++ b/dandi/consts.py
@@ -1,0 +1,30 @@
+# A list of metadata fields which dandi extracts from .nwb files.
+# Additional fields (such as `number_of_*`) might be added by the
+# get_metadata`
+metadata_fields = (
+    "experiment_description",
+    "experimenter",
+    "identifier",  # note: required arg2 of NWBFile
+    "institution",
+    "keywords",
+    "lab",
+    "related_publications",
+    "session_description",  # note: required arg1 of NWBFile
+    "session_id",
+    "session_start_time",
+)
+
+metadata_subject_fields = (
+    "age",
+    "date_of_birth",
+    "genotype",
+    "sex",
+    "species",
+    "subject_id",
+)
+
+metadata_computed_fields = ("number_of_electrodes", "number_of_units", "nwb_version")
+
+metadata_all_fields = (
+    metadata_fields + metadata_subject_fields + metadata_computed_fields
+)

--- a/dandi/pynwb_utils.py
+++ b/dandi/pynwb_utils.py
@@ -5,36 +5,7 @@ from . import get_logger
 
 lgr = get_logger()
 
-# A list of metadata fields which dandi extracts from .nwb files.
-# Additional fields (such as `number_of_*`) might be added by the
-# get_metadata`
-metadata_fields = (
-    "experiment_description",
-    "experimenter",
-    "identifier",  # note: required arg2 of NWBFile
-    "institution",
-    "keywords",
-    "lab",
-    "related_publications",
-    "session_description",  # note: required arg1 of NWBFile
-    "session_id",
-    "session_start_time",
-)
-
-metadata_subject_fields = (
-    "age",
-    "date_of_birth",
-    "genotype",
-    "sex",
-    "species",
-    "subject_id",
-)
-
-metadata_computed_fields = ("number_of_electrodes", "number_of_units", "nwb_version")
-
-metadata_all_fields = (
-    metadata_fields + metadata_subject_fields + metadata_computed_fields
-)
+from .consts import metadata_fields, metadata_computed_fields, metadata_subject_fields
 
 
 def get_nwb_version(filepath):

--- a/dandi/pynwb_utils.py
+++ b/dandi/pynwb_utils.py
@@ -30,6 +30,12 @@ metadata_subject_fields = (
     "subject_id",
 )
 
+metadata_computed_fields = ("number_of_electrodes", "number_of_units", "nwb_version")
+
+metadata_all_fields = (
+    metadata_fields + metadata_subject_fields + metadata_computed_fields
+)
+
 
 def get_nwb_version(filepath):
     """Return a version of the NWB standard used by a file
@@ -85,7 +91,14 @@ def get_metadata(filepath):
         # Add a few additional useful fields
 
         # Counts
-        for f in ["electrodes", "units"]:
-            out["number_of_{}".format(f)] = len(getattr(nwb, f, []) or [])
+        for f in metadata_computed_fields:
+            if f in ("nwb_version",):
+                continue
+            if not f.startswith("number_of_"):
+                raise NotImplementedError(
+                    "ATM can only compute number_of_ fields. Got {}".format(f)
+                )
+            key = f[len("number_of_") :]
+            out[f] = len(getattr(nwb, key, []) or [])
 
     return out

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ install_requires =
     click-didyoumean
     pyout
     humanize
+    pyyaml
 tests_require =
     pytest
 # TODO: figure out. For now alias test


### PR DESCRIPTION
https://github.com/pyout/pyout/pull/86 is to add ability to hide columns which had no value in any of the rows.  This way we could aim to display the pertinent extended list of columns/metadata for the files at hand.
Overall - it works! formatting is a bit off, will report in pyout PR

By mistake pushed here also `--format` (Closes #25), and decided to just let it be here.  Unless there would be a need, let's proceed with changes "in bulk"

TODOs:
- [ ] wait for pyout release, adjust version in setup.cfg