### PR TITLE
DOC: inform that there is dandi COMMAND --help

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ Usage: dandi [OPTIONS] COMMAND [ARGS]...
   A client to support interactions with DANDI archive
   (http://dandiarchive.org).
 
+  To see help for a specific command, run
+
+      dandi COMMAND --help
+
+  e.g. dandi upload --help
+
 Options:
   --version
   -l, --log-level [DEBUG|INFO|WARNING|ERROR|CRITICAL]

--- a/dandi/cli/command.py
+++ b/dandi/cli/command.py
@@ -168,6 +168,12 @@ def upper(ctx, param, value):
 @click.option("--pdb", help="Fall into pdb if errors out", is_flag=True)
 def main(log_level, pdb=False):
     """A client to support interactions with DANDI archive (http://dandiarchive.org).
+
+    To see help for a specific command, run
+
+        dandi COMMAND --help
+
+    e.g. dandi upload --help
     """
     set_logger_level(get_logger(), log_level)
     if pdb:


### PR DESCRIPTION
Now it would look like

```
$> dandi --help
Usage: dandi [OPTIONS] COMMAND [ARGS]...

  A client to support interactions with DANDI archive
  (http://dandiarchive.org).

  To see help for a specific command, run

      dandi COMMAND --help

  e.g. dandi upload --help

Options:
  --version
  -l, --log-level [DEBUG|INFO|WARNING|ERROR|CRITICAL]
                                  Log level name  [default: INFO]
  --pdb                           Fall into pdb if errors out
  --help                          Show this message and exit.

Commands:
  download  Download a file or entire folder from DANDI
  ls        List .nwb files and dandisets metadata.
  organize  (Re)organize files according to the metadata.
  register  Register a new dandiset in the DANDI archive
  upload    Upload dandiset (files) to DANDI archive.
  validate  Validate files for NWB (and DANDI) compliance.
```

