### PR TITLE
BF: do not use shell=True to invoke test command

### DIFF
--- a/dandi/cli/tests/test_command.py
+++ b/dandi/cli/tests/test_command.py
@@ -36,7 +36,6 @@ def test_no_heavy_imports():
             "print(','.join(set(m.split('.')[0] for m in sys.modules)));",
         ],
         env=env,
-        shell=True,
         stdout=PIPE,
         stderr=PIPE,
     )


### PR DESCRIPTION
Not yet sure why but it can lead to stalling, most likely because
shell might be spitting out some errors so with PIPEs for both stdout,
stderr we get into the stalling of the process.

I kept running into the stall locally and now while building dandi conda package