### PR TITLE
ENH: upload coverage reports to codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,4 +34,13 @@ jobs:
         pip install ".[test]"
     - name: ${{ matrix.module }} tests
       run: |
-        python -m pytest -s -v --cov=dandi dandi
+        python -m pytest -s -v --cov=dandi --cov-report=xml dandi
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./coverage.xml
+        flags: unittests
+        # name: codecov-umbrella
+        # yml: ./codecov.yml
+        fail_ci_if_error: true


### PR DESCRIPTION
For that to work, we need to provide a secret token and that one would be available only (according to docs) if pull request comes from this repo (so cannot do from my fork... although may be I could set it there as well???)