### PR TITLE
Add Dockerized redirector to Docker Compose

### DIFF
--- a/dandi/consts.py
+++ b/dandi/consts.py
@@ -84,10 +84,7 @@ known_instances = {
         "http://localhost:8080", "http://localhost:8085", None
     ),
     "local-docker-tests": dandi_instance(
-        # "http://localhost:8081", "http://localhost:8086", None
-        "http://localhost:8081",
-        None,
-        None,
+        "http://localhost:8081", "http://localhost:8086", "http://localhost:8079"
     ),
     "dandi": dandi_instance(
         "https://girder.dandiarchive.org",

--- a/dandi/tests/data/dandiarchive-docker/docker-compose.yml
+++ b/dandi/tests/data/dandiarchive-docker/docker-compose.yml
@@ -19,18 +19,32 @@ services:
     ports:
       - "8081:8080"
 
-  #client:
-  #  image: dandiarchive/dandiarchive-client
-  #  depends_on:
-  #    - girder
-  #  ports:
-  #    - "8086:80"
+  client:
+    image: dandiarchive/dandiarchive-client
+    depends_on:
+      - girder
+    ports:
+      - "8086:80"
+    #environment:
+    #  VUE_APP_API_ROOT: http://localhost:8081/api/v1
 
   provision:
     image: dandiarchive/dandiarchive-provision
     depends_on:
-      #- client
+      - client
       - girder
+
+  redirector:
+    image: dandiarchive/dandiarchive-redirector
+    depends_on:
+      - client
+      - girder
+    ports:
+      - "8079:8080"
+    environment:
+      GIRDER_URL: http://girder:8080
+      GUI_URL: http://localhost:8086
+      ABOUT_URL: http://dandiarchive.org
 
 volumes:
   dandi_girder_mongo_db:

--- a/dandi/tests/data/dandiarchive-docker/docker-compose.yml
+++ b/dandi/tests/data/dandiarchive-docker/docker-compose.yml
@@ -44,7 +44,7 @@ services:
     environment:
       GIRDER_URL: http://girder:8080
       GUI_URL: http://localhost:8086
-      ABOUT_URL: http://dandiarchive.org
+      ABOUT_URL: http://www.dandiarchive.org
 
 volumes:
   dandi_girder_mongo_db:


### PR DESCRIPTION
Closes #170.

Before this PR can be accepted, dandi/redirector#16 needs to be merged, after which we can set up the redirector image on Docker Hub.

Also note that this PR uncomments the client container so that the redirector will have something to redirect to, even though the client container currently returns only blank pages due to the Girder container using a non-default port.  [I've asked dandi/dandiarchive to address this point, though.](https://github.com/dandi/dandiarchive/issues/468)