### PR TITLE
BF+RF: download - use regexes to prescribe known urls, support items and netlify

### DIFF
--- a/dandi/download.py
+++ b/dandi/download.py
@@ -55,6 +55,7 @@ def parse_dandi_url(url):
       in case of multiple files
 
     """
+    lgr.debug("Parsing url %s", url)
     if "#" not in url:
         # assume that it was a dandi notation, let's try to follow redirects
         # TODO: make .head work instead of .get on the redirector
@@ -67,7 +68,7 @@ def parse_dandi_url(url):
         elif r.url != url:
             url = r.url
         else:
-            lgr.warning(f"Redirection did not happen for {url}")
+            lgr.warning("Redirection did not happen for %s", url)
 
     # We will just allow exception to escape if something goes wrong.
     # Warnings above could provide a clue in some cases
@@ -115,7 +116,9 @@ def parse_dandi_url(url):
             f" .*/(folder|collection|dandiset-meta)/ID24 or pointing to "
             f"individual selected items: {url}"
         )
-    return server, asset_type, asset_ids
+    res = server, asset_type, asset_ids
+    lgr.debug("Parsed into %s", res)
+    return res
 
 
 def download(

--- a/dandi/download.py
+++ b/dandi/download.py
@@ -106,12 +106,13 @@ class _dandi_url_parser:
                 break
 
         if not match:
-            known_regexes = ", ".join(cls.known_urls)
+            known_regexes = "\n - ".join([""] + list(cls.known_urls))
             # TODO: may be make use of etelemetry and report if newer client
             # which might know is available?
             raise UnknownURLError(
-                f"We do not know how to map URL {url} to girder. "
-                f"Regular expressions for known setups: {known_regexes}"
+                f"We do not know how to map URL {url} to girder.\n"
+                f"Regular expressions for known setups:"
+                f"{known_regexes}"
             )
 
         groups = match.groupdict()

--- a/dandi/download.py
+++ b/dandi/download.py
@@ -195,10 +195,7 @@ def _get_asset_files(
             )
             break
         except girder.gcl.HttpError as exc:
-            response = girder.get_HttpError_response(exc)
-            if not authenticate and (
-                exc.status == 401 or "access denied" in response.get("message", "")
-            ):
+            if not authenticate and girder.is_access_denied(exc):
                 lgr.warning("unauthenticated access denied, let's authenticate")
                 client.dandi_authenticate()
                 continue

--- a/dandi/exceptions.py
+++ b/dandi/exceptions.py
@@ -5,3 +5,21 @@ class OrganizeImpossibleError(ValueError):
     """
 
     pass
+
+
+class UnknownURLError(ValueError):
+    """Given url is not known to correspond to DANDI archive schema(s)"""
+
+    pass
+
+
+class NotFoundError(RuntimeError):
+    """Online resource which we tried to connect to is not found"""
+
+    pass
+
+
+class FailedToConnectError(RuntimeError):
+    """Failed to connect to online resource"""
+
+    pass

--- a/dandi/girder.py
+++ b/dandi/girder.py
@@ -67,6 +67,14 @@ def get_HttpError_response(exc):
     return None
 
 
+def is_access_denied(exc):
+    """Tell if an exception about denied access"""
+    response = get_HttpError_response(exc)
+    return exc.status == 401 or (
+        response and "access denied" in response.get("message", "")
+    )
+
+
 from requests.adapters import HTTPAdapter
 
 
@@ -228,10 +236,7 @@ class GirderCli(gcl.GirderClient):
                 g = self.getResource(asset_type, asset_id)
                 break
             except gcl.HttpError as exc:
-                response = get_HttpError_response(exc)
-                if not self.token and (
-                    exc.status == 401 or "access denied" in response.get("message", "")
-                ):
+                if not self.token and is_access_denied(exc):
                     lgr.warning("unauthenticated access denied, let's authenticate")
                     self.dandi_authenticate()
                 else:

--- a/dandi/tests/test_download.py
+++ b/dandi/tests/test_download.py
@@ -36,6 +36,14 @@ def test_parse_dandi_url():
     assert s == "https://girder.dandiarchive.org/"
     assert a, aid == ("item", ["5e7b9e44529c28f35128c747", "5e7b9e43529c28f35128c746"])
 
+    # new (v1? not yet tagged) web UI, and as it comes from a PR,
+    # so we need to provide yet another mapping to stock girder
+    s, a, aid = parse_dandi_url(
+        "https://refactor--gui-dandiarchive-org.netlify.app/#/file-browser/folder/5e9f9588b5c9745bad9f58fe"
+    )
+    assert s == "https://girder.dandiarchive.org"
+    assert a, aid == "folder"["5e9f9588b5c9745bad9f58fe"]
+
 
 @mark.skipif_no_network
 def test_parse_dandi_url_redirect():

--- a/dandi/tests/test_download.py
+++ b/dandi/tests/test_download.py
@@ -1,5 +1,8 @@
 from ..download import download, parse_dandi_url
+from ..exceptions import NotFoundError
 from ..tests.skip import mark
+
+import pytest
 
 
 def test_parse_dandi_url():
@@ -32,6 +35,17 @@ def test_parse_dandi_url():
     )
     assert s == "https://girder.dandiarchive.org/"
     assert a, aid == ("item", ["5e7b9e44529c28f35128c747", "5e7b9e43529c28f35128c746"])
+
+
+@mark.skipif_no_network
+def test_parse_dandi_url_redirect():
+    # Unlikely this one would ever come to existence
+    with pytest.raises(NotFoundError):
+        parse_dandi_url("https://dandiarchive.org/dandiset/999999")
+    # Is there ATM
+    s, a, aid = parse_dandi_url("https://dandiarchive.org/dandiset/000003")
+    assert s == "https://girder.dandiarchive.org/"
+    assert a, aid == ("dandiset-meta", "5e6eb2b776569eb93f451f8d")
 
 
 @mark.skipif_no_network


### PR DESCRIPTION
Closes gh-92 :

- supports download from netlify instance (going to the main girder)
- supports /v1/.../download girder urls

Also later added

- retry download up to 3 times (Closes gh-87)

Individual commit messages could provide more details