### PR TITLE
ENH: dandi download (multiple) files

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,3 +138,8 @@ Please see [DEVELOPMENT.md](./DEVELOPMENT.md) file.
 
 From https://github.com/eric-wieser/generatorify, as of 7bd759ecf88f836ece6cdbcf7ce1074260c0c5ef
 Copyright (c) 2019 Eric Wieser, MIT/Expat licensed.
+
+### dandi/tests/skip.py
+
+From https://github.com/ReproNim/reproman, as of v0.2.1-40-gf4f026d
+Copyright (c) 2016-2020  ReproMan Team

--- a/dandi/cli/cmd_download.py
+++ b/dandi/cli/cmd_download.py
@@ -50,4 +50,4 @@ def download(url, output_dir, existing, develop_debug=False):
     # Python function
     from ..download import download
 
-    return download(url, output_dir, existing, develop_debug)
+    return download(url, output_dir, existing=existing, develop_debug=develop_debug)

--- a/dandi/download.py
+++ b/dandi/download.py
@@ -5,6 +5,7 @@ import urllib.parse as up
 from . import girder, get_logger
 from .consts import dandiset_metadata_file
 from .dandiset import Dandiset
+from .utils import flattened
 
 lgr = get_logger()
 
@@ -26,14 +27,17 @@ def parse_dandi_url(url):
     - Dataset landing page metadata
       https://gui.dandiarchive.org/#/dandiset-meta/5e6d5c6976569eb93f451e4f
 
-    Individual file:
-      dandi???
-      https://girder.dandiarchive.org/api/v1/item/5dab0972f377535c7d96c392/download
+    Individual and multiple files:
+      - dandi???
+      - girder -- we don't support:
+        https://girder.dandiarchive.org/api/v1/item/5dab0972f377535c7d96c392/download
+      - gui.: support single or multiple
+        # if there is a selection, we could get multiple items
+        https://gui.dandiarchive.org/#/folder/5e60c14f81bc3e47d94aa012/selected/item+5e60c19381bc3e47d94aa014
 
-      # if there is a selection, we could get multiple items TODO:
-      https://gui.dandiarchive.org/#/folder/5e60c14f81bc3e47d94aa012/selected/item+5e60c19381bc3e47d94aa014
-      # might be a convenience to provide, but then this one should become a
-      # generator or return a list of asset_ids
+    Multiple selected files + folders -- we do not support ATM, then further
+    RFing would be due, probably making this into a generator or returning a
+    list of entries.
 
     "Features":
 
@@ -47,7 +51,8 @@ def parse_dandi_url(url):
     Returns
     -------
     server, asset_type, asset_id
-      asset_type is either asset_id or folder ATM
+      asset_type is either asset_id or folder ATM. asset_id might be a list
+      in case of multiple files
 
     """
     if "#" not in url:
@@ -81,31 +86,48 @@ def parse_dandi_url(url):
     # The rest will come from fragment
     # TODO: redo with regexp
     frags = u.fragment.rstrip("/").split("/")
-    # Just use the term before the last entry which should be the ID
+    item_prefix = "item+"  # just a constant for reuse
     if (
-        len(frags) < 2
-        or frags[-2] not in ("folder", "collection", "dandiset-meta")
-        or len(frags[-1]) != 24
+        len(frags) >= 2
+        and frags[-2] in ("folder", "collection", "dandiset-meta")
+        and len(frags[-1]) == 24
     ):
+        # Just use the term before the last entry which should be the ID
+        if frags[-2] == "dandiset-meta":
+            frags[-2] = "folder"
+        asset_type = frags[-2]
+        asset_ids = frags[-1]  # a single one
+    elif "selected" in frags and frags[-1].startswith(item_prefix):
+        # single or multiple files selected in web ui
+        # get all item+ after selected
+        asset_ids = []
+        for v in frags[frags.index("selected") + 1 :]:
+            if not v.startswith(item_prefix):
+                raise ValueError(
+                    f"Fragment seems to point to individual selected items but "
+                    f"{v} is not of {item_prefix!r} format in the url: {url}"
+                )
+            asset_ids.append(v[len(item_prefix) :])
+        asset_type = "item"
+    else:
         raise ValueError(
             f"Fragment of the following URL is not following desired convention"
-            f" .*/(folder|collection|dandiset-meta)/ID24: {url}"
+            f" .*/(folder|collection|dandiset-meta)/ID24 or pointing to "
+            f"individual selected items: {url}"
         )
-    if frags[-2] == "dandiset-meta":
-        frags[-2] = "folder"
-
-    return server, frags[-2], frags[-1]
+    return server, asset_type, asset_ids
 
 
 def download(
     urls,
     output_dir,
-    existing,
-    develop_debug,
+    existing="error",
+    develop_debug=False,
     authenticate=False,  # Seems to work just fine for public stuff
     recursive=True,
 ):
     """Download a file or entire folder from DANDI"""
+    urls = flattened([urls])
     if len(urls) > 1:
         raise NotImplementedError("multiple URLs not supported")
     if not urls:
@@ -115,7 +137,6 @@ def download(
         raise NotImplementedError("No URLs were provided.  Cannot download anything")
     url = urls[0]
     girder_server_url, asset_type, asset_id = parse_dandi_url(url)
-    lgr.info(f"Downloading {asset_type} with id {asset_id} from {girder_server_url}")
 
     # We could later try to "dandi_authenticate" if run into permission issues.
     # May be it could be not just boolean but the "id" to be used?
@@ -124,19 +145,40 @@ def download(
         authenticate=authenticate,
         progressbars=True,  # TODO: redo all this
     )
+
+    lgr.info(f"Downloading {asset_type} with id {asset_id} from {girder_server_url}")
+
+    # there might be multiple asset_ids, e.g. if multiple files were selected etc,
+    # so we will traverse all of them
+    files = flattened(
+        _get_asset_files(
+            asset_id_, asset_type, output_dir, client, authenticate, existing, recursive
+        )
+        for asset_id_ in set(flattened([asset_id]))
+    )
+
+    for file in files:
+        client.download_file(
+            file["id"],
+            op.join(output_dir, file["path"]),
+            existing=existing,
+            attrs=file["attrs"],
+        )
+
+
+def _get_asset_files(
+    asset_id, asset_type, output_dir, client, authenticate, existing, recursive
+):
     # asset_rec = client.getResource(asset_type, asset_id)
     # lgr.info("Working with asset %s", str(asset_rec))
-
     # In principle Girder's client already has ability to download any
     # resource (collection/folder/item/file).  But it seems that "mending" it
     # with custom handling (e.g. later adding filtering to skip some files,
     # or add our own behavior on what to do when files exist locally, etc) would
     # not be easy.  So we will reimplement as a two step (kinda) procedure.
-
     # Return a generator which would be traversing girder and yield records
     # of encountered resources.
     # TODO later:  may be look into making it async
-
     # First we access top level records just to sense what we are working with
     top_entities = None
     while True:
@@ -155,7 +197,6 @@ def download(
                 client.dandi_authenticate()
                 continue
             raise
-
     entity_type = list(set(e["type"] for e in top_entities))
     if len(entity_type) > 1:
         raise ValueError(
@@ -163,11 +204,10 @@ def download(
             f" folder(s) or file(s).  Got: {entity_type}"
         )
     entity_type = entity_type[0]
-
     if entity_type in ("dandiset", "folder"):
         # redo recursively
         lgr.info(
-            "Traversing remote %ss (%s) recursively and downloading them locally",
+            "Traversing remote %ss (%s) recursively and downloading them " "locally",
             entity_type,
             ", ".join(e["name"] for e in top_entities),
         )
@@ -180,30 +220,23 @@ def download(
         files = top_entities
     else:
         raise ValueError(f"Unexpected entity type {entity_type}")
-
     if entity_type == "dandiset":
         for e in top_entities:
             dandiset_path = op.join(output_dir, e["path"])
             dandiset_yaml = op.join(dandiset_path, dandiset_metadata_file)
             lgr.info(
-                f"Updating {dandiset_metadata_file} from obtained dandiset metadata"
+                f"Updating {dandiset_metadata_file} from obtained dandiset " f"metadata"
             )
             if op.lexists(dandiset_yaml):
                 if existing != "overwrite":
                     lgr.info(
                         f"{dandiset_yaml} already exists.  Set 'existing' "
-                        f"to overwrite if you want it to be redownloaded. Skipping"
+                        f"to overwrite if you want it to be redownloaded. "
+                        f"Skipping"
                     )
                     continue
             dandiset = Dandiset(dandiset_path, allow_empty=True)
             if not dandiset.path_obj.exists():
                 dandiset.path_obj.mkdir()
             dandiset.update_metadata(e.get("metadata", {}).get("dandiset", {}))
-
-    for file in files:
-        client.download_file(
-            file["id"],
-            op.join(output_dir, file["path"]),
-            existing=existing,
-            attrs=file["attrs"],
-        )
+    return files

--- a/dandi/girder.py
+++ b/dandi/girder.py
@@ -401,6 +401,8 @@ def get_client(server_url, authenticate=True, progressbars=False):
     server_url: str
       URL to girder instance
     """
+    lgr.debug(f"Establishing a client for {server_url}")
+
     client = GirderCli(server_url, progressbars=progressbars)
     if authenticate:
         client.dandi_authenticate()

--- a/dandi/tests/skip.py
+++ b/dandi/tests/skip.py
@@ -1,8 +1,11 @@
 # ex: set sts=4 ts=4 sw=4 noet:
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 #
-#   See COPYING file distributed along with the reproman package for the
+#   See LICENSE file distributed along with the dandi-cli package for the
 #   copyright and license terms.
+#
+#   This file is borrowed from ReproMan, MIT license, Copyright 2016-2020
+#   ReproMan developers.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Define `skipif` and `mark` namespaces for custom pytest skippers.
@@ -45,83 +48,85 @@ import os
 
 import pytest
 
-from reproman.cmd import Runner
-from reproman.support.exceptions import CommandError
-from reproman.support.external_versions import external_versions
-from reproman.utils import on_windows as _on_windows
+# from reproman.cmd import Runner
+# from reproman.support.exceptions import CommandError
+# from reproman.support.external_versions import external_versions
+from ..utils import on_windows as _on_windows
 
 # Condition functions
 #
 # To create a new condition, (1) add a condition function and (2) add that
 # function to CONDITION_FNS.
 
-
-def no_apt_cache():
-    return ("apt-cache not available", not external_versions["cmd:apt-cache"])
-
-
-def no_aws_dependencies():
-    return "boto3 not installed", not external_versions["boto3"]
-
-
-def no_condor():
-    def is_running():
-        try:
-            Runner().run(["condor_status"])
-        except CommandError as exc:
-            return False
-        return True
-
-    return (
-        "condor not available",
-        not (external_versions["cmd:condor"] and is_running()),
-    )
-
-
-def no_datalad():
-    return ("datalad not available", not external_versions["datalad"])
-
-
-def no_docker_dependencies():
-    missing_deps = []
-    for dep in "docker", "dockerpty":
-        if dep not in external_versions:
-            missing_deps.append(dep)
-    msg = "missing dependencies: {}".format(", ".join(missing_deps))
-    return msg, missing_deps
-
-
-def no_docker_engine():
-    def is_engine_running():
-        from reproman.resource.docker_container import DockerContainer
-
-        return DockerContainer.is_engine_running()
-
-    # DockerContainer depends on docker.
-    msg, missing_deps = no_docker_dependencies()
-    if missing_deps:
-        return msg, missing_deps
-    return "docker engine not running", not is_engine_running()
+# Left commented out for future references
+# def no_apt_cache():
+#     return ("apt-cache not available", not external_versions["cmd:apt-cache"])
+#
+#
+# def no_aws_dependencies():
+#     return "boto3 not installed", not external_versions["boto3"]
+#
+#
+# def no_condor():
+#     def is_running():
+#         try:
+#             Runner().run(["condor_status"])
+#         except CommandError as exc:
+#             return False
+#         return True
+#
+#     return (
+#         "condor not available",
+#         not (external_versions["cmd:condor"] and is_running()),
+#     )
+#
+#
+# def no_datalad():
+#     return ("datalad not available", not external_versions["datalad"])
+#
+#
+# def no_docker_dependencies():
+#     missing_deps = []
+#     for dep in "docker", "dockerpty":
+#         if dep not in external_versions:
+#             missing_deps.append(dep)
+#     msg = "missing dependencies: {}".format(", ".join(missing_deps))
+#     return msg, missing_deps
+#
+#
+# def no_docker_engine():
+#     def is_engine_running():
+#         from reproman.resource.docker_container import DockerContainer
+#
+#         return DockerContainer.is_engine_running()
+#
+#     # DockerContainer depends on docker.
+#     msg, missing_deps = no_docker_dependencies()
+#     if missing_deps:
+#         return msg, missing_deps
+#     return "docker engine not running", not is_engine_running()
+#
 
 
 def no_network():
-    return ("no network settings", os.environ.get("REPROMAN_TESTS_NONETWORK"))
+    return ("no network settings", os.environ.get("DANDI_TESTS_NONETWORK"))
 
 
-def no_singularity():
-    return ("singularity not available", not external_versions["cmd:singularity"])
+# def no_singularity():
+#     return ("singularity not available", not external_versions["cmd:singularity"])
 
 
 def no_ssh():
     if _on_windows:
         reason = "no ssh on windows"
     else:
-        reason = "no ssh (REPROMAN_TESTS_SSH unset)"
-    return (reason, _on_windows or not os.environ.get("REPROMAN_TESTS_SSH"))
+        reason = "no ssh (DANDI_TESTS_SSH unset)"
+    return (reason, _on_windows or not os.environ.get("DANDI_TESTS_SSH"))
 
 
-def no_svn():
-    return ("subversion not available", not external_versions["cmd:svn"])
+# def no_svn():
+#     return ("subversion not available", not external_versions["cmd:svn"])
+#
 
 
 def on_windows():
@@ -129,16 +134,16 @@ def on_windows():
 
 
 CONDITION_FNS = [
-    no_apt_cache,
-    no_aws_dependencies,
-    no_condor,
-    no_datalad,
-    no_docker_dependencies,
-    no_docker_engine,
+    # no_apt_cache,
+    # no_aws_dependencies,
+    # no_condor,
+    # no_datalad,
+    # no_docker_dependencies,
+    # no_docker_engine,
     no_network,
-    no_singularity,
+    # no_singularity,
     no_ssh,
-    no_svn,
+    # no_svn,
     on_windows,
 ]
 

--- a/dandi/tests/skip.py
+++ b/dandi/tests/skip.py
@@ -1,0 +1,217 @@
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the reproman package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Define `skipif` and `mark` namespaces for custom pytest skippers.
+
+There are two main ways to skip in pytest:
+
+  * decorating a test function, such as
+
+        @pytest.mark.skip(sys.platform.startswith("win"), reason="on windows")
+        def test_func():
+            [...]
+
+  * skipping inline, such as
+
+        def test_func():
+            if sys.platform.startswith("win"):
+                pytest.skip("on Windows")
+            [...]
+
+This module provides a mechanism to register a reason and condition as both a
+decorator and an inline function:
+
+  * Within this module, create a condition function that returns a tuple of the
+    form (REASON, COND). REASON is a str that will be shown as the reason for
+    the skip, and COND is a boolean indicating if the test should be skipped.
+
+    For example
+
+    def windows():
+        return "on windows", sys.platform.startswith("win")
+
+  * Then add the above function to CONDITION_FNS.
+
+Doing that will make the skip condition available in two places:
+`mark.skipif_NAME` and `skipif.NAME`. So, for the above example, there would
+now be `mark.skipif_windows` and `skipif.windows`.
+"""
+import abc
+import os
+
+import pytest
+
+from reproman.cmd import Runner
+from reproman.support.exceptions import CommandError
+from reproman.support.external_versions import external_versions
+from reproman.utils import on_windows as _on_windows
+
+# Condition functions
+#
+# To create a new condition, (1) add a condition function and (2) add that
+# function to CONDITION_FNS.
+
+
+def no_apt_cache():
+    return ("apt-cache not available", not external_versions["cmd:apt-cache"])
+
+
+def no_aws_dependencies():
+    return "boto3 not installed", not external_versions["boto3"]
+
+
+def no_condor():
+    def is_running():
+        try:
+            Runner().run(["condor_status"])
+        except CommandError as exc:
+            return False
+        return True
+
+    return (
+        "condor not available",
+        not (external_versions["cmd:condor"] and is_running()),
+    )
+
+
+def no_datalad():
+    return ("datalad not available", not external_versions["datalad"])
+
+
+def no_docker_dependencies():
+    missing_deps = []
+    for dep in "docker", "dockerpty":
+        if dep not in external_versions:
+            missing_deps.append(dep)
+    msg = "missing dependencies: {}".format(", ".join(missing_deps))
+    return msg, missing_deps
+
+
+def no_docker_engine():
+    def is_engine_running():
+        from reproman.resource.docker_container import DockerContainer
+
+        return DockerContainer.is_engine_running()
+
+    # DockerContainer depends on docker.
+    msg, missing_deps = no_docker_dependencies()
+    if missing_deps:
+        return msg, missing_deps
+    return "docker engine not running", not is_engine_running()
+
+
+def no_network():
+    return ("no network settings", os.environ.get("REPROMAN_TESTS_NONETWORK"))
+
+
+def no_singularity():
+    return ("singularity not available", not external_versions["cmd:singularity"])
+
+
+def no_ssh():
+    if _on_windows:
+        reason = "no ssh on windows"
+    else:
+        reason = "no ssh (REPROMAN_TESTS_SSH unset)"
+    return (reason, _on_windows or not os.environ.get("REPROMAN_TESTS_SSH"))
+
+
+def no_svn():
+    return ("subversion not available", not external_versions["cmd:svn"])
+
+
+def on_windows():
+    return "on windows", _on_windows
+
+
+CONDITION_FNS = [
+    no_apt_cache,
+    no_aws_dependencies,
+    no_condor,
+    no_datalad,
+    no_docker_dependencies,
+    no_docker_engine,
+    no_network,
+    no_singularity,
+    no_ssh,
+    no_svn,
+    on_windows,
+]
+
+# Entry points: skipif and mark
+
+
+class NamespaceAttributeError(AttributeError):
+    """Namespace-specific AttributeError.
+
+    Raised by Namespace when it cannot find the specified condition function.
+    Using a derived class allows us to distinguish an unknown condition
+    function from a condition function that raises an AttributeError.
+    """
+
+
+class Namespace(object, metaclass=abc.ABCMeta):
+    """Provide namespace skip conditions in CONDITION_FNS.
+    """
+
+    fns = {c.__name__: c for c in CONDITION_FNS}
+
+    @abc.abstractmethod
+    def attr_value(self, condition_func):
+        """Given a condition function, return an attribute value.
+        """
+
+    def __getattr__(self, item):
+        try:
+            condfn = self.fns[item]
+        except KeyError:
+            raise NamespaceAttributeError(item) from None
+        return self.attr_value(condfn)
+
+
+class SkipIf(Namespace):
+    """Namespace for inline variants of the condition functions.
+
+    Each condition is available under an attribute with the same name as the
+    condition function name.
+    """
+
+    def attr_value(self, condition_func):
+        def fn():
+            reason, cond = condition_func()
+            if cond:
+                pytest.skip(reason, allow_module_level=True)
+
+        return fn
+
+
+skipif = SkipIf()
+
+
+class Mark(Namespace):
+    """Namespace for mark variants of the condition functions.
+
+    Each condition is available under an attribute "skipif_NAME", where NAME is
+    the condition function name.
+    """
+
+    def attr_value(self, condition_func):
+        reason, cond = condition_func()
+        return pytest.mark.skipif(cond, reason=reason)
+
+    def __getattr__(self, item):
+        if item.startswith("skipif_"):
+            try:
+                return super(Mark, self).__getattr__(item[len("skipif_") :])
+            except NamespaceAttributeError:
+                # Fall back to the original item name so that the attribute
+                # error message doesn't confusingly drop "skipif_".
+                pass
+        return super(Mark, self).__getattr__(item)
+
+
+mark = Mark()

--- a/dandi/tests/test_download.py
+++ b/dandi/tests/test_download.py
@@ -1,4 +1,5 @@
 from ..download import download, parse_dandi_url
+from ..tests.skip import mark
 
 
 def test_parse_dandi_url():
@@ -33,6 +34,7 @@ def test_parse_dandi_url():
     assert a, aid == ("item", ["5e7b9e44529c28f35128c747", "5e7b9e43529c28f35128c746"])
 
 
+@mark.skipif_no_network
 def test_download_multiple_files(tmpdir):
     url = (
         "https://gui.dandiarchive.org/#/folder/5e70d3173da50caa9adaf334/selected/"

--- a/dandi/tests/test_download.py
+++ b/dandi/tests/test_download.py
@@ -1,0 +1,49 @@
+from ..download import download, parse_dandi_url
+
+
+def test_parse_dandi_url():
+    # user
+    s, a, aid = parse_dandi_url(
+        "https://girder.dandiarchive.org/"
+        "#user/5da4b8fe51c340795cb18fd0/folder/5e5593cc1a343161ff7c5a92"
+    )
+    # we do not care about user -- we care about folder id
+    assert a, aid == ("folder", "5e5593cc1a343161ff7c5a92")
+    # dandiset
+
+    # folder
+    s, a, aid = parse_dandi_url(
+        "https://gui.dandiarchive.org/#/folder/5e5593cc1a343161ff7c5a92"
+    )
+    assert s == "https://girder.dandiarchive.org/"
+    assert a, aid == ("folder", "5e5593cc1a343161ff7c5a92")
+
+    # selected folder(s)
+    # "https://gui.dandiarchive.org/#/folder/5d978d9ecc10d1bc31040bca/selected/folder+5e8672e06cce296e2e817318"
+
+    # selected items and folders
+    # "https://gui.dandiarchive.org/#/folder/5d978d9ecc10d1bc31040bca/selected/item+5e8674dc6cce296e2e8173c5/folder+5e8672e06cce296e2e817318"
+
+    # Selected multiple items
+    s, a, aid = parse_dandi_url(
+        "https://gui.dandiarchive.org/#/folder/5e7b9e43529c28f35128c745/selected/"
+        "item+5e7b9e44529c28f35128c747/item+5e7b9e43529c28f35128c746"
+    )
+    assert s == "https://girder.dandiarchive.org/"
+    assert a, aid == ("item", ["5e7b9e44529c28f35128c747", "5e7b9e43529c28f35128c746"])
+
+
+def test_download_multiple_files(tmpdir):
+    url = (
+        "https://gui.dandiarchive.org/#/folder/5e70d3173da50caa9adaf334/selected/"
+        "item+5e70d3173da50caa9adaf335/item+5e70d3183da50caa9adaf336"
+    )
+
+    ret = download(url, tmpdir)
+    assert not ret  # we return nothing ATM, might want to "generate"
+    downloads = (x.basename for x in tmpdir.listdir())
+    assert sorted(downloads) == [
+        "sub-anm372795_ses-20170714.nwb",
+        "sub-anm372795_ses-20170715.nwb",
+    ]
+    assert all(x.lstat().size > 1e5 for x in tmpdir.listdir())  # all bigish files


### PR DESCRIPTION
- no support to download selected folders and files (well -- we cannot even do that anywhere among drafts AFAIK since we have only either folders or files ATM in a directory)
- comes with a basic unittest and drags along machinery from reproman for flexible and concise annotation of the tests to be skipped.