### PR TITLE
ENH: autoimport allensdk.brain_observatory.ecephys.nwb

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,10 @@ test=pytest
 #    matplotlib >= 1.3.1
 #    numpydoc
 #    sphinx >=0.3
+# PyNWB extensions we know and somewhat care about
+# e.g. import whenever pynwb fails without them
+extensions =
+    allensdk
 style =
     flake8
     pre-commit
@@ -68,6 +72,7 @@ test =
     pytest-cov
 all =
     #%(doc)s
+    %(extensions)s
     %(style)s
     %(test)s
 


### PR DESCRIPTION
… when encountering exception with AIBS_ecephys listed missing

Ultimate solution should IMHO be implemented within PyNWB itself.
See https://github.com/NeurodataWithoutBorders/pynwb/issues/1143 feature request.
Also related - dedicated exception (https://github.com/NeurodataWithoutBorders/pynwb/issues/1144)

With this change we should be able to deal with neuropixels files from Allen