### PR TITLE
RF: ls - use wait_for_top (seems to not of effect as of pyout 0.5.0), allow ls of non-existing files

### DIFF
--- a/dandi/cli/formatter.py
+++ b/dandi/cli/formatter.py
@@ -59,7 +59,7 @@ class PYOUTFormatter(pyout.Tabular):
         # max_filename_len = max(map(lambda x: len(op.basename(x)), files))
         PYOUT_STYLE = pyouts.get_style(hide_if_missing=not fields)
 
-        kw = dict(style=PYOUT_STYLE)
+        kw = dict(wait_for_top=2, style=PYOUT_STYLE)
         if fields:
             kw["columns"] = fields
         super().__init__(**kw)

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     hdmf != 1.1.2
     click
     click-didyoumean
-    pyout
+    pyout >= 0.5.0
     humanize
     pyyaml
     keyring


### PR DESCRIPTION
I was testing on http://github.com/dandi/najafi-2018-nwb  where I have fetched only a few
files

    (git-annex)lena:~/proj/dandi/nwb-datasets/najafi-2018-nwb[master]data/FN_dataSharing/nwb
    $> git annex list . | head -n 20
    here
    |origin
    ||smaug
    |||upstream
    ||||web
    |||||bittorrent
    ||||||datalad-archives
    |||||||
    X_X____ mouse1_fni16_150817_001_ch2-PnevPanResults-170808-190057.nwb
    X_X____ mouse1_fni16_150818_001_ch2-PnevPanResults-170808-180842.nwb
    __X____ mouse1_fni16_150819_001_ch2-PnevPanResults-170815-163235.nwb
    __X____ mouse1_fni16_150820_001_ch2-PnevPanResults-170808-185044.nwb
    __X____ mouse1_fni16_150821_001-002_ch2-PnevPanResults-170808-184141.nwb
    __X____ mouse1_fni16_150825_001-002-003_ch2-PnevPanResults-170814-191401.nwb
    __X____ mouse1_fni16_150826_001_ch2-PnevPanResults-170808-002053.nwb
    __X____ mouse1_fni16_150827_001_ch2-PnevPanResults-170807-171156.nwb
    __X____ mouse1_fni16_150828_001-002_ch2-PnevPanResults-170807-204746.nwb
    __X____ mouse1_fni16_150831_001-002_ch2-PnevPanResults-170807-193348.nwb
    X_X____ mouse1_fni16_150901_001_ch2-PnevPanResults-170807-072732.nwb
    X_X____ mouse1_fni16_150903_001_ch2-PnevPanResults-170809-075033.nwb
    ...

and was expecting pyout to wait until first two processed before considering other
ones for even showing (like the removed loop was doing, just for a different number
of rows).  But unfortunately it is not the case -- it is immediately lists all while
actively working (the callback returned values appear later) on those files with
content:

<details>
<summary>najafi-2018-nwb example:</summary> 

	(git-annex)lena:~/proj/dandi/nwb-datasets/najafi-2018-nwb[master]data/FN_dataSharing/nwb
	$> dandi ls mouse1_fni16_150*
	PATH                                                                     SIZE
	mouse1_fni16_150817_001_ch2-PnevPanResults-170808-190057.nwb             302.9 MB
	mouse1_fni16_150818_001_ch2-PnevPanResults-170808-180842.nwb             227.7 MB
	mouse1_fni16_150819_001_ch2-PnevPanResults-170815-163235.nwb
	mouse1_fni16_150820_001_ch2-PnevPanResults-170808-185044.nwb
	mouse1_fni16_150821_001-002_ch2-PnevPanResults-170808-184141.nwb
	mouse1_fni16_150825_001-002-003_ch2-PnevPanResults-170814-191401.nwb
	mouse1_fni16_150826_001_ch2-PnevPanResults-170808-002053.nwb
	mouse1_fni16_150827_001_ch2-PnevPanResults-170807-171156.nwb
	mouse1_fni16_150828_001-002_ch2-PnevPanResults-170807-204746.nwb
	mouse1_fni16_150831_001-002_ch2-PnevPanResults-170807-193348.nwb
	mouse1_fni16_150901_001_ch2-PnevPanResults-170807-072732.nwb             458.6 MB
	mouse1_fni16_150903_001_ch2-PnevPanResults-170809-075033.nwb             1.2 GB
	mouse1_fni16_150904_001_ch2-PnevPanResults-170809-073123.nwb
	mouse1_fni16_150915_001_ch2-PnevPanResults-170806-163508.nwb
	mouse1_fni16_150916_001-002_ch2-PnevPanResults-170806-114920.nwb
	mouse1_fni16_150917_001_ch2-PnevPanResults-170806-110934.nwb
	mouse1_fni16_150918_001-002-003-004_ch2-PnevPanResults-170715-124821.nwb
	mouse1_fni16_150921_001_ch2-PnevPanResults-170715-114212.nwb
	mouse1_fni16_150922_001_ch2-PnevPanResults-170715-120548.nwb
	mouse1_fni16_150923_001_ch2-PnevPanResults-170715-124558.nwb
	mouse1_fni16_150924_001_ch2-PnevPanResults-170715-124619.nwb
	mouse1_fni16_150925_001-002-003_ch2-PnevPanResults-170715-164713.nwb
	mouse1_fni16_150928_001-002_ch2-PnevPanResults-170716-002540.nwb
	mouse1_fni16_150929_001-002_ch2-PnevPanResults-170715-205011.nwb
	mouse1_fni16_150930_001-002_ch2-PnevPanResults-161221-134921.nwb
	Summary:                                                                 2.2 GB
	^C
	Keyboard interrupt registered
	Canceled pending asynchronous workers. 4 workers already running

	Aborted!
	[1]    197373 segmentation fault (core dumped)  dandi ls mouse1_fni16_150*
	dandi ls mouse1_fni16_150*  24.48s user 1.34s system 107% cpu 24.078 total

</details>

Note that there is also a segfault which I have not seen before, but it could be something
"new". To be troubleshooted separately. Happens even when not interrupted.

<details>
<summary>Similar situation with http://github.com/dandi-datasets/nwb_test_data - seems nothing is waiting for anything, header escapes from the screen etc.  Here is a dump with scrolling terminal beyond visible:</summary> 

```shell
(git-annex)lena:~/proj/dandi/nwb-datasets/nwb_test_data[master]git
$> dandi ls v2.0.*/*nwb
PATH                                       SIZE     IDENTIFIER SESSION_DESCRIPTION SESSION_START_TIME   #ELECTRODES NWB 
PATH                                       SIZE     IDENTIFIER  SESSION_DESCRIPTION                         SESSION_START_TIME   #ELECTRODES NWB 
PATH                                       SIZE     IDENTIFIER      SESSION_DESCRIPTION                             SESSION_START_TIME   #ELECTRODES NWB 
PATH                                       SIZE     IDENTIFIER        SESSION_DESCRIPTION                               SESSION_START_TIME   #ELECTRODES #UNITS NWB 
PATH                                       SIZE     IDENTIFIER            SESSION_DESCRIPTION                                   SESSION_START_TIME   #ELECTRODES #UNITS NWB 
PATH                                       SIZE     IDENTIFIER                  SESSION_DESCRIPTION                                         SESSION_START_TIME   #ELECTRODES #UNITS NWB 
v2.0.0/test_append.nwb                     43.1 kB  hi                          hi                                                          1970-01-01/12:00:00  1                  2.0b
v2.0.0/test_Clustering.nwb                 17.8 kB  TEST_Clustering             a file to test writing and reading a Clustering             1971-01-01/12:00:00                     2.0b
PATH                                       SIZE     IDENTIFIER                      SESSION_DESCRIPTION                                             SESSION_START_TIME   #ELECTRODES #UNITS NWB 
v2.0.0/test_append.nwb                     43.1 kB  hi                              hi                                                              1970-01-01/12:00:00  1                  2.0b
v2.0.0/test_Clustering.nwb                 17.8 kB  TEST_Clustering                 a file to test writing and reading a Clustering                 1971-01-01/12:00:00                     2.0b
PATH                                       SIZE     IDENTIFIER                      SESSION_DESCRIPTION                                SESSION_START_TIME   AGE   GENOTYPE SEX SPECIES           SUBJECT_ID #ELECTRODES #UNITS NWB 
v2.0.0/test_append.nwb                     43.1 kB  hi                              hi                                                 1970-01-01/12:00:00                                                  1                  2.0b
v2.0.0/test_Clustering.nwb                 17.8 kB  TEST_Clustering                 a file to test writing and reading a Clustering    1971-01-01/12:00:00                                                                     2.0b
v2.0.0/test_ClusterWaveforms.nwb           20.0 kB  TEST_ClusterWaveforms           a file to test writing and reading a ClusterWav... 1971-01-01/12:00:00                                                                     2.0b
v2.0.0/test_CurrentClampSeries.nwb         25.5 kB  TEST_CurrentClampSeries         a file to test writing and reading a CurrentCla... 1971-01-01/12:00:00                                                                     2.0b
v2.0.0/test_CurrentClampStimulusSeries.nwb 24.7 kB  TEST_CurrentClampStimulusSeries a file to test writing and reading a CurrentCla... 1971-01-01/12:00:00                                                                     2.0b
v2.0.0/test_DecompositionSeries.nwb        24.8 kB  TEST_DecompositionSeries        a file to test writing and reading a Decomposit... 1971-01-01/12:00:00                                                                     2.0b
v2.0.0/test_Device.nwb                     17.4 kB  TEST_Device                     a file to test writing and reading a Device        1971-01-01/12:00:00                                                                     2.0b
v2.0.0/test_DynamicTable.nwb               18.0 kB  TEST_DynamicTable               a file to test writing and reading a DynamicTable  1971-01-01/12:00:00                                                              2      2.0b
v2.0.0/test_ElectricalSeries.nwb           29.5 kB  TEST_ElectricalSeries           a file to test writing and reading a Electrical... 1971-01-01/12:00:00                                                  4                  2.0b
v2.0.0/test_ElectrodeGroup.nwb             19.8 kB  TEST_ElectrodeGroup             a file to test writing and reading a ElectrodeG... 1971-01-01/12:00:00                                                                     2.0b
v2.0.0/test_EventDetection.nwb             31.7 kB  TEST_EventDetection             a file to test writing and reading a EventDetec... 1971-01-01/12:00:00                                                  4                  2.0b
v2.0.0/test_EventWaveform.nwb              30.7 kB  TEST_EventWaveform              a file to test writing and reading a EventWaveform 1971-01-01/12:00:00                                                  4                  2.0b
v2.0.0/test_FeatureExtraction.nwb          29.3 kB  TEST_FeatureExtraction          a file to test writing and reading a FeatureExt... 1971-01-01/12:00:00                                                  4                  2.0b
v2.0.0/test_FilteredEphys.nwb              33.6 kB  TEST_FilteredEphys              a file to test writing and reading a FilteredEphys 1971-01-01/12:00:00                                                  4                  2.0b
v2.0.0/test_ImagingPlane.nwb               23.3 kB  TEST_ImagingPlane               a file to test writing and reading a ImagingPlane  1971-01-01/12:00:00                                                                     2.0b
v2.0.0/test_IntracellularElectrode.nwb     21.7 kB  TEST_IntracellularElectrode     a file to test writing and reading a Intracellu... 1971-01-01/12:00:00                                                                     2.0b
v2.0.0/test_IZeroClampSeries.nwb           25.5 kB  TEST_IZeroClampSeries           a file to test writing and reading a IZeroClamp... 1971-01-01/12:00:00                                                                     2.0b
v2.0.0/test_LFP.nwb                        33.6 kB  TEST_LFP                        a file to test writing and reading a LFP           1971-01-01/12:00:00                                                  4                  2.0b
v2.0.0/test_OptogeneticSeries.nwb          23.2 kB  TEST_OptogeneticSeries          a file to test writing and reading a Optogeneti... 1971-01-01/12:00:00                                                                     2.0b
v2.0.0/test_OptogeneticStimulusSite.nwb    20.6 kB  TEST_OptogeneticStimulusSite    a file to test writing and reading a Optogeneti... 1971-01-01/12:00:00                                                                     2.0b
v2.0.0/test_PatchClampSeries.nwb           28.2 kB  TEST_PatchClampSeries           a file to test writing and reading a PatchClamp... 1971-01-01/12:00:00                                                                     2.0b
v2.0.0/test_PlaneSegmentation.nwb          34.4 kB  TEST_PlaneSegmentation          a file to test writing and reading a PlaneSegme... 1971-01-01/12:00:00                                                                     2.0b
v2.0.0/test_RoiResponseSeries.nwb          37.6 kB  TEST_RoiResponseSeries          a file to test writing and reading a RoiRespons... 1971-01-01/12:00:00                                                                     2.0b
v2.0.0/test_Subject.nwb                    18.8 kB  TEST_Subject                    a file to test writing and reading a Subject       1971-01-01/12:00:00  12 mo WT       M   Rattus norvegicus RAT123                        2.0b
v2.0.0/test_SweepTable.nwb                 28.2 kB  TEST_SweepTable                 a file to test writing and reading a SweepTable    1971-01-01/12:00:00                                                                     2.0b
v2.0.0/test_TimeIntervals.nwb              27.2 kB  TEST_TimeIntervals              a file to test writing and reading a TimeIntervals 1971-01-01/12:00:00                                                                     2.0b
v2.0.0/test_TimeSeries.nwb                 17.6 kB  TEST_TimeSeries                 a file to test writing and reading a TimeSeries    1971-01-01/12:00:00                                                                     2.0b
v2.0.0/test_timestamps_linking.nwb         43.5 kB  foo                             bar                                                2019-03-21/19:36:06                                                                     2.0b
v2.0.0/test_TwoPhotonSeries.nwb            26.9 kB  TEST_TwoPhotonSeries            a file to test writing and reading a TwoPhotonS... 1971-01-01/12:00:00                                                                     2.0b
v2.0.0/test_Units.nwb                      19.3 kB  TEST_Units                      a file to test writing and reading a Units         1971-01-01/12:00:00                                                                     2.0b
v2.0.0/test_VoltageClampSeries.nwb         27.1 kB  TEST_VoltageClampSeries         a file to test writing and reading a VoltageCla... 1971-01-01/12:00:00                                                                     2.0b
v2.0.0/test_VoltageClampStimulusSeries.nwb 24.7 kB  TEST_VoltageClampStimulusSeries a file to test writing and reading a VoltageCla... 1971-01-01/12:00:00                                                                     2.0b
v2.0.1/test_Clustering.nwb                 17.8 kB  TEST_Clustering                 a file to test writing and reading a Clustering    1971-01-01/12:00:00                                                                     2.0b
v2.0.1/test_ClusterWaveforms.nwb           20.0 kB  TEST_ClusterWaveforms           a file to test writing and reading a ClusterWav... 1971-01-01/12:00:00                                                                     2.0b
v2.0.1/test_CurrentClampSeries.nwb         25.5 kB  TEST_CurrentClampSeries         a file to test writing and reading a CurrentCla... 1971-01-01/12:00:00                                                                     2.0b
v2.0.1/test_CurrentClampStimulusSeries.nwb 24.7 kB  TEST_CurrentClampStimulusSeries a file to test writing and reading a CurrentCla... 1971-01-01/12:00:00                                                                     2.0b
v2.0.1/test_DecompositionSeries.nwb        24.8 kB  TEST_DecompositionSeries        a file to test writing and reading a Decomposit... 1971-01-01/12:00:00                                                                     2.0b
v2.0.1/test_Device.nwb                     17.4 kB  TEST_Device                     a file to test writing and reading a Device        1971-01-01/12:00:00                                                                     2.0b
v2.0.1/test_DynamicTable.nwb               18.0 kB  TEST_DynamicTable               a file to test writing and reading a DynamicTable  1971-01-01/12:00:00                                                              2      2.0b
v2.0.1/test_ElectricalSeries.nwb           29.5 kB  TEST_ElectricalSeries           a file to test writing and reading a Electrical... 1971-01-01/12:00:00                                                  4                  2.0b
v2.0.1/test_ElectrodeGroup.nwb             19.8 kB  TEST_ElectrodeGroup             a file to test writing and reading a ElectrodeG... 1971-01-01/12:00:00                                                                     2.0b
v2.0.1/test_EventDetection.nwb             31.7 kB  TEST_EventDetection             a file to test writing and reading a EventDetec... 1971-01-01/12:00:00                                                  4                  2.0b
v2.0.1/test_EventWaveform.nwb              30.7 kB  TEST_EventWaveform              a file to test writing and reading a EventWaveform 1971-01-01/12:00:00                                                  4                  2.0b
v2.0.1/test_FeatureExtraction.nwb          29.3 kB  TEST_FeatureExtraction          a file to test writing and reading a FeatureExt... 1971-01-01/12:00:00                                                  4                  2.0b
v2.0.1/test_FilteredEphys.nwb              33.6 kB  TEST_FilteredEphys              a file to test writing and reading a FilteredEphys 1971-01-01/12:00:00                                                  4                  2.0b
v2.0.1/test_ImagingPlane.nwb               23.3 kB  TEST_ImagingPlane               a file to test writing and reading a ImagingPlane  1971-01-01/12:00:00                                                                     2.0b
v2.0.1/test_IntracellularElectrode.nwb     21.7 kB  TEST_IntracellularElectrode     a file to test writing and reading a Intracellu... 1971-01-01/12:00:00                                                                     2.0b
v2.0.1/test_IZeroClampSeries.nwb           25.5 kB  TEST_IZeroClampSeries           a file to test writing and reading a IZeroClamp... 1971-01-01/12:00:00                                                                     2.0b
v2.0.1/test_LFP.nwb                        33.6 kB  TEST_LFP                        a file to test writing and reading a LFP           1971-01-01/12:00:00                                                  4                  2.0b
v2.0.1/test_OptogeneticSeries.nwb          23.2 kB  TEST_OptogeneticSeries          a file to test writing and reading a Optogeneti... 1971-01-01/12:00:00                                                                     2.0b
v2.0.1/test_OptogeneticStimulusSite.nwb    20.6 kB  TEST_OptogeneticStimulusSite    a file to test writing and reading a Optogeneti... 1971-01-01/12:00:00                                                                     2.0b
v2.0.1/test_PatchClampSeries.nwb           28.2 kB  TEST_PatchClampSeries           a file to test writing and reading a PatchClamp... 1971-01-01/12:00:00                                                                     2.0b
v2.0.1/test_PlaneSegmentation.nwb          34.4 kB  TEST_PlaneSegmentation          a file to test writing and reading a PlaneSegme... 1971-01-01/12:00:00                                                                     2.0b
v2.0.1/test_RoiResponseSeries.nwb          37.6 kB  TEST_RoiResponseSeries          a file to test writing and reading a RoiRespons... 1971-01-01/12:00:00                                                                     2.0b
v2.0.1/test_Subject.nwb                    18.8 kB  TEST_Subject                    a file to test writing and reading a Subject       1971-01-01/12:00:00  12 mo WT       M   Rattus norvegicus RAT123                        2.0b
v2.0.1/test_SweepTable.nwb                 28.2 kB  TEST_SweepTable                 a file to test writing and reading a SweepTable    1971-01-01/12:00:00                                                                     2.0b
v2.0.1/test_TimeIntervals.nwb              27.2 kB  TEST_TimeIntervals              a file to test writing and reading a TimeIntervals 1971-01-01/12:00:00                                                                     2.0b
v2.0.1/test_TimeSeries.nwb                 17.6 kB  TEST_TimeSeries                 a file to test writing and reading a TimeSeries    1971-01-01/12:00:00                                                                     2.0b
v2.0.1/test_timestamps_linking.nwb         43.5 kB  foo                             bar                                                2019-03-21/19:13:50                                                                     2.0b
v2.0.1/test_TwoPhotonSeries.nwb            26.9 kB  TEST_TwoPhotonSeries            a file to test writing and reading a TwoPhotonS... 1971-01-01/12:00:00                                                                     2.0b
v2.0.1/test_Units.nwb                      19.3 kB  TEST_Units                      a file to test writing and reading a Units         1971-01-01/12:00:00                                                                     2.0b
v2.0.1/test_VoltageClampSeries.nwb         27.1 kB  TEST_VoltageClampSeries         a file to test writing and reading a VoltageCla... 1971-01-01/12:00:00                                                                     2.0b
v2.0.1/test_VoltageClampStimulusSeries.nwb 24.7 kB  TEST_VoltageClampStimulusSeries a file to test writing and reading a VoltageCla... 1971-01-01/12:00:00                                                                     2.0b
Summary:                                   1.7 MB                                                                                      1970-01-01/12:00:00>                                                                        
                                                                                                                                       2019-03-21/19:36:06<                                                                        
[1]    198627 segmentation fault (core dumped)  dandi ls v2.0.*/*nwb
dandi ls v2.0.*/*nwb  5.69s user 0.32s system 117% cpu 5.136 total
```
</details>