### PR TITLE
ENH(TEMP): disallow use of a known to be outdated version of dandi client

### DIFF
--- a/dandi/cli/command.py
+++ b/dandi/cli/command.py
@@ -186,6 +186,11 @@ def main(log_level, pdb=False):
 
         etelemetry.check_available_version("dandi/dandi-cli", __version__, lgr=lgr)
     except Exception as exc:
+        # This magical undocumented env var would allow to overcome some internal
+        # or external issues by merely disclosing its availability to effected users,
+        # while mandating users to update to the most recent version of the client
+        if not bool(os.environ.get("DANDI_ALLOW_OUTDATED", None)):
+            raise
         lgr.warning(
             "Failed to check for a more recent version available with etelemetry: %s",
             exc,


### PR DESCRIPTION
Only if DANDI_ALLOW_OUTDATED env variable is set, it will be just a good old
warning.  I wanted to provision some way to proceed in cases that some other
issue (connectivity, OS, whatnot) prevents people from using dandi cli version
checking

This is a band-aid toward upcoming "dandi-publish" RF until there is a way for a client to interrogate API about supported functionality.