### PR TITLE
AFAIK no dateutil is needed for newer pythons.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,6 @@ install_requires =
     click-didyoumean
     etelemetry >= 0.2.0
     joblib
-    python-dateutil
     pyout
     humanize
     pyyaml


### PR DESCRIPTION
We have an additional entry below conditioned on py < 3.7

Let's see if tests pass