### PR TITLE
BF: Place into process_paths "normalized" (via Path) paths

### DIFF
--- a/dandi/cli/cmd_upload.py
+++ b/dandi/cli/cmd_upload.py
@@ -584,10 +584,11 @@ def upload(
             while len(process_paths) >= 10:
                 lgr.log(2, "Sleep waiting for some paths to finish processing")
                 time.sleep(0.5)
-            process_paths.add(path)
 
             rec = {"path": path}
             path = Path(path)
+            process_paths.add(str(path))
+
             try:
                 fullpath = path if path.is_absolute() else path.absolute()
                 relpath = fullpath.relative_to(dandiset.path)


### PR DESCRIPTION
otherwise we try to remove paths which might have had leading ./ which causes
exception upon attempt to remove it, as has been reported by a user:

	bash-4.2$ DANDI_DEVEL=1 dandi upload --allow-any-path --validation ignore ./rawdata/sub-I46/ses-MRI/anat/test.json
	Please enter password for encrypted keyring:
	2020-07-20 17:23:23,255 [    INFO] Found 1 files to consider
	PATH                                   SIZE         ERRORS     UPLOAD      STATUS                       MESSAGE
	rawdata/sub-I46/ses-MRI/anat/test.json 196 Bytes       2       100%        done
	Summary:                               196 Bytes 1 with errors 95 Bytes/s  1 done

	ERROR: 1 asynchronous worker failed

	Producing value for row ('rawdata/sub-I46/ses-MRI/anat/test.json',) failed:
	Traceback (most recent call last):
	  File "/space/freesurfer/python/3.6/centos7/lib/python3.6/site-packages/pyout/interface.py", line 270, in _print_async_exceptions
		future.result()
	  File "/space/freesurfer/python/3.6/centos7/lib/python3.6/concurrent/futures/_base.py", line 425, in result
		return self.__get_result()
	  File "/space/freesurfer/python/3.6/centos7/lib/python3.6/concurrent/futures/_base.py", line 384, in __get_result
		raise self._exception
	  File "/space/freesurfer/python/3.6/centos7/lib/python3.6/concurrent/futures/thread.py", line 56, in run
		result = self.fn(*self.args, **self.kwargs)
	  File "/space/freesurfer/python/3.6/centos7/lib/python3.6/site-packages/pyout/interface.py", line 461, in async_fn
		for i in gen:
	  File "/space/freesurfer/python/3.6/centos7/lib/python3.6/site-packages/dandi/cli/cmd_upload.py", line 556, in process_path
		process_paths.remove(str(path))
	KeyError: 'rawdata/sub-I46/ses-MRI/anat/test.json'