### PR TITLE
Add {posargs} to pytest command in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,9 @@ envlist = lint,py3
 [testenv]
 extras = test
 commands =
-    # Using pytest-cov leaves a bunch of .coverage.$HOSTNAME.#.# files lying
-    # around for some reason
-    #python -m pytest -s -v --cov=dandi dandi
-    coverage run -m pytest -v dandi
+    # Using pytest-cov instead of using coverage directly leaves a bunch of
+    # .coverage.$HOSTNAME.#.# files lying around for some reason
+    coverage run -m pytest -v {posargs} dandi
     coverage combine
     coverage report
 


### PR DESCRIPTION
So that I can pass arguments to pytest from the tox command line.