### PR TITLE
Set up testing with tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ sandbox/
 venv/
 venvs/
 .coverage
+.tox/
+__pycache__/
+*.pyc

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,16 +47,9 @@ install_requires =
     python-dateutil;  python_version < "3.7"
     semantic-version
     tqdm
-tests_require =
-    pytest
-# TODO: figure out. For now alias test
-# test_suite = pytest.collector
 zip_safe = False
 packages = find:
 include_package_data = True
-
-[aliases]
-test=pytest
 
 [options.extras_require]
 # I bet will come handy
@@ -98,6 +91,7 @@ exclude =
     *sphinx*
     dandi/externals/*
     */__init__.py
+    .tox/
 
 [versioneer]
 VCS = git

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,26 @@
+[tox]
+envlist = lint,py3
+
+[testenv]
+extras = test
+commands =
+    # Using pytest-cov leaves a bunch of .coverage.$HOSTNAME.#.# files lying
+    # around for some reason
+    #python -m pytest -s -v --cov=dandi dandi
+    coverage run -m pytest -s -v dandi
+    coverage combine
+    coverage report
+
+[testenv:lint]
+skip_install = true
+deps =
+    flake8
+commands =
+    flake8 --config=setup.cfg {posargs}
+
+[pytest]
+markers = integration
+
+[coverage:run]
+parallel = True
+source = dandi


### PR DESCRIPTION
`setup.py test` and `tests_require` are deprecated [[1]](https://setuptools.readthedocs.io/en/latest/setuptools.html#test-build-package-and-run-a-unittest-suite) [[2]](https://github.com/pypa/setuptools/issues/1684), with `tox` or similar recommended instead.