### PR TITLE
BF: export NO_ET=1 on github workflow - we must not artifiially blow up user counts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    env:
+      NO_ET: 1
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Filed issue against etelemetry-client to automate that:
https://github.com/sensein/etelemetry-client/issues/17

@satra, may be we would like to prune our records on etelemetry server after this is merged.