### PR TITLE
BF: explicit request to handle redirect for identifiers.org

### DIFF
--- a/dandi/download.py
+++ b/dandi/download.py
@@ -22,6 +22,7 @@ class _dandi_url_parser:
         # TODO: Later should better conform to our API, so we could allow
         #       for not only "dandiarchive.org" URLs
         "https?://dandiarchive.org/.*": {"handle_redirect": True},
+        "https?://identifiers.org/DANDI:.*": {"handle_redirect": True},
         "https?://[^/]*dandiarchive-org.netlify.app/.*": {"map_instance": "dandi"},
         # Girder-inflicted urls to folders etc based on the IDs
         # For those we will completely ignore domain - it will be "handled"


### PR DESCRIPTION
Ref #99 where @satra wants to go even more wild and handle all redirects - yet to see a support for that.

As for identifiers Seems to work (no dedicated unittest):

	$> dandi download https://identifiers.org/DANDI:000004
	2020-05-12 12:07:53,034 [    INFO] Downloading folder with id ['5e6ff4140fe0ec33e6b3d5d2'] from https://girder.dandiarchive.org/
	2020-05-12 12:07:54,819 [    INFO] Traversing remote dandisets (000004) recursively and downloading them locally
	2020-05-12 12:07:54,819 [    INFO] Updating dandiset.yaml from obtained dandiset metadata
	sub-P15HMH_ses-20070901_obj-8et7lc.nwb:  19%|███████▍                               | 10.4M/54.7M [00:22<04:35, 161kB/s^Cub-P10HM_ses-20060901.nwb:  29%|██████████████▊                                    | 21.2M/73.2M [00:21<02:55, 296kB/s]
	Aborted20060901.nwb:  29%|██████████████▉                                    | 21.4M/73.2M [00:22<02:14, 384kB/s]
	dandi download https://identifiers.org/DANDI:000004