### PR TITLE
ENH: organize - resolve ambiguity by adding _obj- where necessary

### DIFF
--- a/dandi/cli/cmd_organize.py
+++ b/dandi/cli/cmd_organize.py
@@ -22,13 +22,6 @@ from ..consts import dandiset_metadata_file, file_operation_modes
 )
 @dandiset_id_option()
 @click.option(
-    "-f",
-    "--format",
-    help="Python .format() template to be used to create a full path to a file. "
-    "It will be provided a dict with metadata fields and some prepared "
-    "fields such as '_filename' which is prepared according to internal rules.",
-)
-@click.option(
     "--invalid",
     help="What to do if files without sufficient metadata are encountered.",
     type=click.Choice(["fail", "warn"]),
@@ -50,12 +43,7 @@ from ..consts import dandiset_metadata_file, file_operation_modes
 @click.argument("paths", nargs=-1, type=click.Path(exists=True))
 @map_to_click_exceptions
 def organize(
-    paths,
-    dandiset_path=None,
-    format=None,
-    dandiset_id=None,
-    invalid="fail",
-    files_mode="dry",
+    paths, dandiset_path=None, dandiset_id=None, invalid="fail", files_mode="dry"
 ):
     """(Re)organize files according to the metadata.
 
@@ -69,10 +57,6 @@ def organize(
     See https://github.com/dandi/metadata-dumps/tree/organize/organized/ for
     examples of (re)organized datasets (files content is original filenames)
     """
-    if format:
-        raise NotImplementedError("format support is not yet implemented")
-
-    # import tqdm
     from ..utils import copy_file, delayed, find_files, load_jsonl, move_file, Parallel
     from ..pynwb_utils import ignore_benign_pynwb_warnings
     from ..organize import (

--- a/dandi/cli/cmd_organize.py
+++ b/dandi/cli/cmd_organize.py
@@ -47,15 +47,36 @@ def organize(
 ):
     """(Re)organize files according to the metadata.
 
-    The purpose of this command is to provide datasets with consistently named files,
-    so their naming reflects data they contain.
+    The purpose of this command is to take advantage of metadata contained in
+    the .nwb fils to provide datasets with consistently named files, so their
+    naming reflects data they contain. In addition it will also populate
+    the dataset level descriptor file dandiset.yaml with some of the
+    collected metadata and statistics (e.g. number_of_cells).
 
-    Based on the metadata contained in the considered files, it will also generate
-    the dataset level descriptor file, which possibly later would need to
-    be adjusted "manually".
+    .nwb files are organized into a hierarchy of subfolders one per each
+    "subject", e.g. sub-0001 if .nwb file had contained a Subject group with
+    subject_id=0001.  Each file in a subject-specific subfolder follows the
+    convention:
 
-    See https://github.com/dandi/metadata-dumps/tree/organize/organized/ for
-    examples of (re)organized datasets (files content is original filenames)
+        sub-<subject_id>[_key-<value>][_mod1+mod2+...].nwb
+
+    where following keys are considered if present in the data:
+
+        ses -- session_id\n
+        tis -- tissue_sample_id\n
+        slice -- slice_id\n
+        cell -- cell_id\n
+
+    and `modX` are "modalities" as identified based on detected neural data types
+    (such as "ecephys", "icephys") per extensions found in nwb-schema definitions:
+    https://github.com/NeurodataWithoutBorders/nwb-schema/tree/dev/core
+
+    In addition an "obj" key with a value corresponding to crc32 checksum of
+    "object_id" is added if aforementioned keys and the list of modalities are
+    not sufficient to disambiguate different files.
+
+    You can visit https://dandiarchive.org/dandisets/drafts for a growing
+    collection of (re)organized datasets (files content is original filenames).
     """
     from ..utils import copy_file, delayed, find_files, load_jsonl, move_file, Parallel
     from ..pynwb_utils import ignore_benign_pynwb_warnings

--- a/dandi/cli/cmd_organize.py
+++ b/dandi/cli/cmd_organize.py
@@ -20,7 +20,7 @@ from ..consts import dandiset_metadata_file, file_operation_modes
     "For 'simulate' mode target dandiset/directory must not exist.",
     type=click.Path(dir_okay=True, file_okay=False),
 )
-@dandiset_id_option()
+# @dandiset_id_option()
 @click.option(
     "--invalid",
     help="What to do if files without sufficient metadata are encountered.",
@@ -190,10 +190,7 @@ def organize(
     dandiset_metadata_filepath = op.join(dandiset_path, dandiset_metadata_file)
     if op.lexists(dandiset_metadata_filepath):
         if dandiset_id is not None:
-            lgr.info(
-                f"We found {dandiset_metadata_filepath} present, provided"
-                f" {dandiset_id} will be ignored."
-            )
+            lgr.info(f"We found {dandiset_metadata_filepath} present")
     elif dandiset_id:
         # TODO: request it from the server and store into dandiset.yaml
         lgr.debug(
@@ -213,8 +210,7 @@ def organize(
         dandiset_metadata_filepath = None
     else:
         lgr.warning(
-            f"Found no {dandiset_metadata_filepath} and no --dandiset-id was"
-            f" specified. This file will lack mandatory metadata."
+            f"Found no {dandiset_metadata_filepath}. This file will lack mandatory metadata."
             f" For upload later on, you must first use 'register'"
             f" to obtain a dandiset id.  Meanwhile you could use 'simulate' mode"
             f" to generate a sample dandiset.yaml if you are interested."

--- a/dandi/exceptions.py
+++ b/dandi/exceptions.py
@@ -1,0 +1,7 @@
+class OrganizeImpossibleError(ValueError):
+    """Exception to be raised if given current list of files it is impossible
+
+    E.g. if metadata is not sufficient or conflicting
+    """
+
+    pass

--- a/dandi/metadata.py
+++ b/dandi/metadata.py
@@ -3,6 +3,7 @@ from .pynwb_utils import (
     _get_pynwb_metadata,
     get_neurodata_types,
     get_nwb_version,
+    ignore_benign_pynwb_warnings,
     metadata_cache,
 )
 
@@ -26,6 +27,8 @@ def get_metadata(path):
     -------
     dict
     """
+    # when we run in parallel, these annoying warnings appear
+    ignore_benign_pynwb_warnings()
     path = str(path)  # for Path
     meta = dict()
 

--- a/dandi/organize.py
+++ b/dandi/organize.py
@@ -139,11 +139,19 @@ def _assign_obj_id(metadata, non_unique):
     seen_object_ids = {}  # object_id: path
     for r in metadata:
         if r["dandi_path"] in non_unique:
-            object_id = get_object_id(r["path"])
+            try:
+                object_id = get_object_id(r["path"])
+            except KeyError:
+                raise OrganizeImpossibleError(
+                    msg + ". We tried to use object_id but it is absent in %r. "
+                    "It is either not .nwb file or produced by older *nwb libraries. "
+                    "You must re-save files e.g. using recent pynwb." % (r["path"])
+                )
+
             if not object_id:
                 raise OrganizeImpossibleError(
                     msg + ". We tried to use object_id but it was %r for %s. "
-                    " You must re-save files using recent pynwb"
+                    " You might need to re-save files using recent pynwb"
                     % (object_id, r["path"])
                 )
             # shorter version

--- a/dandi/organize.py
+++ b/dandi/organize.py
@@ -126,7 +126,7 @@ def create_unique_filenames_from_metadata(
         if non_unique:
             raise OrganizeImpossibleError(
                 "Even after adding obj_id we ended up with non-unique file names. "
-                "Should have not happened: %s" % str(non_unique)
+                "Should not have happened: %s" % str(non_unique)
             )
     return metadata
 

--- a/dandi/organize.py
+++ b/dandi/organize.py
@@ -116,10 +116,7 @@ def create_unique_filenames_from_metadata(
             )
             raise OrganizeImpossibleError(
                 msg_detailed + "\nPlease adjust/provide metadata in your .nwb "
-                "files to disambiguate or rerun allowing adding "
-                "object_id."
-                " You can also use 'simulate' mode to produce a "
-                " tentative layout."
+                "files to disambiguate or rerun allowing adding object_id."
             )
         _assign_obj_id(metadata, non_unique)
         _assign_dandi_names(
@@ -137,7 +134,7 @@ def create_unique_filenames_from_metadata(
 def _assign_obj_id(metadata, non_unique):
     msg = "%d out of %d paths are not unique" % (len(non_unique), len(metadata))
 
-    lgr.info(msg + ". We will consider adding _obj- based on object_id")
+    lgr.info(msg + ". We will try adding _obj- based on crc32 of object_id")
     seen_obj_ids = {}  # obj_id: object_id
     seen_object_ids = {}  # object_id: path
     for r in metadata:

--- a/dandi/organize.py
+++ b/dandi/organize.py
@@ -137,22 +137,24 @@ def _assign_obj_id(metadata, non_unique):
     lgr.info(msg + ". We will try adding _obj- based on crc32 of object_id")
     seen_obj_ids = {}  # obj_id: object_id
     seen_object_ids = {}  # object_id: path
+    recent_nwb_msg = "NWB>=2.1.0 standard (supported by pynwb>=1.1.0)."
     for r in metadata:
         if r["dandi_path"] in non_unique:
             try:
                 object_id = get_object_id(r["path"])
             except KeyError:
                 raise OrganizeImpossibleError(
-                    msg + ". We tried to use object_id but it is absent in %r. "
-                    "It is either not .nwb file or produced by older *nwb libraries. "
-                    "You must re-save files e.g. using recent pynwb." % (r["path"])
+                    msg
+                    + f". We tried to use object_id but it is absent in {r['path']!r}. "
+                    f"It is either not .nwb file or produced by older *nwb libraries. "
+                    f"You must re-save files e.g. using {recent_nwb_msg}"
                 )
 
             if not object_id:
                 raise OrganizeImpossibleError(
-                    msg + ". We tried to use object_id but it was %r for %s. "
-                    " You might need to re-save files using recent pynwb"
-                    % (object_id, r["path"])
+                    msg
+                    + f". We tried to use object_id but it was {object_id!r} for {r['path']!r}. "
+                    f"You might need to re-save files using {recent_nwb_msg}"
                 )
             # shorter version
             obj_id = np.base_repr(binascii.crc32(object_id.encode("ascii")), 36).lower()
@@ -160,11 +162,10 @@ def _assign_obj_id(metadata, non_unique):
                 seen_object_id = seen_obj_ids[obj_id]
                 if seen_object_id == object_id:
                     raise OrganizeImpossibleError(
-                        "Two files (%r and %r) have the same object_id %s. "
-                        "Must not happen. Either files are duplicates "
-                        "(remove one) or were not saved correctly using "
-                        "recent pynwb"
-                        % (r["path"], seen_object_ids[object_id], object_id)
+                        f"Two files ({r['path']!r} and {seen_object_ids[object_id]!r}) "
+                        f"have the same object_id {object_id}. Must not "
+                        f"happen. Either files are duplicates (remove one) "
+                        f"or were not saved correctly using {recent_nwb_msg}"
                     )
                 else:
                     raise RuntimeError(

--- a/dandi/organize.py
+++ b/dandi/organize.py
@@ -157,7 +157,7 @@ def _assign_obj_id(metadata, non_unique):
                     f"You might need to re-save files using {recent_nwb_msg}"
                 )
             # shorter version
-            obj_id = np.base_repr(binascii.crc32(object_id.encode("ascii")), 36).lower()
+            obj_id = get_obj_id(object_id)
             if obj_id in seen_obj_ids:
                 seen_object_id = seen_obj_ids[obj_id]
                 if seen_object_id == object_id:
@@ -178,6 +178,12 @@ def _assign_obj_id(metadata, non_unique):
             r["obj_id"] = obj_id
             seen_obj_ids[obj_id] = object_id
             seen_object_ids[object_id] = r["path"]
+
+
+def get_obj_id(object_id):
+    """Given full object_id, get its shortened version
+    """
+    return np.base_repr(binascii.crc32(object_id.encode("ascii")), 36).lower()
 
 
 def _assign_dandi_names(metadata, mandatory, mandatory_if_not_empty):

--- a/dandi/tests/fixtures.py
+++ b/dandi/tests/fixtures.py
@@ -5,7 +5,7 @@ import shutil
 import tempfile
 
 import pynwb
-from ..pynwb_utils import metadata_nwb_file_fields
+from ..pynwb_utils import make_nwb_file, metadata_nwb_file_fields
 
 import pytest
 
@@ -20,6 +20,8 @@ lgr = get_logger()
 def simple1_nwb_metadata(tmpdir_factory):
     # very simple assignment with the same values as the key with 1 as suffix
     metadata = {f: "{}1".format(f) for f in metadata_nwb_file_fields}
+    # subject_fields
+
     # tune specific ones:
     # Needs an explicit time zone since otherwise pynwb would add one
     # But then comparison breaks anyways any ways yoh have tried to set it
@@ -36,11 +38,24 @@ def simple1_nwb_metadata(tmpdir_factory):
 
 @pytest.fixture(scope="session")
 def simple1_nwb(simple1_nwb_metadata, tmpdir_factory):
-    filename = str(tmpdir_factory.mktemp("data").join("simple1.nwb"))
-    nwbfile = pynwb.NWBFile(**simple1_nwb_metadata)
-    with pynwb.NWBHDF5IO(filename, "w") as io:
-        io.write(nwbfile, cache_spec=False)
-    return filename
+    return make_nwb_file(
+        str(tmpdir_factory.mktemp("data").join("simple1.nwb")), **simple1_nwb_metadata
+    )
+
+
+@pytest.fixture(scope="session")
+def simple2_nwb(simple1_nwb_metadata, tmpdir_factory):
+    """With a subject"""
+    return make_nwb_file(
+        str(tmpdir_factory.mktemp("data").join("simple2.nwb")),
+        subject=pynwb.file.Subject(
+            subject_id="mouse001",
+            date_of_birth=datetime(2019, 12, 1),
+            sex="M",
+            species="mouse",
+        ),
+        **simple1_nwb_metadata,
+    )
 
 
 @pytest.fixture()


### PR DESCRIPTION
The need for this was reminded by @satra and implementation uses proposed by him shorter version based on alphanum encoding of the crc32 checksum value, instead of the one I thought about -- first octet of object_id uuid (such change was done in 2845eda4c2fac4341c085d69debfc25e0a65ad94, which also has a brief show case example).

It could be seen needed on an older version of Kriegstein data (now no longer avail in dandiarchive)

- Diff is a bit big since in the first commit (362d346b069c15ca3d542b4b19b7fd3509bb647f ATM) I just refactored code by moving around to prepare for the follow up changes.
- I dropped "special" to "simulate" mode support for non-unique files handling - no need really.

TODOs:
- [x] check which version of nwb-schema (and/or) pynwb (and matnwb) introduced storing `object_id` and add that info into error messages. [nwb-schema 2.1.0](https://nwb-schema.readthedocs.io/en/latest/format_release_notes.html#march-2-2020) and pynwb 1.1.0 which uses that schema
- [x] basic tests
- [x] provide documentation in `--help` on how file names are generated and what constitutes `_obj-` value