### PR TITLE
Eliminate pyyaml dependency

### DIFF
--- a/dandi/cli/formatter.py
+++ b/dandi/cli/formatter.py
@@ -45,9 +45,10 @@ class YAMLFormatter(Formatter):
         self.records = []
 
     def __exit__(self, exc_type, exc_value, traceback):
-        import yaml
+        import ruamel.yaml
 
-        self.out.write(yaml.dump(self.records))
+        yaml = ruamel.yaml.YAML()
+        yaml.dump(self.records, self.out)
 
     def __call__(self, rec):
         self.records.append(rec)

--- a/dandi/cli/tests/test_ls.py
+++ b/dandi/cli/tests/test_ls.py
@@ -17,10 +17,11 @@ def test_smoke(simple1_nwb_metadata, simple1_nwb, format):
 
         load = json.loads
     elif format == "yaml":
-        import yaml
+        import ruamel.yaml
 
         def load(s):
-            obj = yaml.load(s, Loader=yaml.BaseLoader)
+            yaml = ruamel.yaml.YAML(typ="base")
+            obj = yaml.load(s)
             assert len(obj) == 1  # will be a list with a single elem
             return obj[0]
 

--- a/dandi/cli/tests/test_ls.py
+++ b/dandi/cli/tests/test_ls.py
@@ -2,6 +2,7 @@ from click.testing import CliRunner
 import pytest
 
 from ..command import ls
+from ...utils import yaml_load
 
 
 @pytest.mark.parametrize("format", ("auto", "json", "json_pp", "yaml", "pyout"))
@@ -17,11 +18,9 @@ def test_smoke(simple1_nwb_metadata, simple1_nwb, format):
 
         load = json.loads
     elif format == "yaml":
-        import ruamel.yaml
 
         def load(s):
-            yaml = ruamel.yaml.YAML(typ="base")
-            obj = yaml.load(s)
+            obj = yaml_load(s, typ="base")
             assert len(obj) == 1  # will be a list with a single elem
             return obj[0]
 

--- a/dandi/dandiset.py
+++ b/dandi/dandiset.py
@@ -1,7 +1,7 @@
 """Classes/utilities for support of a dandiset"""
 
 import os
-import yaml
+import ruamel.yaml
 from pathlib import Path
 
 from .consts import dandiset_metadata_file
@@ -42,7 +42,7 @@ class Dandiset(object):
             with open(self._metadata_file_obj) as f:
                 # TODO it would cast 000001 if not explicitly string into
                 # an int -- we should prevent it... probably with some custom loader
-                self.metadata = yaml.safe_load(f)
+                self.metadata = ruamel.yaml.YAML(typ="safe").load(f)
         else:
             self.metadata = None
 
@@ -70,15 +70,9 @@ class Dandiset(object):
             lgr.debug("No updates to metadata, returning")
             return
 
-        # We will use ruaml to load/save it
-        # Seems to be too tricky to add new entries, etc so we will
-        # just resort to explicitly adding the header while saving
-        # import ruamel.yaml
-        # yaml = ruamel.yaml.YAML()  # defaults to round-trip if no parameters
-        # given
         if self._metadata_file_obj.exists():
             with open(self._metadata_file_obj) as f:
-                rec = yaml.safe_load(f)
+                rec = ruamel.yaml.YAML(typ="safe").load(f)
         else:
             rec = {}
 

--- a/dandi/dandiset.py
+++ b/dandi/dandiset.py
@@ -1,11 +1,10 @@
 """Classes/utilities for support of a dandiset"""
 
 import os
-import ruamel.yaml
 from pathlib import Path
 
 from .consts import dandiset_metadata_file
-from .utils import find_parent_directory_containing, yaml_dump
+from .utils import find_parent_directory_containing, yaml_dump, yaml_load
 
 from . import get_logger
 
@@ -42,7 +41,7 @@ class Dandiset(object):
             with open(self._metadata_file_obj) as f:
                 # TODO it would cast 000001 if not explicitly string into
                 # an int -- we should prevent it... probably with some custom loader
-                self.metadata = ruamel.yaml.YAML(typ="safe").load(f)
+                self.metadata = yaml_load(f, typ="safe")
         else:
             self.metadata = None
 
@@ -72,7 +71,7 @@ class Dandiset(object):
 
         if self._metadata_file_obj.exists():
             with open(self._metadata_file_obj) as f:
-                rec = ruamel.yaml.YAML(typ="safe").load(f)
+                rec = yaml_load(f, typ="safe")
         else:
             rec = {}
 

--- a/dandi/organize.py
+++ b/dandi/organize.py
@@ -13,7 +13,7 @@ import os.path as op
 from .exceptions import OrganizeImpossibleError
 from . import get_logger
 from .pynwb_utils import get_neurodata_types_to_modalities_map, get_object_id
-from .utils import ensure_datetime, flattened
+from .utils import ensure_datetime, flattened, yaml_load
 
 lgr = get_logger()
 
@@ -467,7 +467,7 @@ def populate_dataset_yml(filepath, metadata):
             pass
 
     with open(filepath) as f:
-        rec = yaml.load(f)
+        rec = yaml_load(f)
 
     if not rec:
         rec = {}

--- a/dandi/tests/test_organize.py
+++ b/dandi/tests/test_organize.py
@@ -13,12 +13,9 @@ from ..organize import (
     get_obj_id,
     populate_dataset_yml,
 )
-from ..utils import find_files, on_windows
+from ..utils import find_files, on_windows, yaml_load
 from ..pynwb_utils import copy_nwb_file, get_object_id
 import pytest
-
-
-yaml_ruamel = ruamel.yaml.YAML()  # defaults to round-trip if no parameters given
 
 
 def test_sanitize_value():
@@ -33,7 +30,7 @@ def test_populate_dataset_yml(tmpdir):
 
     def c():  # shortcut
         with open(path) as f:
-            return ruamel.yaml.YAML(typ="safe").load(f)
+            return yaml_load(f, typ="safe")
 
     path.write("")
     populate_dataset_yml(str(path), [])  # doesn't crash
@@ -50,7 +47,7 @@ def test_populate_dataset_yml(tmpdir):
         {"age": 2, "cell_id": "2", "tissue_sample_id": 1, "sex": "F"},
     ]
 
-    # even though we use ruyaml for manipulation, we should assure it is readable
+    # even though we use ruamel for manipulation, we should assure it is readable
     # by regular yaml
     populate_dataset_yml(str(path), metadata)
     assert c() == {
@@ -62,9 +59,9 @@ def test_populate_dataset_yml(tmpdir):
     }
 
     # and if we set units and redo -- years should stay unchanged, while other fields change
-    m = yaml_ruamel.load(path.read())
+    m = yaml_load(path.read())
     m["age"]["units"] = "years"
-    yaml_ruamel.dump(m, open(path, "w"))
+    ruamel.yaml.YAML().dump(m, open(path, "w"))
 
     populate_dataset_yml(str(path), metadata[:1])
     assert c() == {

--- a/dandi/tests/test_organize.py
+++ b/dandi/tests/test_organize.py
@@ -2,7 +2,6 @@ import os
 from glob import glob
 import os.path as op
 import ruamel.yaml
-import yaml
 
 from ..consts import file_operation_modes
 
@@ -34,7 +33,7 @@ def test_populate_dataset_yml(tmpdir):
 
     def c():  # shortcut
         with open(path) as f:
-            return yaml.safe_load(f)
+            return ruamel.yaml.YAML(typ="safe").load(f)
 
     path.write("")
     populate_dataset_yml(str(path), [])  # doesn't crash

--- a/dandi/tests/test_register.py
+++ b/dandi/tests/test_register.py
@@ -1,13 +1,8 @@
 import re
 
-import ruamel.yaml
-
 from ..consts import dandiset_identifier_regex, dandiset_metadata_file
 from ..register import register
-
-
-def yaml_load(s):
-    return ruamel.yaml.YAML(typ="base").load(s)
+from ..utils import yaml_load
 
 
 def test_smoke_metadata_present(local_docker_compose_env, monkeypatch, tmp_path):
@@ -22,7 +17,7 @@ def test_smoke_metadata_present(local_docker_compose_env, monkeypatch, tmp_path)
         is None
     )
     with (tmp_path / dandiset_metadata_file).open() as fp:
-        metadata = yaml_load(fp.read())
+        metadata = yaml_load(fp, typ="base")
     assert metadata
     assert metadata["name"] == "Dandiset Name"
     assert metadata["description"] == "Dandiset Description"
@@ -42,7 +37,7 @@ def test_smoke_metadata_not_present(local_docker_compose_env, monkeypatch, tmp_p
         is None
     )
     with (tmp_path / dandiset_metadata_file).open() as fp:
-        metadata = yaml_load(fp.read())
+        metadata = yaml_load(fp, typ="base")
     assert metadata
     assert metadata["name"] == "Dandiset Name"
     assert metadata["description"] == "Dandiset Description"

--- a/dandi/tests/test_register.py
+++ b/dandi/tests/test_register.py
@@ -1,14 +1,13 @@
 import re
 
-import yaml
+import ruamel.yaml
 
 from ..consts import dandiset_identifier_regex, dandiset_metadata_file
 from ..register import register
 
 
 def yaml_load(s):
-    obj = yaml.load(s, Loader=yaml.BaseLoader)
-    return obj
+    return ruamel.yaml.YAML(typ="base").load(s)
 
 
 def test_smoke_metadata_present(local_docker_compose_env, monkeypatch, tmp_path):

--- a/dandi/tests/test_upload.py
+++ b/dandi/tests/test_upload.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from shutil import copyfile
 
 import pytest
-import yaml
+import ruamel.yaml
 
 from .. import girder
 from ..consts import collection_drafts, dandiset_metadata_file
@@ -31,7 +31,7 @@ def test_upload(local_docker_compose_env, monkeypatch, tmp_path):
         dandi_instance=dandi_instance_id,
     )
     with (tmp_path / dandiset_metadata_file).open() as fp:
-        metadata = yaml.safe_load(fp)
+        metadata = ruamel.yaml.YAML(typ="safe").load(fp)
     dandi_id = metadata["identifier"]
 
     client = girder.get_client(local_docker_compose_env["instance"].girder)

--- a/dandi/tests/test_upload.py
+++ b/dandi/tests/test_upload.py
@@ -2,12 +2,12 @@ from pathlib import Path
 from shutil import copyfile
 
 import pytest
-import ruamel.yaml
 
 from .. import girder
 from ..consts import collection_drafts, dandiset_metadata_file
 from ..register import register
 from ..upload import upload
+from ..utils import yaml_load
 
 DANDIFILES_DIR = Path(__file__).with_name("data") / "dandifiles"
 
@@ -31,7 +31,7 @@ def test_upload(local_docker_compose_env, monkeypatch, tmp_path):
         dandi_instance=dandi_instance_id,
     )
     with (tmp_path / dandiset_metadata_file).open() as fp:
-        metadata = ruamel.yaml.YAML(typ="safe").load(fp)
+        metadata = yaml_load(fp, typ="safe")
     dandi_id = metadata["identifier"]
 
     client = girder.get_client(local_docker_compose_env["instance"].girder)

--- a/dandi/utils.py
+++ b/dandi/utils.py
@@ -1,5 +1,6 @@
 import datetime
 import inspect
+import io
 import itertools
 import os
 import os.path as op
@@ -347,9 +348,13 @@ def yaml_dump(rec):
     to assure proper formatting on versions of pyyaml before
     5.1: https://github.com/yaml/pyyaml/pull/256
     """
-    import yaml
+    import ruamel.yaml
 
-    return yaml.safe_dump(rec, default_flow_style=False)
+    yaml = ruamel.yaml.YAML(typ="safe")
+    yaml.default_flow_style = False
+    out = io.StringIO()
+    yaml.dump(rec, out)
+    return out.getvalue()
 
 
 #

--- a/dandi/utils.py
+++ b/dandi/utils.py
@@ -11,6 +11,8 @@ import sys
 
 from pathlib import Path
 
+import ruamel.yaml
+
 if sys.version_info[:2] < (3, 7):
     import dateutil.parser
 
@@ -348,13 +350,17 @@ def yaml_dump(rec):
     to assure proper formatting on versions of pyyaml before
     5.1: https://github.com/yaml/pyyaml/pull/256
     """
-    import ruamel.yaml
-
     yaml = ruamel.yaml.YAML(typ="safe")
     yaml.default_flow_style = False
     out = io.StringIO()
     yaml.dump(rec, out)
     return out.getvalue()
+
+
+def yaml_load(f, typ=None):
+    # `f` can be either a string or a file-like object.
+    # `typ` defaults to "rt" (round-trip)
+    return ruamel.yaml.YAML(typ=typ).load(f)
 
 
 #

--- a/dandi/utils.py
+++ b/dandi/utils.py
@@ -358,8 +358,22 @@ def yaml_dump(rec):
 
 
 def yaml_load(f, typ=None):
-    # `f` can be either a string or a file-like object.
-    # `typ` defaults to "rt" (round-trip)
+    """
+    Load YAML source from a file or string.
+
+    Parameters
+    ----------
+    f: str or IO[str]
+      The YAML source to load
+    typ: str, optional
+      The value of `typ` to pass to `ruamel.yaml.YAML`.  May be "rt" (default),
+      "safe", "unsafe", or "base"
+
+    Returns
+    -------
+    Any
+      The parsed YAML value
+    """
     return ruamel.yaml.YAML(typ=typ).load(f)
 
 

--- a/dandi/validate.py
+++ b/dandi/validate.py
@@ -1,9 +1,8 @@
 import os.path as op
 from .consts import dandiset_metadata_file
-import ruamel.yaml
 
 from .pynwb_utils import validate as pynwb_validate, validate_cache
-from .utils import find_dandi_files
+from .utils import find_dandi_files, yaml_load
 from .metadata import get_metadata
 
 
@@ -42,7 +41,7 @@ def validate_file(filepath):
 def validate_dandiset_yaml(filepath):
     """Validate dandiset.yaml"""
     with open(filepath) as f:
-        meta = ruamel.yaml.YAML(typ="safe").load(f)
+        meta = yaml_load(f, typ="safe")
     return _check_required_fields(meta, _required_dandiset_metadata_fields)
 
 

--- a/dandi/validate.py
+++ b/dandi/validate.py
@@ -1,6 +1,6 @@
 import os.path as op
 from .consts import dandiset_metadata_file
-import yaml
+import ruamel.yaml
 
 from .pynwb_utils import validate as pynwb_validate, validate_cache
 from .utils import find_dandi_files
@@ -42,7 +42,7 @@ def validate_file(filepath):
 def validate_dandiset_yaml(filepath):
     """Validate dandiset.yaml"""
     with open(filepath) as f:
-        meta = yaml.safe_load(f)
+        meta = ruamel.yaml.YAML(typ="safe").load(f)
     return _check_required_fields(meta, _required_dandiset_metadata_fields)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,8 +42,7 @@ install_requires =
     joblib
     pyout
     humanize
-    pyyaml
-    ruamel.yaml
+    ruamel.yaml >=0.15, <1
     keyring
     keyrings.alt
     python-dateutil;  python_version < "3.7"


### PR DESCRIPTION
There's no reason to use two YAML libraries, so this PR gets rid of the one that doesn't support round-tripping comments.

**Note**: dandi-cli currently uses the API introduced in ruamel.yaml 0.15.0 (featuring `ruamel.yaml.YAML()` and its `load()` and `dump()` methods, as opposed to using the `load()` and `dump()` functions directly in `ruamel.yaml`), and this PR does that as well.  However, [the ruamel.yaml docs](https://yaml.readthedocs.io/en/latest/basicuse.html) state that the new API is "still in the process of being fleshed out" and recommend that production software use pre-0.15 versions of the library.  Should we follow that advice?