### PR TITLE
ENH: sanitize, validate and tolerate better wrong nwb_version

### DIFF
--- a/dandi/pynwb_utils.py
+++ b/dandi/pynwb_utils.py
@@ -8,6 +8,7 @@ from collections import Counter
 
 import pynwb
 from pynwb import NWBHDF5IO
+import semantic_version
 
 from . import get_logger
 
@@ -34,7 +35,7 @@ def _sanitize_nwb_version(v, filename=None, log=None):
 
     Would log a warning if something detected to be fishy"""
     msg = f"File {filename}: " if filename else ""
-    msg += "Version is"
+    msg += f"nwb_version {v!r}"
 
     if log is None:
         log = lgr.warning
@@ -46,16 +47,19 @@ def _sanitize_nwb_version(v, filename=None, log=None):
             # should be semver since 2.1.0
             if not (v_.startswith("1.") or v_.startswith("2.0")):
                 log(
-                    f"{msg} {v} with NWB- prefix, which is not part of the "
+                    f"{msg} starts with NWB- prefix, which is not part of the "
                     f"specification since NWB 2.1.0"
                 )
             v = v_
-        # TODO: could do regex matching etc
     elif isinstance(v, int):
-        log(f"{msg} an int {v} whenever it should be a string")
+        log(f"{msg} is an integer whenever it should be text")
         v = str(v)
     elif v:
-        log(f"{msg} {v!r} which is not text following semver. We do not sanitize")
+        log(f"{msg} is not text which follows semver specification")
+
+    if isinstance(v, str) and not semantic_version.validate(v):
+        log(f"{msg} is not a proper semantic version. See http://semver.org")
+
     return v
 
 

--- a/dandi/pynwb_utils.py
+++ b/dandi/pynwb_utils.py
@@ -58,7 +58,8 @@ def _sanitize_nwb_version(v, filename=None, log=None):
         log(f"{msg} is not text which follows semver specification")
 
     if isinstance(v, str) and not semantic_version.validate(v):
-        log(f"{msg} is not a proper semantic version. See http://semver.org")
+        msgtype = "error" if LooseVersion(v) >= "2.1.0" else "warning"
+        log(f"{msgtype}: {msg} is not a proper semantic version. See http://semver.org")
 
     return v
 

--- a/dandi/pynwb_utils.py
+++ b/dandi/pynwb_utils.py
@@ -238,17 +238,16 @@ def validate(path):
         # Explicitly sanitize so we collect warnings.
         # TODO: later cast into proper ERRORs
         version = _sanitize_nwb_version(version, log=errors.append)
-        if version and semantic_version.validate(version):
-            semver = semantic_version.Version(version)
-            if semver < semantic_version.Version("2.1.0"):
-                errors_ = errors[:]
-                errors = [e for e in errors if not re_ok_prior_210.search(str(e))]
-                if errors != errors_:
-                    lgr.debug(
-                        "Filtered out %d validation errors on %s",
-                        len(errors_) - len(errors),
-                        path,
-                    )
+        loosever = LooseVersion(version)
+        if loosever and loosever < "2.1.0":
+            errors_ = errors[:]
+            errors = [e for e in errors if not re_ok_prior_210.search(str(e))]
+            if errors != errors_:
+                lgr.debug(
+                    "Filtered out %d validation errors on %s",
+                    len(errors_) - len(errors),
+                    path,
+                )
     return errors
 
 

--- a/dandi/tests/test_pynwb_utils.py
+++ b/dandi/tests/test_pynwb_utils.py
@@ -48,7 +48,8 @@ def test_sanitize_nwb_version():
     assert _sanitize_nwb_version("NWB-2.0.0", log=_nocall) == "2.0.0"
     assert (
         _sanitize_nwb_version(
-            "NWB-2.1.0", log=assert_regex("^Version is NWB-2.1.0 with NWB- prefix,")
+            "NWB-2.1.0",
+            log=assert_regex("^nwb_version 'NWB-2.1.0' starts with NWB- prefix,"),
         )
         == "2.1.0"
     )
@@ -56,7 +57,9 @@ def test_sanitize_nwb_version():
         _sanitize_nwb_version(
             "NWB-2.1.0",
             filename="/bu",
-            log=assert_regex("^File /bu: Version is NWB-2.1.0 with NWB- prefix,"),
+            log=assert_regex(
+                "^File /bu: nwb_version 'NWB-2.1.0' starts with NWB- prefix,"
+            ),
         )
         == "2.1.0"
     )

--- a/dandi/tests/test_pynwb_utils.py
+++ b/dandi/tests/test_pynwb_utils.py
@@ -1,6 +1,7 @@
+import re
 import pynwb
 
-from ..pynwb_utils import metadata_nwb_subject_fields
+from ..pynwb_utils import metadata_nwb_subject_fields, _sanitize_nwb_version
 from ..metadata import get_metadata
 
 
@@ -30,3 +31,32 @@ def test_pynwb_io(simple1_nwb):
         nwbfile = reader.read()
     assert repr(nwbfile)
     assert str(nwbfile)
+
+
+def test_sanitize_nwb_version():
+    def _nocall(*args):
+        raise AssertionError(f"Should have not been called. Was called with {args}")
+
+    def assert_regex(regex):
+        def search(v):
+            assert re.search(regex, v)
+
+        return search
+
+    assert _sanitize_nwb_version("1.0.0", log=_nocall) == "1.0.0"
+    assert _sanitize_nwb_version("NWB-1.0.0", log=_nocall) == "1.0.0"
+    assert _sanitize_nwb_version("NWB-2.0.0", log=_nocall) == "2.0.0"
+    assert (
+        _sanitize_nwb_version(
+            "NWB-2.1.0", log=assert_regex("^Version is NWB-2.1.0 with NWB- prefix,")
+        )
+        == "2.1.0"
+    )
+    assert (
+        _sanitize_nwb_version(
+            "NWB-2.1.0",
+            filename="/bu",
+            log=assert_regex("^File /bu: Version is NWB-2.1.0 with NWB- prefix,"),
+        )
+        == "2.1.0"
+    )

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ install_requires =
     keyring
     keyrings.alt
     python-dateutil;  python_version < "3.7"
+    semantic-version
     tqdm
 tests_require =
     pytest


### PR DESCRIPTION
As reported on slack, we have use cases with nwb_version somehow `NWB-2.2.0`.
This PR strips NWB- prefix while obtaining the version, and would complain if that is to be happen for files with nwb_version >= 2.1.0 (in a custom comparison, so we defer to proper semver check later). 

`validate` also would now check and report a problem.  This is hopefully a temporary implementation within dandi -- hopefully nwb_schema would introduce constraints via regular expressions so validity of nwb_version could be checked "natively" by pynwb, see https://github.com/NeurodataWithoutBorders/nwb-schema/issues/426

There is no test for `validate` changes here.  I am (slowly) working on a separate branch to RF validation, so they will (hopefully) come there ;)