### PR TITLE
ENH: add nd_types (for neural data types) into "ls"

### DIFF
--- a/dandi/consts.py
+++ b/dandi/consts.py
@@ -23,7 +23,12 @@ metadata_subject_fields = (
     "subject_id",
 )
 
-metadata_computed_fields = ("number_of_electrodes", "number_of_units", "nwb_version")
+metadata_computed_fields = (
+    "number_of_electrodes",
+    "number_of_units",
+    "nwb_version",
+    "nd_types",
+)
 
 metadata_all_fields = (
     metadata_fields + metadata_subject_fields + metadata_computed_fields


### PR DESCRIPTION
It allows for quite quite useful overview of what files actually contain:

	(git-annex)lena:…proj/dandi/nwb-datasets/visual-coding-neuropixels/ecephys-cache[master]git
	$> dandi ls session_71*/*nwb
	PATH                                      SIZE    NWB  ND_TYPES
	session_715093703/probe_810755797_lfp.nwb 2.1 GB  2.0b Device (2), DynamicTable, EcephysProbe, ElectricalSeries (3), LFP, ProcessingModule, TimeSeries
	session_715093703/probe_810755799_lfp.nwb 2.5 GB  2.0b Device (2), DynamicTable, EcephysProbe, ElectricalSeries (3), LFP, ProcessingModule, TimeSeries
	session_715093703/probe_810755801_lfp.nwb 2.2 GB  2.0b Device (2), DynamicTable, EcephysProbe, ElectricalSeries (3), LFP, ProcessingModule, TimeSeries
	session_715093703/probe_810755803_lfp.nwb 2.3 GB  2.0b Device (2), DynamicTable, EcephysProbe, ElectricalSeries (3), LFP, ProcessingModule, TimeSeries
	session_715093703/probe_810755805_lfp.nwb 2.5 GB  2.0b Device (2), DynamicTable, EcephysProbe, ElectricalSeries (3), LFP, ProcessingModule, TimeSeries
	session_715093703/probe_810755807_lfp.nwb 1.3 GB  2.0b Device (2), DynamicTable, EcephysProbe, ElectricalSeries (3), LFP, ProcessingModule, TimeSeries
	session_715093703/session_715093703.nwb   2.9 GB  2.0b Device (12), DynamicTable, EcephysLabMetaData, EcephysProbe (6), ProcessingModule (3), TimeIntervals (3), TimeSeries (7), Units
	session_719161530/probe_729445648_lfp.nwb 2.4 GB  2.0b Device (2), DynamicTable, EcephysProbe, ElectricalSeries (3), LFP, ProcessingModule, TimeSeries
	session_719161530/probe_729445650_lfp.nwb 2.4 GB  2.0b Device (2), DynamicTable, EcephysProbe, ElectricalSeries (3), LFP, ProcessingModule, TimeSeries
	session_719161530/probe_729445652_lfp.nwb 2.2 GB  2.0b Device (2), DynamicTable, EcephysProbe, ElectricalSeries (3), LFP, ProcessingModule, TimeSeries
	session_719161530/probe_729445654_lfp.nwb 71.6 MB 2.0b Device (2), DynamicTable, EcephysProbe, ElectricalSeries (3), LFP, ProcessingModule, TimeSeries
	session_719161530/probe_729445656_lfp.nwb 72.2 MB 2.0b Device (2), DynamicTable, EcephysProbe, ElectricalSeries (3), LFP, ProcessingModule, TimeSeries
	session_719161530/probe_729445658_lfp.nwb 1.3 GB  2.0b Device (2), DynamicTable, EcephysProbe, ElectricalSeries (3), LFP, ProcessingModule, TimeSeries
	session_719161530/session_719161530.nwb   3.1 GB  2.0b Device (12), DynamicTable, EcephysLabMetaData, EcephysProbe (6), ProcessingModule (3), TimeIntervals (3), TimeSeries (7), Units
	Summary:                                  27.3 GB

or

	$> dandi ls -F path,nd_types ../nwb_test_data/v2.0.0/*
	PATH                                                        ND_TYPES
	../nwb_test_data/v2.0.0/test_append.nwb                     Device (2), DynamicTable, ElectricalSeries (2), ElectrodeGroup, LFP, ProcessingModule
	../nwb_test_data/v2.0.0/test_Clustering.nwb                 Clustering
	../nwb_test_data/v2.0.0/test_ClusterWaveforms.nwb           ClusterWaveforms, Clustering (2)
	../nwb_test_data/v2.0.0/test_CurrentClampSeries.nwb         CurrentClampSeries, Device (3), IntracellularElectrode (2)
	../nwb_test_data/v2.0.0/test_CurrentClampStimulusSeries.nwb CurrentClampStimulusSeries, Device (3), IntracellularElectrode (2)
	../nwb_test_data/v2.0.0/test_DecompositionSeries.nwb        DecompositionSeries, DynamicTable, ProcessingModule, TimeSeries (2)
	../nwb_test_data/v2.0.0/test_Device.nwb                     Device
	../nwb_test_data/v2.0.0/test_DynamicTable.nwb               Units
	../nwb_test_data/v2.0.0/test_ElectricalSeries.nwb           Device (2), DynamicTable, ElectricalSeries, ElectrodeGroup
	../nwb_test_data/v2.0.0/test_ElectrodeGroup.nwb             Device (2), ElectrodeGroup
	../nwb_test_data/v2.0.0/test_EventDetection.nwb             Device (2), DynamicTable, ElectricalSeries (2), ElectrodeGroup, EventDetection
	../nwb_test_data/v2.0.0/test_EventWaveform.nwb              Device (2), DynamicTable, ElectrodeGroup, EventWaveform, SpikeEventSeries
	../nwb_test_data/v2.0.0/test_FeatureExtraction.nwb          Device (2), DynamicTable, ElectrodeGroup, FeatureExtraction
	../nwb_test_data/v2.0.0/test_FilteredEphys.nwb              Device (2), DynamicTable, ElectricalSeries (2), ElectrodeGroup, FilteredEphys
	../nwb_test_data/v2.0.0/test_ImagingPlane.nwb               Device (2), ImagingPlane, OpticalChannel
	../nwb_test_data/v2.0.0/test_IntracellularElectrode.nwb     Device (2), IntracellularElectrode
	../nwb_test_data/v2.0.0/test_IZeroClampSeries.nwb           Device (3), IZeroClampSeries, IntracellularElectrode (2)
	../nwb_test_data/v2.0.0/test_LFP.nwb                        Device (2), DynamicTable, ElectricalSeries (2), ElectrodeGroup, LFP
	../nwb_test_data/v2.0.0/test_OptogeneticSeries.nwb          Device (3), OptogeneticSeries, OptogeneticStimulusSite (2)
	../nwb_test_data/v2.0.0/test_OptogeneticStimulusSite.nwb    Device (2), OptogeneticStimulusSite
	../nwb_test_data/v2.0.0/test_PatchClampSeries.nwb           Device (3), IntracellularElectrode (2), PatchClampSeries, SweepTable
	../nwb_test_data/v2.0.0/test_PlaneSegmentation.nwb          Device (3), ImageSegmentation, ImageSeries, ImagingPlane (2), OpticalChannel (2), PlaneSegmentation, ProcessingModule
	../nwb_test_data/v2.0.0/test_RoiResponseSeries.nwb          Device (3), ImageSegmentation, ImageSeries, ImagingPlane (2), OpticalChannel (2), PlaneSegmentation, ProcessingModule, RoiResponseSeries
	../nwb_test_data/v2.0.0/test_Subject.nwb                    Subject
	../nwb_test_data/v2.0.0/test_SweepTable.nwb                 Device (3), IntracellularElectrode (2), PatchClampSeries, SweepTable
	../nwb_test_data/v2.0.0/test_TimeIntervals.nwb              TimeIntervals, TimeSeries (2)
	../nwb_test_data/v2.0.0/test_TimeSeries.nwb                 TimeSeries
	../nwb_test_data/v2.0.0/test_timestamps_linking.nwb         TimeSeries (2)
	../nwb_test_data/v2.0.0/test_TwoPhotonSeries.nwb            Device (3), ImagingPlane (2), OpticalChannel (2), TwoPhotonSeries
	../nwb_test_data/v2.0.0/test_Units.nwb                      Units
	../nwb_test_data/v2.0.0/test_VoltageClampSeries.nwb         Device (3), IntracellularElectrode (2), VoltageClampSeries
	../nwb_test_data/v2.0.0/test_VoltageClampStimulusSeries.nwb Device (3), IntracellularElectrode (2), VoltageClampStimulusSeries

Thanks @bendichter for the original code snippet