### PR TITLE
List repository URL in project_urls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [build-system]
 # Setuptools version should match setup.py; wheel because pip will insert it noisily
-requires = ["setuptools >= 30.3.0", "wheel"]
+requires = ["setuptools >= 38.3.0", "wheel"]
 build-backend = 'setuptools.build_meta'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,6 @@
 [metadata]
 name = dandi
 url = http://dandiarchive.org
-download_url = https://github.com/dandi/dandi-cli
 author = DANDI developers
 author_email = team@dandiarchive.org
 maintainer = Yaroslav O. Halchenko
@@ -24,6 +23,8 @@ long_description_content_type = text/markdown; charset=UTF-8
 platforms = OS Independent
 provides =
     dandi
+project_urls =
+    Source Code = https://github.com/dandi/dandi-cli
 
 [options]
 python_requires = >=3.6

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ except ImportError:
 # Give setuptools a hint to complain if it's too old a version
 # 30.3.0 allows us to put most metadata in setup.cfg
 # Should match pyproject.toml
-SETUP_REQUIRES = ["setuptools >= 30.3.0"]
+SETUP_REQUIRES = ["setuptools >= 38.3.0"]
 # This enables setuptools to install wheel on-the-fly
 SETUP_REQUIRES += ["wheel"] if "bdist_wheel" in sys.argv else []
 


### PR DESCRIPTION
download_url (which seems to be effectively deprecated anyway) is not the appropriate place to put a repository URL.

This requires setuptools 38.3.0+.