### PR TITLE
BF(workaround): do not fail test workflow if codecov fails

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,4 +46,4 @@ jobs:
         flags: unittests
         # name: codecov-umbrella
         # yml: ./codecov.yml
-        fail_ci_if_error: true
+        fail_ci_if_error: false


### PR DESCRIPTION
Failures to upload to codecov come and go.  AFAIK there is no way to
retry and thus we will just allow to skip if codecov "errors"