### PR TITLE
ENH: Upload digests (only 4 checksums for now)

### DIFF
--- a/dandi/cli/cmd_upload.py
+++ b/dandi/cli/cmd_upload.py
@@ -22,6 +22,7 @@ from ..consts import (
     dandiset_identifier_regex,
     dandiset_metadata_file,
     known_instances,
+    metadata_digests,
 )
 
 
@@ -417,8 +418,8 @@ def upload(
                 # TODO: in theory we could also cache the result, but since it is
                 # critical to get correct checksums, safer to just do it all the time.
                 # Should typically be faster than upload itself ;-)
-                digester = Digester(["md5", "sha1", "sha256"])
-                file_metadata_["uploaded_digests"] = digester(path)
+                digester = Digester(metadata_digests)
+                file_metadata_.update(digester(path))
             except Exception as exc:
                 yield skip_file("failed to compute digests: %s" % str(exc))
                 return

--- a/dandi/consts.py
+++ b/dandi/consts.py
@@ -64,7 +64,7 @@ metadata_all_fields = metadata_nwb_fields + metadata_dandiset_fields
 # Order matters - observed compute time from shorter to longer
 # Those are not to be included in metadata reported for a local file,
 # but will be available for files in the archive
-metadata_digests = ("sha1", "md5", "sha256")
+metadata_digests = ("sha1", "md5", "sha512", "sha256")
 
 dandiset_metadata_file = "dandiset.yaml"
 dandiset_identifier_regex = "^[0-9]{6}$"

--- a/dandi/consts.py
+++ b/dandi/consts.py
@@ -60,6 +60,12 @@ metadata_dandiset_fields = (
 
 metadata_all_fields = metadata_nwb_fields + metadata_dandiset_fields
 
+# checksums and other digests to compute on the files to upload
+# Order matters - observed compute time from shorter to longer
+# Those are not to be included in metadata reported for a local file,
+# but will be available for files in the archive
+metadata_digests = ("sha1", "md5", "sha256")
+
 dandiset_metadata_file = "dandiset.yaml"
 dandiset_identifier_regex = "^[0-9]{6}$"
 

--- a/dandi/download.py
+++ b/dandi/download.py
@@ -226,6 +226,8 @@ def download(
             op.join(output_dir, file["path"]),
             existing=existing,
             attrs=file["attrs"],
+            # TODO: make it less "fluid" to not breed a bug where we stop verifying
+            digests=file.get("metadata").get("uploaded_digests"),
         )
         for file in files
     )

--- a/dandi/download.py
+++ b/dandi/download.py
@@ -3,7 +3,7 @@ import re
 import requests
 
 from . import girder, get_logger
-from .consts import dandiset_metadata_file, known_instances
+from .consts import dandiset_metadata_file, known_instances, metadata_digests
 from .dandiset import Dandiset
 from .exceptions import FailedToConnectError, NotFoundError, UnknownURLError
 from .utils import flatten, flattened, Parallel, delayed
@@ -227,7 +227,12 @@ def download(
             existing=existing,
             attrs=file["attrs"],
             # TODO: make it less "fluid" to not breed a bug where we stop verifying
-            digests=file.get("metadata").get("uploaded_digests"),
+            # for e.g. digests move
+            digests={
+                d: file.get("metadata")[d]
+                for d in metadata_digests
+                if d in file.get("metadata", {})
+            },
         )
         for file in files
     )

--- a/dandi/girder.py
+++ b/dandi/girder.py
@@ -14,7 +14,7 @@ import girder_client as gcl
 
 from . import get_logger
 from .utils import ensure_datetime, ensure_strtime, is_same_time
-from .consts import known_instances, known_instances_rev
+from .consts import known_instances, known_instances_rev, metadata_digests
 from .support.digests import Digester
 
 lgr = get_logger()
@@ -410,12 +410,11 @@ class GirderCli(gcl.GirderClient):
             if mtime:
                 os.utime(path, (time.time(), mtime.timestamp()))
         if digests:
-            # Order according to speed of computation according to Yarik's laptop
-            # x2 difference between sha1 and sha256
-            for algo in ["sha1", "md5", "sha512", "sha256", None]:
+            # Pick the first one (ordered according to speed of computation)
+            for algo in metadata_digests:
                 if algo in digests:
                     break
-            if algo is None:
+            else:
                 algo = list(digests)[:1]  # first available
             digest = Digester([algo])(path)[algo]
             if digests[algo] != digest:

--- a/dandi/girder.py
+++ b/dandi/girder.py
@@ -15,7 +15,7 @@ import girder_client as gcl
 from . import get_logger
 from .utils import ensure_datetime, ensure_strtime, is_same_time
 from .consts import known_instances, known_instances_rev
-
+from .support.digests import Digester
 
 lgr = get_logger()
 
@@ -339,7 +339,14 @@ class GirderCli(gcl.GirderClient):
                 if len(children) < gcl.DEFAULT_PAGE_LIMIT:
                     break
 
-    def download_file(self, file_id, path, existing="error", attrs=None):
+    def download_file(self, file_id, path, existing="error", attrs=None, digests=None):
+        """
+        Parameters
+        ----------
+        digests: dict, optional
+          possible checksums or other digests provided for the file. Only one
+          will be used to verify download
+        """
         if op.lexists(path):
             msg = f"File {path!r} already exists"
             if existing == "error":
@@ -402,6 +409,25 @@ class GirderCli(gcl.GirderClient):
             mtime = self._get_file_mtime(attrs)
             if mtime:
                 os.utime(path, (time.time(), mtime.timestamp()))
+        if digests:
+            # Order according to speed of computation according to Yarik's laptop
+            # x2 difference between sha1 and sha256
+            for algo in ["sha1", "md5", "sha512", "sha256", None]:
+                if algo in digests:
+                    break
+            if algo is None:
+                algo = list(digests)[:1]  # first available
+            digest = Digester([algo])(path)[algo]
+            if digests[algo] != digest:
+                lgr.warning(
+                    "%s %s is different: downloaded %s, should have been %s.",
+                    path,
+                    algo,
+                    digest,
+                    digests[algo],
+                )
+            else:
+                lgr.debug("Verified that %s has correct %s %s", path, algo, digest)
 
     @staticmethod
     def _get_file_mtime(attrs):

--- a/dandi/support/digests.py
+++ b/dandi/support/digests.py
@@ -1,0 +1,72 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Provides helper to compute digests (md5 etc) on files
+"""
+
+import hashlib
+
+from ..utils import auto_repr
+
+import logging
+
+lgr = logging.getLogger("datalad.support.digests")
+
+
+@auto_repr
+class Digester(object):
+    """Helper to compute multiple digests in one pass for a file
+    """
+
+    # Loosely based on snippet by PM 2Ring 2014.10.23
+    # http://unix.stackexchange.com/a/163769/55543
+
+    # Ideally we should find an efficient way to parallelize this but
+    # atm this one is sufficiently speedy
+
+    DEFAULT_DIGESTS = ["md5", "sha1", "sha256", "sha512"]
+
+    def __init__(self, digests=None, blocksize=1 << 16):
+        """
+        Parameters
+        ----------
+        digests : list or None
+          List of any supported algorithm labels, such as md5, sha1, etc.
+          If None, a default set of hashes will be computed (md5, sha1,
+          sha256, sha512).
+        blocksize : int
+          Chunk size (in bytes) by which to consume a file.
+        """
+        self._digests = digests or self.DEFAULT_DIGESTS
+        self._digest_funcs = [getattr(hashlib, digest) for digest in self._digests]
+        self.blocksize = blocksize
+
+    @property
+    def digests(self):
+        return self._digests
+
+    def __call__(self, fpath):
+        """
+        fpath : str
+          File path for which a checksum shall be computed.
+
+        Return
+        ------
+        dict
+          Keys are algorithm labels, and values are checksum strings
+        """
+        lgr.debug("Estimating digests for %s" % fpath)
+        digests = [x() for x in self._digest_funcs]
+        with open(fpath, "rb") as f:
+            while True:
+                block = f.read(self.blocksize)
+                if not block:
+                    break
+                [d.update(block) for d in digests]
+
+        return {n: d.hexdigest() for n, d in zip(self.digests, digests)}

--- a/dandi/support/digests.py
+++ b/dandi/support/digests.py
@@ -2,7 +2,7 @@
 # ex: set sts=4 ts=4 sw=4 noet:
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 #
-#   See COPYING file distributed along with the datalad package for the
+#   See COPYING file distributed along with the dandi package for the
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
@@ -15,7 +15,7 @@ from ..utils import auto_repr
 
 import logging
 
-lgr = logging.getLogger("datalad.support.digests")
+lgr = logging.getLogger("dandi.support.digests")
 
 
 @auto_repr

--- a/dandi/support/tests/test_digests.py
+++ b/dandi/support/tests/test_digests.py
@@ -2,46 +2,40 @@
 # ex: set sts=4 ts=4 sw=4 noet:
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 #
-#   See COPYING file distributed along with the datalad package for the
+#   See COPYING file distributed along with the dandi package for the
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-from os.path import join as opj
 from ..digests import Digester
-from ...tests.utils import with_tree
-from ...tests.utils import assert_equal
 
 
-@with_tree(tree={"sample.txt": "123", "0": chr(0), "long.txt": "123abz\n" * 1000000})
-def test_digester(path):
+def test_digester(tmp_path):
     digester = Digester()
-    assert_equal(
-        digester(opj(path, "sample.txt")),
-        {
-            "md5": "202cb962ac59075b964b07152d234b70",
-            "sha1": "40bd001563085fc35165329ea1ff5c5ecbdbbeef",
-            "sha256": "a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3",
-            "sha512": "3c9909afec25354d551dae21590bb26e38d53f2173b8d3dc3eee4c047e7ab1c1eb8b85103e3be7ba613b31bb5c9c36214dc9f14a42fd7a2fdb84856bca5c44c2",
-        },
-    )
 
-    assert_equal(
-        digester(opj(path, "0")),
-        {
-            "md5": "93b885adfe0da089cdf634904fd59f71",
-            "sha1": "5ba93c9db0cff93f52b521d7420e43f6eda2784f",
-            "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
-            "sha512": "b8244d028981d693af7b456af8efa4cad63d282e19ff14942c246e50d9351d22704a802a71c3580b6370de4ceb293c324a8423342557d4e5c38438f0e36910ee",
-        },
-    )
+    f = tmp_path / "sample.txt"
+    f.write_text("123")
+    assert digester(f) == {
+        "md5": "202cb962ac59075b964b07152d234b70",
+        "sha1": "40bd001563085fc35165329ea1ff5c5ecbdbbeef",
+        "sha256": "a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3",
+        "sha512": "3c9909afec25354d551dae21590bb26e38d53f2173b8d3dc3eee4c047e7ab1c1eb8b85103e3be7ba613b31bb5c9c36214dc9f14a42fd7a2fdb84856bca5c44c2",
+    }
 
-    assert_equal(
-        digester(opj(path, "long.txt")),
-        {
-            "md5": "81b196e3d8a1db4dd2e89faa39614396",
-            "sha1": "5273ac6247322c3c7b4735a6d19fd4a5366e812f",
-            "sha256": "80028815b3557e30d7cbef1d8dbc30af0ec0858eff34b960d2839fd88ad08871",
-            "sha512": "684d23393eee455f44c13ab00d062980937a5d040259d69c6b291c983bf635e1d405ff1dc2763e433d69b8f299b3f4da500663b813ce176a43e29ffcc31b0159",
-        },
-    )
+    f = tmp_path / "0"
+    f.write_text(chr(0))
+    assert digester(f) == {
+        "md5": "93b885adfe0da089cdf634904fd59f71",
+        "sha1": "5ba93c9db0cff93f52b521d7420e43f6eda2784f",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
+        "sha512": "b8244d028981d693af7b456af8efa4cad63d282e19ff14942c246e50d9351d22704a802a71c3580b6370de4ceb293c324a8423342557d4e5c38438f0e36910ee",
+    }
+
+    f = tmp_path / "long.txt"
+    f.write_text("123abz\n" * 1000000)
+    assert digester(f) == {
+        "md5": "81b196e3d8a1db4dd2e89faa39614396",
+        "sha1": "5273ac6247322c3c7b4735a6d19fd4a5366e812f",
+        "sha256": "80028815b3557e30d7cbef1d8dbc30af0ec0858eff34b960d2839fd88ad08871",
+        "sha512": "684d23393eee455f44c13ab00d062980937a5d040259d69c6b291c983bf635e1d405ff1dc2763e433d69b8f299b3f4da500663b813ce176a43e29ffcc31b0159",
+    }

--- a/dandi/support/tests/test_digests.py
+++ b/dandi/support/tests/test_digests.py
@@ -14,7 +14,7 @@ def test_digester(tmp_path):
     digester = Digester()
 
     f = tmp_path / "sample.txt"
-    f.write_text("123")
+    f.write_bytes(b"123")
     assert digester(f) == {
         "md5": "202cb962ac59075b964b07152d234b70",
         "sha1": "40bd001563085fc35165329ea1ff5c5ecbdbbeef",
@@ -23,7 +23,7 @@ def test_digester(tmp_path):
     }
 
     f = tmp_path / "0"
-    f.write_text(chr(0))
+    f.write_bytes(chr(0).encode())
     assert digester(f) == {
         "md5": "93b885adfe0da089cdf634904fd59f71",
         "sha1": "5ba93c9db0cff93f52b521d7420e43f6eda2784f",
@@ -32,7 +32,7 @@ def test_digester(tmp_path):
     }
 
     f = tmp_path / "long.txt"
-    f.write_text("123abz\n" * 1000000)
+    f.write_bytes(b"123abz\n" * 1000000)
     assert digester(f) == {
         "md5": "81b196e3d8a1db4dd2e89faa39614396",
         "sha1": "5273ac6247322c3c7b4735a6d19fd4a5366e812f",

--- a/dandi/support/tests/test_digests.py
+++ b/dandi/support/tests/test_digests.py
@@ -1,0 +1,47 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+
+from os.path import join as opj
+from ..digests import Digester
+from ...tests.utils import with_tree
+from ...tests.utils import assert_equal
+
+
+@with_tree(tree={"sample.txt": "123", "0": chr(0), "long.txt": "123abz\n" * 1000000})
+def test_digester(path):
+    digester = Digester()
+    assert_equal(
+        digester(opj(path, "sample.txt")),
+        {
+            "md5": "202cb962ac59075b964b07152d234b70",
+            "sha1": "40bd001563085fc35165329ea1ff5c5ecbdbbeef",
+            "sha256": "a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3",
+            "sha512": "3c9909afec25354d551dae21590bb26e38d53f2173b8d3dc3eee4c047e7ab1c1eb8b85103e3be7ba613b31bb5c9c36214dc9f14a42fd7a2fdb84856bca5c44c2",
+        },
+    )
+
+    assert_equal(
+        digester(opj(path, "0")),
+        {
+            "md5": "93b885adfe0da089cdf634904fd59f71",
+            "sha1": "5ba93c9db0cff93f52b521d7420e43f6eda2784f",
+            "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
+            "sha512": "b8244d028981d693af7b456af8efa4cad63d282e19ff14942c246e50d9351d22704a802a71c3580b6370de4ceb293c324a8423342557d4e5c38438f0e36910ee",
+        },
+    )
+
+    assert_equal(
+        digester(opj(path, "long.txt")),
+        {
+            "md5": "81b196e3d8a1db4dd2e89faa39614396",
+            "sha1": "5273ac6247322c3c7b4735a6d19fd4a5366e812f",
+            "sha256": "80028815b3557e30d7cbef1d8dbc30af0ec0858eff34b960d2839fd88ad08871",
+            "sha512": "684d23393eee455f44c13ab00d062980937a5d040259d69c6b291c983bf635e1d405ff1dc2763e433d69b8f299b3f4da500663b813ce176a43e29ffcc31b0159",
+        },
+    )

--- a/dandi/utils.py
+++ b/dandi/utils.py
@@ -408,6 +408,62 @@ def safe_call(func, path, default=None):
         return default
 
 
+def shortened_repr(value, l=30):
+    try:
+        if hasattr(value, "__repr__") and (value.__repr__ is not object.__repr__):
+            value_repr = repr(value)
+            if not value_repr.startswith("<") and len(value_repr) > l:
+                value_repr = "<<%s++%d chars++%s>>" % (
+                    value_repr[: l - 16],
+                    len(value_repr) - (l - 16 + 4),
+                    value_repr[-4:],
+                )
+            elif (
+                value_repr.startswith("<")
+                and value_repr.endswith(">")
+                and " object at 0x"
+            ):
+                raise ValueError("I hate those useless long reprs")
+        else:
+            raise ValueError("gimme class")
+    except Exception as e:
+        value_repr = "<%s>" % value.__class__.__name__.split(".")[-1]
+    return value_repr
+
+
+def __auto_repr__(obj):
+    attr_names = tuple()
+    if hasattr(obj, "__dict__"):
+        attr_names += tuple(obj.__dict__.keys())
+    if hasattr(obj, "__slots__"):
+        attr_names += tuple(obj.__slots__)
+
+    items = []
+    for attr in sorted(set(attr_names)):
+        if attr.startswith("_"):
+            continue
+        value = getattr(obj, attr)
+        # TODO:  should we add this feature to minimize some talktative reprs
+        # such as of URL?
+        # if value is None:
+        #    continue
+        items.append("%s=%s" % (attr, shortened_repr(value)))
+
+    return "%s(%s)" % (obj.__class__.__name__, ", ".join(items))
+
+
+def auto_repr(cls):
+    """Decorator for a class to assign it an automagic quick and dirty __repr__
+
+    It uses public class attributes to prepare repr of a class
+
+    Original idea: http://stackoverflow.com/a/27799004/1265472
+    """
+
+    cls.__repr__ = __auto_repr__
+    return cls
+
+
 def Parallel(**kwargs):  # TODO: disable lint complaint
     """Adapter for joblib.Parallel so we could if desired, centralize control
     """


### PR DESCRIPTION
3 right away to capture popular checksums which could possibly later help to identify this file in other places (e.g. datalad uses md5 by default, git annex - sha256, and sha1 iirc used by git)

Theoretically we could provide some progress indication while computing digests which would be valuable for large files, but IMHO not a priority

Unfortunately there is still no unittests for upload, so nothing is tested beyond local tries.

@satra - please recommend another name than `uploaded_digests` for the metadata field.  I kept `uploaded_` prefix consistent with other metadata fields I add upon upload.

TODOs
- [x] (now) add validation upon download that file received correctly.  Will be a naive implementation doing it after download of a file completes.
- (later, possibly) extend with digests for s3 digest with our blocking setting, default ipfs

Closes gh-106 