### PR TITLE
ENH: upload - add locking of the dandiset

### DIFF
--- a/dandi/exceptions.py
+++ b/dandi/exceptions.py
@@ -23,3 +23,9 @@ class FailedToConnectError(RuntimeError):
     """Failed to connect to online resource"""
 
     pass
+
+
+class LockingError(RuntimeError):
+    """Failed to lock or unlock a resource"""
+
+    pass

--- a/dandi/girder.py
+++ b/dandi/girder.py
@@ -457,20 +457,20 @@ class GirderCli(gcl.GirderClient):
         presumably_locked = False
         try:
             lgr.debug("Trying to acquire lock for %s", dandiset_identifier)
-            resp = self.post(f"dandi/{dandiset_identifier}/lock")
-            presumably_locked = True
-            # TODO: remove "if resp" 2 instances below after
-            #  https://github.com/dandi/dandiarchive/issues/421 is fixed up
-            if resp and resp.status_code != 200:
-                presumably_locked = False
+            try:
+                self.post(f"dandi/{dandiset_identifier}/lock")
+            except gcl.HttpError:
                 raise LockingError(f"Failed to lock dandiset {dandiset_identifier}")
+            else:
+                presumably_locked = True
 
             yield
         finally:
             if presumably_locked:
                 lgr.debug("Trying to release the lock for %s", dandiset_identifier)
-                resp = self.post(f"dandi/{dandiset_identifier}/unlock")
-                if resp and resp.status_code != 200:
+                try:
+                    self.post(f"dandi/{dandiset_identifier}/unlock")
+                except gcl.HttpError:
                     raise LockingError(
                         f"Failed to unlock dandiset {dandiset_identifier}"
                     )

--- a/dandi/tests/test_girder.py
+++ b/dandi/tests/test_girder.py
@@ -1,0 +1,37 @@
+import pytest
+from ..exceptions import LockingError
+from .. import girder
+
+
+def test_lock_dandiset(local_docker_compose_env):
+    DANDISET_ID = "000001"
+    client = girder.get_client(local_docker_compose_env["instance"].girder)
+    resp = client.get(f"dandi/{DANDISET_ID}/lock/owner")
+    assert resp is None
+    with client.lock_dandiset(DANDISET_ID):
+        resp = client.get(f"dandi/{DANDISET_ID}/lock/owner")
+        assert resp is not None
+    resp = client.get(f"dandi/{DANDISET_ID}/lock/owner")
+    assert resp is None
+
+
+def test_lock_dandiset_error_on_nest(local_docker_compose_env):
+    DANDISET_ID = "000001"
+    client = girder.get_client(local_docker_compose_env["instance"].girder)
+    with client.lock_dandiset(DANDISET_ID):
+        with pytest.raises(LockingError) as excinfo:
+            with client.lock_dandiset(DANDISET_ID):
+                pass
+        assert str(excinfo.value) == f"Failed to lock dandiset {DANDISET_ID}"
+
+
+def test_lock_dandiset_unlock_within(local_docker_compose_env):
+    DANDISET_ID = "000001"
+    client = girder.get_client(local_docker_compose_env["instance"].girder)
+    unlocked = False
+    with pytest.raises(LockingError) as excinfo:
+        with client.lock_dandiset(DANDISET_ID):
+            client.post(f"dandi/{DANDISET_ID}/unlock")
+            unlocked = True
+    assert unlocked
+    assert str(excinfo.value) == f"Failed to unlock dandiset {DANDISET_ID}"

--- a/dandi/tests/test_girder.py
+++ b/dandi/tests/test_girder.py
@@ -21,7 +21,7 @@ def test_lock_dandiset_error_on_nest(local_docker_compose_env):
     with client.lock_dandiset(DANDISET_ID):
         with pytest.raises(LockingError) as excinfo:
             with client.lock_dandiset(DANDISET_ID):
-                pass
+                raise AssertionError("This shouldn't be reached")  # pragma: no cover
         assert str(excinfo.value) == f"Failed to lock dandiset {DANDISET_ID}"
 
 

--- a/dandi/tests/test_upload.py
+++ b/dandi/tests/test_upload.py
@@ -98,3 +98,18 @@ def test_upload_locks(local_docker_compose_env, mocker, monkeypatch, tmp_path):
     lockmock.assert_called()
     lockmock.return_value.__enter__.assert_called()
     lockmock.return_value.__exit__.assert_called()
+
+
+def test_upload_unregistered(local_docker_compose_env, monkeypatch, tmp_path):
+    DIRNAME = "sub-anm369963"
+    FILENAME = "sub-anm369963_ses-20170228.nwb"
+    dandi_instance_id = local_docker_compose_env["instance_id"]
+    (tmp_path / dandiset_metadata_file).write_text("identifier: '999999'\n")
+    (tmp_path / DIRNAME).mkdir(exist_ok=True, parents=True)
+    copyfile(DANDIFILES_DIR / DIRNAME / FILENAME, tmp_path / DIRNAME / FILENAME)
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(ValueError) as excinfo:
+        upload(paths=[DIRNAME], dandi_instance=dandi_instance_id, devel_debug=True)
+    assert str(excinfo.value) == (
+        f"There is no 999999 in {collection_drafts}. Did you use 'dandi register'?"
+    )

--- a/dandi/upload.py
+++ b/dandi/upload.py
@@ -73,13 +73,6 @@ def upload(
             f"into a collection directly."
         )
 
-    # TODO: that the folder already exists
-    if False:
-        raise ValueError(
-            f"There is no {girder_top_folder} in {girder_collection}. "
-            f"Did you use 'dandi register'?"
-        )
-
     import multiprocessing
     from . import girder
     from .pynwb_utils import ignore_benign_pynwb_warnings, get_object_id
@@ -107,6 +100,14 @@ def upload(
         sys.exit(1)
 
     lgr.debug("Working with collection %s", collection_rec)
+
+    try:
+        girder.lookup(client, girder_collection, path=girder_top_folder)
+    except girder.GirderNotFound:
+        raise ValueError(
+            f"There is no {girder_top_folder} in {girder_collection}. "
+            f"Did you use 'dandi register'?"
+        )
 
     #
     # Treat paths

--- a/dandi/upload.py
+++ b/dandi/upload.py
@@ -505,7 +505,7 @@ def upload(
     rec_fields = ["path", "size", "errors", "upload", "status", "message"]
     out = pyout.Tabular(style=pyout_style, columns=rec_fields)
 
-    with out:
+    with out, client.lock_dandiset(dandiset.identifier):
         for path in paths:
             while len(process_paths) >= 10:
                 lgr.log(2, "Sleep waiting for some paths to finish processing")

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,9 +67,9 @@ style =
     pre-commit
 test =
     coverage
-    mock
     pytest
     pytest-cov
+    pytest-mock
     requests ~= 2.20
 all =
     #%(doc)s

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,7 +71,6 @@ test =
     pytest
     pytest-cov
     pytest-mock
-    requests ~= 2.20
     responses
 all =
     #%(doc)s


### PR DESCRIPTION
It locks the entire dandiset for the entire operation (loop across all
files), even if no actual upload would happen (e.g. if all files
already uploaded and recent).

It has a few TODO items added in the code which ideally should be
resolved before we proceed with merging this PR.

Closes #125 since ATM `upload` is the only one which modifies  an existing dandiset