### PR TITLE
Don't test coverage of runtime-sensitive code

### DIFF
--- a/dandi/support/tests/test_cache.py
+++ b/dandi/support/tests/test_cache.py
@@ -118,7 +118,7 @@ def test_memoize_path(cache, tmp_path):
         # cache._min_dtime between our creating the file and testing,
         # so we would force a direct read:
         check_new_memoread(0, "content", True)
-    except AssertionError:
+    except AssertionError:  # pragma: no cover
         # if computer is indeed slow (happens on shared CIs) we might fail
         # because distance is too short
         if time.time() - t0 < cache._min_dtime:


### PR DESCRIPTION
If I'm reading the report right, this was the only bit of code that lost coverage from #217.

Closes #218.