### PR TITLE
Fix warning caused by `load_namespaces=True`

### DIFF
--- a/dandi/tests/test_pynwb_utils.py
+++ b/dandi/tests/test_pynwb_utils.py
@@ -27,7 +27,7 @@ def test_get_metadata(simple1_nwb, simple1_nwb_metadata):
 def test_pynwb_io(simple1_nwb):
     # To verify that our dependencies spec is sufficient to avoid
     # stepping into known pynwb/hdmf issues
-    with pynwb.NWBHDF5IO(str(simple1_nwb), "r", load_namespaces=True) as reader:
+    with pynwb.NWBHDF5IO(str(simple1_nwb), "r") as reader:
         nwbfile = reader.read()
     assert repr(nwbfile)
     assert str(nwbfile)


### PR DESCRIPTION
Without this change, pywnb generates the warning "UserWarning: No cached namespaces found in /private/var/folders/l7/wrkq93d133d8zpn36fmqrq0r0000gn/T/pytest-of-jwodder/pytest-103/data1/simple1.nwb"

Note: I'm not actually sure what the `load_namespaces=True` is trying to accomplish, so it's possible this PR is the wrong way to handle this.