### PR TITLE
Add "instance" and "instance_id" keys to local_docker_compose return value

### DIFF
--- a/dandi/tests/fixtures.py
+++ b/dandi/tests/fixtures.py
@@ -139,3 +139,9 @@ def local_docker_compose():
         yield {"api_key": api_key, "instance_id": "local-docker-tests"}
     finally:
         run(["docker-compose", "down", "-v"], cwd=str(LOCAL_DOCKER_DIR), check=True)
+
+
+@pytest.fixture()
+def local_docker_compose_env(local_docker_compose, monkeypatch):
+    monkeypatch.setenv("DANDI_API_KEY", local_docker_compose["api_key"])
+    return local_docker_compose

--- a/dandi/tests/fixtures.py
+++ b/dandi/tests/fixtures.py
@@ -12,6 +12,7 @@ import requests
 
 from .skip import skipif
 from .. import get_logger
+from ..consts import known_instances
 from ..pynwb_utils import make_nwb_file, metadata_nwb_file_fields
 
 
@@ -136,7 +137,11 @@ def local_docker_compose():
         r.raise_for_status()
         api_key = r.json()["key"]
 
-        yield {"api_key": api_key, "instance_id": "local-docker-tests"}
+        yield {
+            "api_key": api_key,
+            "instance_id": "local-docker-tests",
+            "instance": known_instances["local-docker-tests"],
+        }
     finally:
         run(["docker-compose", "down", "-v"], cwd=str(LOCAL_DOCKER_DIR), check=True)
 

--- a/dandi/tests/fixtures.py
+++ b/dandi/tests/fixtures.py
@@ -136,6 +136,6 @@ def local_docker_compose():
         r.raise_for_status()
         api_key = r.json()["key"]
 
-        yield {"api_key": api_key}
+        yield {"api_key": api_key, "instance_id": "local-docker-tests"}
     finally:
         run(["docker-compose", "down", "-v"], cwd=str(LOCAL_DOCKER_DIR), check=True)

--- a/dandi/tests/test_register.py
+++ b/dandi/tests/test_register.py
@@ -13,7 +13,7 @@ def yaml_load(s):
 
 def test_smoke_metadata_present(local_docker_compose, monkeypatch, tmp_path):
     monkeypatch.setenv("DANDI_API_KEY", local_docker_compose["api_key"])
-    dandi_instance = known_instances["local-docker-tests"]
+    dandi_instance = known_instances[local_docker_compose["instance_id"]]
     (tmp_path / dandiset_metadata_file).write_text("{}\n")
     assert (
         register(
@@ -36,7 +36,7 @@ def test_smoke_metadata_present(local_docker_compose, monkeypatch, tmp_path):
 
 def test_smoke_metadata_not_present(local_docker_compose, monkeypatch, tmp_path):
     monkeypatch.setenv("DANDI_API_KEY", local_docker_compose["api_key"])
-    dandi_instance = known_instances["local-docker-tests"]
+    dandi_instance = known_instances[local_docker_compose["instance_id"]]
     assert (
         register(
             dandi_instance,

--- a/dandi/tests/test_register.py
+++ b/dandi/tests/test_register.py
@@ -11,9 +11,8 @@ def yaml_load(s):
     return obj
 
 
-def test_smoke_metadata_present(local_docker_compose, monkeypatch, tmp_path):
-    monkeypatch.setenv("DANDI_API_KEY", local_docker_compose["api_key"])
-    dandi_instance = known_instances[local_docker_compose["instance_id"]]
+def test_smoke_metadata_present(local_docker_compose_env, monkeypatch, tmp_path):
+    dandi_instance = known_instances[local_docker_compose_env["instance_id"]]
     (tmp_path / dandiset_metadata_file).write_text("{}\n")
     assert (
         register(
@@ -34,9 +33,8 @@ def test_smoke_metadata_present(local_docker_compose, monkeypatch, tmp_path):
     # with the given identifier
 
 
-def test_smoke_metadata_not_present(local_docker_compose, monkeypatch, tmp_path):
-    monkeypatch.setenv("DANDI_API_KEY", local_docker_compose["api_key"])
-    dandi_instance = known_instances[local_docker_compose["instance_id"]]
+def test_smoke_metadata_not_present(local_docker_compose_env, monkeypatch, tmp_path):
+    dandi_instance = known_instances[local_docker_compose_env["instance_id"]]
     assert (
         register(
             dandi_instance,

--- a/dandi/tests/test_register.py
+++ b/dandi/tests/test_register.py
@@ -2,7 +2,7 @@ import re
 
 import yaml
 
-from ..consts import dandiset_identifier_regex, known_instances, dandiset_metadata_file
+from ..consts import dandiset_identifier_regex, dandiset_metadata_file
 from ..register import register
 
 

--- a/dandi/tests/test_register.py
+++ b/dandi/tests/test_register.py
@@ -12,7 +12,7 @@ def yaml_load(s):
 
 
 def test_smoke_metadata_present(local_docker_compose_env, monkeypatch, tmp_path):
-    dandi_instance = known_instances[local_docker_compose_env["instance_id"]]
+    dandi_instance = local_docker_compose_env["instance"]
     (tmp_path / dandiset_metadata_file).write_text("{}\n")
     assert (
         register(
@@ -34,7 +34,7 @@ def test_smoke_metadata_present(local_docker_compose_env, monkeypatch, tmp_path)
 
 
 def test_smoke_metadata_not_present(local_docker_compose_env, monkeypatch, tmp_path):
-    dandi_instance = known_instances[local_docker_compose_env["instance_id"]]
+    dandi_instance = local_docker_compose_env["instance"]
     assert (
         register(
             dandi_instance,

--- a/dandi/tests/test_upload.py
+++ b/dandi/tests/test_upload.py
@@ -12,14 +12,13 @@ from ..upload import upload
 DANDIFILES_DIR = Path(__file__).with_name("data") / "dandifiles"
 
 
-def test_upload(local_docker_compose, monkeypatch, tmp_path):
+def test_upload(local_docker_compose_env, monkeypatch, tmp_path):
     DIRNAME1 = "sub-anm369963"
     FILENAME1 = "sub-anm369963_ses-20170228.nwb"
     DIRNAME2 = "sub-anm372793"
     FILENAME2 = "sub-anm372793_ses-20170508.nwb"
 
-    monkeypatch.setenv("DANDI_API_KEY", local_docker_compose["api_key"])
-    dandi_instance = local_docker_compose["instance_id"]
+    dandi_instance = local_docker_compose_env["instance_id"]
 
     for dirname, filename in [(DIRNAME1, FILENAME1), (DIRNAME2, FILENAME2)]:
         (tmp_path / dirname).mkdir(exist_ok=True, parents=True)
@@ -48,11 +47,10 @@ def test_upload(local_docker_compose, monkeypatch, tmp_path):
         girder.lookup(client, collection_drafts, path=f"{dandi_id}/{DIRNAME2}")
 
 
-def test_upload_existing_error(local_docker_compose, monkeypatch, tmp_path):
+def test_upload_existing_error(local_docker_compose_env, monkeypatch, tmp_path):
     DIRNAME = "sub-anm369963"
     FILENAME = "sub-anm369963_ses-20170228.nwb"
-    monkeypatch.setenv("DANDI_API_KEY", local_docker_compose["api_key"])
-    dandi_instance = local_docker_compose["instance_id"]
+    dandi_instance = local_docker_compose_env["instance_id"]
     (tmp_path / DIRNAME).mkdir(exist_ok=True, parents=True)
     copyfile(DANDIFILES_DIR / DIRNAME / FILENAME, tmp_path / DIRNAME / FILENAME)
     register(

--- a/dandi/tests/test_upload.py
+++ b/dandi/tests/test_upload.py
@@ -5,7 +5,7 @@ import pytest
 import yaml
 
 from .. import girder
-from ..consts import collection_drafts, dandiset_metadata_file, known_instances
+from ..consts import collection_drafts, dandiset_metadata_file
 from ..register import register
 from ..upload import upload
 
@@ -25,7 +25,7 @@ def test_upload(local_docker_compose_env, monkeypatch, tmp_path):
         copyfile(DANDIFILES_DIR / dirname / filename, tmp_path / dirname / filename)
 
     register(
-        known_instances[dandi_instance_id],
+        local_docker_compose_env["instance"],
         "Upload Test",
         "Upload Test Description",
         dandiset_path=tmp_path,
@@ -34,7 +34,7 @@ def test_upload(local_docker_compose_env, monkeypatch, tmp_path):
         metadata = yaml.safe_load(fp)
     dandi_id = metadata["identifier"]
 
-    client = girder.get_client(known_instances[dandi_instance_id].girder)
+    client = girder.get_client(local_docker_compose_env["instance"].girder)
     for dirname in [DIRNAME1, DIRNAME2]:
         with pytest.raises(girder.GirderNotFound):
             girder.lookup(client, collection_drafts, path=f"{dandi_id}/{dirname}")
@@ -54,7 +54,7 @@ def test_upload_existing_error(local_docker_compose_env, monkeypatch, tmp_path):
     (tmp_path / DIRNAME).mkdir(exist_ok=True, parents=True)
     copyfile(DANDIFILES_DIR / DIRNAME / FILENAME, tmp_path / DIRNAME / FILENAME)
     register(
-        known_instances[dandi_instance_id],
+        local_docker_compose_env["instance"],
         "Upload Test",
         "Upload Test Description",
         dandiset_path=tmp_path,

--- a/dandi/tests/test_upload.py
+++ b/dandi/tests/test_upload.py
@@ -18,14 +18,14 @@ def test_upload(local_docker_compose_env, monkeypatch, tmp_path):
     DIRNAME2 = "sub-anm372793"
     FILENAME2 = "sub-anm372793_ses-20170508.nwb"
 
-    dandi_instance = local_docker_compose_env["instance_id"]
+    dandi_instance_id = local_docker_compose_env["instance_id"]
 
     for dirname, filename in [(DIRNAME1, FILENAME1), (DIRNAME2, FILENAME2)]:
         (tmp_path / dirname).mkdir(exist_ok=True, parents=True)
         copyfile(DANDIFILES_DIR / dirname / filename, tmp_path / dirname / filename)
 
     register(
-        known_instances[dandi_instance],
+        known_instances[dandi_instance_id],
         "Upload Test",
         "Upload Test Description",
         dandiset_path=tmp_path,
@@ -34,13 +34,13 @@ def test_upload(local_docker_compose_env, monkeypatch, tmp_path):
         metadata = yaml.safe_load(fp)
     dandi_id = metadata["identifier"]
 
-    client = girder.get_client(known_instances[dandi_instance].girder)
+    client = girder.get_client(known_instances[dandi_instance_id].girder)
     for dirname in [DIRNAME1, DIRNAME2]:
         with pytest.raises(girder.GirderNotFound):
             girder.lookup(client, collection_drafts, path=f"{dandi_id}/{dirname}")
 
     monkeypatch.chdir(tmp_path)
-    upload(paths=[DIRNAME1], dandi_instance=dandi_instance, devel_debug=True)
+    upload(paths=[DIRNAME1], dandi_instance=dandi_instance_id, devel_debug=True)
 
     girder.lookup(client, collection_drafts, path=f"{dandi_id}/{DIRNAME1}/{FILENAME1}")
     with pytest.raises(girder.GirderNotFound):
@@ -50,11 +50,11 @@ def test_upload(local_docker_compose_env, monkeypatch, tmp_path):
 def test_upload_existing_error(local_docker_compose_env, monkeypatch, tmp_path):
     DIRNAME = "sub-anm369963"
     FILENAME = "sub-anm369963_ses-20170228.nwb"
-    dandi_instance = local_docker_compose_env["instance_id"]
+    dandi_instance_id = local_docker_compose_env["instance_id"]
     (tmp_path / DIRNAME).mkdir(exist_ok=True, parents=True)
     copyfile(DANDIFILES_DIR / DIRNAME / FILENAME, tmp_path / DIRNAME / FILENAME)
     register(
-        known_instances[dandi_instance],
+        known_instances[dandi_instance_id],
         "Upload Test",
         "Upload Test Description",
         dandiset_path=tmp_path,
@@ -62,14 +62,14 @@ def test_upload_existing_error(local_docker_compose_env, monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
     upload(
         paths=[DIRNAME],
-        dandi_instance=dandi_instance,
+        dandi_instance=dandi_instance_id,
         devel_debug=True,
         existing="error",
     )
     with pytest.raises(FileExistsError):
         upload(
             paths=[DIRNAME],
-            dandi_instance=dandi_instance,
+            dandi_instance=dandi_instance_id,
             devel_debug=True,
             existing="error",
         )

--- a/dandi/tests/test_upload.py
+++ b/dandi/tests/test_upload.py
@@ -19,7 +19,7 @@ def test_upload(local_docker_compose, monkeypatch, tmp_path):
     FILENAME2 = "sub-anm372793_ses-20170508.nwb"
 
     monkeypatch.setenv("DANDI_API_KEY", local_docker_compose["api_key"])
-    dandi_instance = "local-docker-tests"
+    dandi_instance = local_docker_compose["instance_id"]
 
     for dirname, filename in [(DIRNAME1, FILENAME1), (DIRNAME2, FILENAME2)]:
         (tmp_path / dirname).mkdir(exist_ok=True, parents=True)
@@ -52,7 +52,7 @@ def test_upload_existing_error(local_docker_compose, monkeypatch, tmp_path):
     DIRNAME = "sub-anm369963"
     FILENAME = "sub-anm369963_ses-20170228.nwb"
     monkeypatch.setenv("DANDI_API_KEY", local_docker_compose["api_key"])
-    dandi_instance = "local-docker-tests"
+    dandi_instance = local_docker_compose["instance_id"]
     (tmp_path / DIRNAME).mkdir(exist_ok=True, parents=True)
     copyfile(DANDIFILES_DIR / DIRNAME / FILENAME, tmp_path / DIRNAME / FILENAME)
     register(


### PR DESCRIPTION
Also define a `local_docker_compose_env` fixture that sets `DANDI_API_KEY`.

Closes #172.