### PR TITLE
Configure pytest to fail on warnings

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,10 @@ commands =
 
 [pytest]
 markers = integration
+filterwarnings =
+    error
+    ignore:No cached namespaces found .*:UserWarning
+    ignore:ignoring namespace '.*' because it already exists:UserWarning
 
 [coverage:run]
 parallel = True


### PR DESCRIPTION
Warnings generated by pynwb due to `load_namespaces=True` are ignored.

This PR includes the changes from #144.