### PR TITLE
Fix some find_files() regexen

### DIFF
--- a/dandi/cli/cmd_ls.py
+++ b/dandi/cli/cmd_ls.py
@@ -68,7 +68,7 @@ def ls(paths, fields=None, format="auto", recursive=False):
 
     # For now we support only individual files
     if recursive:
-        files = list(find_files(".nwb$", paths))
+        files = list(find_files(r"\.nwb\Z", paths))
     else:
         files = paths
 

--- a/dandi/cli/cmd_organize.py
+++ b/dandi/cli/cmd_organize.py
@@ -151,7 +151,7 @@ def organize(
         # Our dumps of metadata
         metadata = load_jsonl(paths[0])
     else:
-        paths = list(find_files(r"\.nwb$", paths=paths))
+        paths = list(find_files(r"\.nwb\Z", paths=paths))
         lgr.info("Loading metadata from %d files", len(paths))
         # Done here so we could still reuse cached 'get_metadata'
         # without having two types of invocation and to guard against

--- a/dandi/tests/test_organize.py
+++ b/dandi/tests/test_organize.py
@@ -131,7 +131,7 @@ def test_organize_nwb_test_data(nwb_test_data, tmpdir, clirunner, mode):
     # this beast doesn't capture our logs ATM so cannot check anything there.
     # At the end we endup only with dandiset.yaml and a single file
     produced_paths = sorted(find_files(".*", paths=outdir))
-    produced_nwb_paths = sorted(find_files(".nwb$", paths=outdir))
+    produced_nwb_paths = sorted(find_files(r"\.nwb\Z", paths=outdir))
     produced_relpaths = [op.relpath(p, outdir) for p in produced_paths]
     if mode == "dry":
         assert produced_relpaths == []

--- a/dandi/utils.py
+++ b/dandi/utils.py
@@ -360,7 +360,8 @@ def move_file(src, dst):
 def find_dandi_files(paths):
     """Adapter to find_files to find files of interest to dandi project
     """
-    yield from find_files(r"(dandiset\.yaml|\.nwb)$", paths)
+    sep = re.escape(os.sep)
+    yield from find_files(rf"((^|{sep})dandiset\.yaml|\.nwb)\Z", paths)
 
 
 def find_parent_directory_containing(filename, path=None):


### PR DESCRIPTION
Without this change, find_dandi_files() would match files whose names ended with "dandiset.yaml" (e.g., "foodandiset.yaml").  I don't think that's intended.

Using `$` instead of `\Z` causes a regex to also accept strings that end with a newline.  That's not desirable here.