### PR TITLE
RF: allow dandi to be used with outdated etelemetry

### DIFF
--- a/dandi/__init__.py
+++ b/dandi/__init__.py
@@ -42,6 +42,12 @@ logging.basicConfig(format=FORMAT)
 import __main__
 
 if not hasattr(__main__, "__file__"):
-    import etelemetry
+    try:
+        import etelemetry
 
-    etelemetry.check_available_version("dandi/dandi-cli", __version__, lgr=lgr)
+        etelemetry.check_available_version("dandi/dandi-cli", __version__, lgr=lgr)
+    except Exception as exc:
+        lgr.warning(
+            "Failed to check for a more recent version available with etelemetry: %s",
+            exc,
+        )

--- a/dandi/cli/tests/test_command.py
+++ b/dandi/cli/tests/test_command.py
@@ -44,5 +44,5 @@ def test_no_heavy_imports():
     loaded_heavy = set(modules).intersection(heavy_modules)
 
     assert not loaded_heavy
-    assert not stderr or b"dandi version" in stderr
+    assert not stderr or b"Failed to check" in stderr or b"dandi version" in stderr
     assert not p.wait()


### PR DESCRIPTION
ATM conda has only 0.1.2 .  That one has no check_available_version.
This and other changes might come to etelemetry in the future and I do not
want to chase it.