### PR TITLE
BF: import known_instances directly

### DIFF
--- a/dandi/cli/cmd_upload.py
+++ b/dandi/cli/cmd_upload.py
@@ -21,6 +21,7 @@ from ..consts import (
     collection_drafts,
     dandiset_identifier_regex,
     dandiset_metadata_file,
+    known_instances,
     metadata_digests,
 )
 
@@ -162,7 +163,7 @@ def upload(
 
     ignore_benign_pynwb_warnings()  # so validate doesn't whine
 
-    client = girder.get_client(girder.known_instances[dandi_instance].girder)
+    client = girder.get_client(known_instances[dandi_instance].girder)
 
     try:
         collection_rec = girder.ensure_collection(client, girder_collection)


### PR DESCRIPTION
Before it was used via imported binding within girder module, which
we recently flake8-ed away.  Since no "upload" tests, breakage went unnoticed

Thanks @alejoe91 for living on the bleeding edge and reporting back upon the first cut ;-)