### PR TITLE
Restrict flake8 to dandi directory

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ skip_install = true
 deps =
     flake8
 commands =
-    flake8 --config=setup.cfg {posargs}
+    flake8 --config=setup.cfg {posargs} dandi
 
 [pytest]
 markers = integration

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ skip_install = true
 deps =
     flake8
 commands =
-    flake8 --config=setup.cfg {posargs} dandi
+    flake8 --config=setup.cfg {posargs} dandi setup.py
 
 [pytest]
 markers = integration


### PR DESCRIPTION
This makes flake8 ignore anything outside the `dandi` directory (such as `venv/`) without having to constantly add to flake8's exclusions list.