### PR TITLE
BF+ENH: workaround tqdm exception, test girder retries loop, ensure sleep of at least 1 sec

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
           - ubuntu-18.04
           - macos-latest
         python:
-          - 3.6
+          - 3.6  # will also be used to test with _DANDI_LOG_GIRDER set
           - 3.7
           - 3.8
 
@@ -35,6 +35,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install ".[test]"
+    - name: Set environment variable when using Python 3.6 to cover more code
+      run: echo "::set-env name=DANDI_LOG_GIRDER::1"
+      if: matrix.python == '3.6'
     - name: ${{ matrix.module }} tests
       run: |
         python -m pytest -s -v --cov=dandi --cov-report=xml dandi

--- a/dandi/girder.py
+++ b/dandi/girder.py
@@ -414,7 +414,7 @@ class GirderCli(gcl.GirderClient):
                     "Failed to download on attempt#%d, will sleep a bit and retry",
                     attempt,
                 )
-                time.sleep(random.random() * 5)
+                time.sleep((1 + random.random()) * 5)
         # It seems that above call does not care about setting either mtime
         if attrs:
             mtime = self._get_file_mtime(attrs)

--- a/dandi/girder.py
+++ b/dandi/girder.py
@@ -523,19 +523,30 @@ class TQDMProgressReporter(object):
     def __init__(self, label="", length=0):
         import tqdm
 
-        self._pbar = tqdm.tqdm(desc=label, total=length, unit="B", unit_scale=True)
         self.label = label
         self.length = length
+
+        self._pbar = None
+        try:
+            self._pbar = tqdm.tqdm(desc=label, total=length, unit="B", unit_scale=True)
+        except AssertionError as exc:
+            lgr.warning(
+                "No progress indication for %s. Failed to initiate tqdm progress bar: %s",
+                label,
+                exc,
+            )
 
     def update(self, chunkSize):
         if _DANDI_LOG_GIRDER:
             lgr.debug("PROGRESS[%s]: +%d", id(self), chunkSize)
-        self._pbar.update(chunkSize)
+        if self._pbar:
+            self._pbar.update(chunkSize)
 
     def __enter__(self):
         return self
 
     def __exit__(self, exc_type, exc_value, tb):
-        self._pbar.clear()  # remove from screen -- not in effect ATM TODO
-        self._pbar.close()
-        del self._pbar
+        if self._pbar:
+            self._pbar.clear()  # remove from screen -- not in effect ATM TODO
+            self._pbar.close()
+            del self._pbar

--- a/dandi/tests/test_download.py
+++ b/dandi/tests/test_download.py
@@ -1,6 +1,10 @@
+import time
+
 from ..download import download, follow_redirect, parse_dandi_url
 from ..exceptions import NotFoundError
 from ..tests.skip import mark
+
+from ..girder import GirderCli, gcl
 
 import pytest
 
@@ -65,22 +69,44 @@ def test_parse_dandi_url_redirect():
 
 
 @mark.skipif_no_network
-def test_download_multiple_files(tmpdir):
+def test_download_multiple_files(monkeypatch, tmpdir):
     url = (
         "https://gui.dandiarchive.org/#/folder/5e70d3173da50caa9adaf334/selected/"
         "item+5e70d3173da50caa9adaf335/item+5e70d3183da50caa9adaf336"
     )
 
-    # TEMP: to workaround https://github.com/tqdm/tqdm/issues/982 upstream
-    # at least during testing. Our issue: https://github.com/dandi/dandi-cli/issues/111
-    # The plan - to stop using tqdm (by default at least) as part of #134 RF
-    try:
-        ret = download(url, tmpdir)
-    except AssertionError as exc:
-        if "attempt to release recursive lock" in str(exc):
-            pytest.skip("tqdm issue")
-        raise
+    # While at it we will also test girder downloadFile to retry at least 3 times
+    # in case of some errors, and that it sleeps between retries
+
+    orig_downloadFile = GirderCli.downloadFile
+
+    class Mocks:
+        ntries = 0
+        sleeps = 0
+
+        @staticmethod
+        def downloadFile(self, *args, **kwargs):
+            Mocks.ntries += 1
+            if Mocks.ntries < 3:
+                raise gcl.HttpError(
+                    text="Failing to download", url=url, method="GET", status=500
+                )
+            return orig_downloadFile(self, *args, **kwargs)
+
+        @staticmethod
+        def sleep(duration):
+            Mocks.sleeps += duration
+            # no actual sleeping
+
+    monkeypatch.setattr(GirderCli, "downloadFile", Mocks.downloadFile)
+    monkeypatch.setattr(time, "sleep", Mocks.sleep)  # to not sleep in the test
+
+    ret = download(url, tmpdir)
     assert not ret  # we return nothing ATM, might want to "generate"
+
+    assert Mocks.ntries == 3 + 1  # 3 on the first since 2 fail + 1 on 2nd file
+    assert Mocks.sleeps >= 2  # slept at least 1 sec each time
+
     downloads = (x.basename for x in tmpdir.listdir())
     assert sorted(downloads) == [
         "sub-anm372795_ses-20170714.nwb",

--- a/dandi/tests/test_download.py
+++ b/dandi/tests/test_download.py
@@ -1,10 +1,11 @@
 import time
+import tqdm
 
 from ..download import download, follow_redirect, parse_dandi_url
 from ..exceptions import NotFoundError
 from ..tests.skip import mark
 
-from ..girder import GirderCli, gcl
+from ..girder import GirderCli, gcl, TQDMProgressReporter
 
 import pytest
 
@@ -113,3 +114,14 @@ def test_download_multiple_files(monkeypatch, tmpdir):
         "sub-anm372795_ses-20170715.nwb",
     ]
     assert all(x.lstat().size > 1e5 for x in tmpdir.listdir())  # all bigish files
+
+
+def test_girder_tqdm(monkeypatch):
+    # smoke test to ensure we do not blow up
+    def raise_assertion_error(*args, **kwargs):
+        assert False, "pretend locking failed"
+
+    monkeypatch.setattr(tqdm, "tqdm", raise_assertion_error)
+
+    with TQDMProgressReporter() as pr:
+        pr.update(10)


### PR DESCRIPTION
This should also stabilize coverage reporting since tested code paths shouldn't vary

While at it
- added smoke testing of logging when `_DANDI_LOG_GIRDER` is set to a single run in the matrix
- added a test that our tqdm progress reporter does not blow when tqdm blows with assertion error