### PR TITLE
Convert regexes with invalid escapes to raw strings

### DIFF
--- a/dandi/cli/cmd_organize.py
+++ b/dandi/cli/cmd_organize.py
@@ -157,7 +157,7 @@ def organize(
         # Our dumps of metadata
         metadata = load_jsonl(paths[0])
     else:
-        paths = list(find_files("\.nwb$", paths=paths))
+        paths = list(find_files(r"\.nwb$", paths=paths))
         lgr.info("Loading metadata from %d files", len(paths))
         # Done here so we could still reuse cached 'get_metadata'
         # without having two types of invocation and to guard against

--- a/dandi/utils.py
+++ b/dandi/utils.py
@@ -319,7 +319,7 @@ def move_file(src, dst):
 def find_dandi_files(paths):
     """Adapter to find_files to find files of interest to dandi project
     """
-    yield from find_files("(dandiset\.yaml|\.nwb)$", paths)
+    yield from find_files(r"(dandiset\.yaml|\.nwb)$", paths)
 
 
 def find_parent_directory_containing(filename, path=None):


### PR DESCRIPTION
`'\.'` is not a valid escape sequence in Python strings, and so it generates a SyntaxError under Python 3.8.3.