### PR TITLE
Make it possible to build package via PEP 517

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+# This line includes versioneer.py in sdists, which is necessary for wheels
+# built from sdists to have the version set in their metadata.
+include versioneer.py

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@
 ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Build helper."""
 
+import os.path
 import sys
 
 from setuptools import setup
@@ -18,6 +19,11 @@ if sys.version_info < (3,):
         "dandi-cli's setup.py requires python 3 or later. "
         "You are using %s" % sys.version
     )
+
+# This is needed for versioneer to be importable when building with PEP 517.
+# See <https://github.com/warner/python-versioneer/issues/193> and links
+# therein for more information.
+sys.path.append(os.path.dirname(__file__))
 
 try:
     import versioneer


### PR DESCRIPTION
This is the simplest possible change to make it possible to build the project with PEP 517 (e.g., using pip or tox).  Without this change, `versioneer.py` is unimportable during the build.  See warner/python-versioneer#193, warner/python-versioneer#192, and pypa/pip#6163 for more information.

This PR also adds `versioneer.py` to `MANIFEST.in` so that it will be present in sdists, which is necessary for wheels built from an sdist to have the correct version set in their metadata.