### PR TITLE
Add a period to the end of the first line in register's docstring

### DIFF
--- a/dandi/cli/cmd_register.py
+++ b/dandi/cli/cmd_register.py
@@ -44,7 +44,7 @@ lgr = get_logger()
 @instance_option()
 @map_to_click_exceptions
 def register(name, description, dandiset_path=None, dandi_instance="dandi"):
-    """Register a new dandiset in the DANDI archive
+    """Register a new dandiset in the DANDI archive.
 
     This command provides only a minimal set of metadata. It is
     recommended to use Web UI to fill out other metadata fields for the


### PR DESCRIPTION
Without this patch, `dandi --help` lists the following description for `register`:

    Register a new dandiset in the DANDI archive This command...