### PR TITLE
RF: DANDI_CACHE_CLEAR -> DANDI_CACHE=(ignore|clear)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -47,7 +47,8 @@ development command line options.
 
 - `DANDI_LOG_LEVEL` -- set log level. By default `INFO`, should be an int (`10` - `DEBUG`).
 
-- `DANDI_CACHE_CLEAR` -- clear persistent cache before re-using.  E.g., for
+- `DANDI_CACHE` -- clear persistent cache handling. Known values
+  are `clear` - would clear the cache, `ignore` - would ignore it. Note that for
   metadata cache we use only released portion of `dandi.__version__` as a token.
   If handling of metadata has changed while developing, set this env var to
-  have cache `clear()`ed before use.
+  `clear` to have cache `clear()`ed before use.

--- a/dandi/support/cache.py
+++ b/dandi/support/cache.py
@@ -32,8 +32,10 @@ class PersistentCache(object):
         dirs = appdirs.AppDirs("dandi")
         self._cache_file = op.join(dirs.user_cache_dir, (name or "cache"))
         self._memory = joblib.Memory(self._cache_file, verbose=0)
-        if os.environ.get("DANDI_CACHE_CLEAR", None):
+        clear_var = os.environ.get("DANDI_CACHE_CLEAR", None)
+        if clear_var in ("1", "yes", "name"):
             self.clear()
+        self._ignore_cache = clear_var == "ignore"
         self._tokens = tokens
 
     def clear(self):
@@ -50,6 +52,8 @@ class PersistentCache(object):
             lgr.warning(f"Failed to clear out the cache directory: {exc}")
 
     def memoize(self, f):
+        if self._ignore_cache:
+            return f
         return self._memory.cache(f)
 
     def memoize_path(self, f):
@@ -110,4 +114,4 @@ class PersistentCache(object):
             lgr.log(5, "Fingerprint for %s: %s", path, fprint)
             return fprint
         except Exception as exc:
-            lgr.debug(f"Cannot fingerptint {path}: {exc}")
+            lgr.debug(f"Cannot fingerprint {path}: {exc}")

--- a/dandi/support/cache.py
+++ b/dandi/support/cache.py
@@ -18,6 +18,8 @@ class PersistentCache(object):
     _min_dtime = 0.01  # min difference between now and mtime to consider
     # for caching
 
+    _cache_var_values = ("", "clear", "ignore")
+
     def __init__(self, name=None, tokens=None):
         """
 
@@ -32,10 +34,15 @@ class PersistentCache(object):
         dirs = appdirs.AppDirs("dandi")
         self._cache_file = op.join(dirs.user_cache_dir, (name or "cache"))
         self._memory = joblib.Memory(self._cache_file, verbose=0)
-        clear_var = os.environ.get("DANDI_CACHE_CLEAR", None)
-        if clear_var in ("1", "yes", "name"):
+        cache_var = os.environ.get("DANDI_CACHE", "").lower()
+        if cache_var not in self._cache_var_values:
+            lgr.warning(
+                f"DANDI_CACHE={cache_var} is not understood and thus ignored. "
+                f"Known values are {self._cache_var_values}"
+            )
+        if cache_var == "clear":
             self.clear()
-        self._ignore_cache = clear_var == "ignore"
+        self._ignore_cache = cache_var == "ignore"
         self._tokens = tokens
 
     def clear(self):


### PR DESCRIPTION
"ignore" is useful to redo metadata extraction and see warnings from pynwb again