### PR TITLE
make mktemp compatible with MacOS and linux

### DIFF
--- a/doc/demos/basic-workflow1.sh
+++ b/doc/demos/basic-workflow1.sh
@@ -43,7 +43,7 @@ function sneak() {
 }
 
 
-TOPPATH=$(mktemp -d --tmpdir dandiset-XXXXXXX)
+TOPPATH=$(mktemp -d "${TMPDIR:-/tmp}/dandiset-XXXXXXX")
 
 if [ "$#" != 1 ]; then
     echo "No path was provided, we will use some really lightweight data repo with a single file"


### PR DESCRIPTION
There's still an error with `sed` in the `basic_workflow1.sh` script that I don't know how to fix.  If I remove the indent step in sneak the script runs.