### PR TITLE
90% of way to enable testing from windows VM over to an instance running on the host

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -55,6 +55,9 @@ development command line options.
   If handling of metadata has changed while developing, set this env var to
   `clear` to have cache `clear()`ed before use.
 
+- `DANDI_INSTANCEHOST` -- defaults to `localhost`. Point to host/IP which hosts
+  a local instance of dandiarchive.
+
 ## Sourcegraph
 
 The [Sourcegraph](https://sourcegraph.com) browser extension can be used to

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -56,11 +56,14 @@ development command line options.
   `clear` to have cache `clear()`ed before use.
 
 - `DANDI_INSTANCEHOST` -- defaults to `localhost`. Point to host/IP which hosts
-  a local instance of dandiarchive.
+  a local instance of dandiarchive. Typically,
+  `DANDI_REUSE_LOCAL_DOCKER_TESTS_API_KEY`
+  should also be set.
 
-- `DANDI_REUSE_LOCAL_DOCKER_TESTS_API_KEY` -- use to make `local_docker_compose*`
-  fixtures work by contacting an instance (possibly at `DANDI_INSTANCEHOST`)
-  instead of starting a new one.
+- `DANDI_REUSE_LOCAL_DOCKER_TESTS_API_KEY` -- make the
+ `local_docker_compose*` fixtures use the given API key for
+ `DANDI_INSTANCEHOST` instead of spinning up a new environment with a new key.
+
 
 ## Sourcegraph
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -58,6 +58,10 @@ development command line options.
 - `DANDI_INSTANCEHOST` -- defaults to `localhost`. Point to host/IP which hosts
   a local instance of dandiarchive.
 
+- `DANDI_REUSE_LOCAL_DOCKER_TESTS_API_KEY` -- use to make `local_docker_compose*`
+  fixtures work by contacting an instance (possibly at `DANDI_INSTANCEHOST`)
+  instead of starting a new one.
+
 ## Sourcegraph
 
 The [Sourcegraph](https://sourcegraph.com) browser extension can be used to

--- a/dandi/consts.py
+++ b/dandi/consts.py
@@ -77,22 +77,26 @@ dandiset_identifier_regex = "^[0-9]{6}$"
 
 dandi_instance = namedtuple("dandi_instance", ("girder", "gui", "redirector", "api"))
 
+# So it could be easily mapped to external IP (e.g. from within VM)
+# to test against instance running outside of current environment
+instancehost = os.environ.get('DANDI_INSTANCEHOST', 'localhost')
+
 known_instances = {
     "local-girder-only": dandi_instance(
-        "http://localhost:8080", None, None, None
+        f"http://{instancehost}:8080", None, None, None
     ),  # just pure girder
     # Redirector: TODO https://github.com/dandi/dandiarchive/issues/139
     "local-docker": dandi_instance(
-        "http://localhost:8080",
-        "http://localhost:8085",
+        f"http://{instancehost}:8080",
+        f"http://{instancehost}:8085",
         None,
-        "http://localhost:9000",  # ATM it is minio, not sure where /api etc
+        f"http://{instancehost}:9000",  # ATM it is minio, not sure where /api etc
         # may be https://github.com/dandi/dandi-publish/pull/71 would help
     ),
     "local-docker-tests": dandi_instance(
-        "http://localhost:8081",
-        "http://localhost:8086",
-        "http://localhost:8079",
+        f"http://{instancehost}:8081",
+        f"http://{instancehost}:8086",
+        f"http://{instancehost}:8079",
         None,  # TODO: https://github.com/dandi/dandi-cli/issues/164
     ),
     "dandi": dandi_instance(


### PR DESCRIPTION
On the host ATM I did

```
(git)lena:~/proj/dandi/dandi-cli[master]git
$> git diff
diff --git a/dandi/tests/data/dandiarchive-docker/docker-compose.yml b/dandi/tests/data/dandiarchive-docker/docker-compose.yml
index 5b825e2..2ce67d3 100644
--- a/dandi/tests/data/dandiarchive-docker/docker-compose.yml
+++ b/dandi/tests/data/dandiarchive-docker/docker-compose.yml
@@ -42,8 +42,8 @@ services:
     ports:
       - "8079:8080"
     environment:
-      GIRDER_URL: http://localhost:8081
-      GUI_URL: http://localhost:8086
+      GIRDER_URL: http://192.168.1.34:8081
+      GUI_URL: http://192.168.1.34:8086
       ABOUT_URL: http://www.dandiarchive.org
 
 volumes:
diff --git a/dandi/tests/test_upload.py b/dandi/tests/test_upload.py
index e7a3163..1100695 100644
--- a/dandi/tests/test_upload.py
+++ b/dandi/tests/test_upload.py
@@ -9,6 +9,7 @@ from ..utils import yaml_load
 
 
 def test_upload(local_docker_compose_env, monkeypatch, organized_nwb_dir2):
+    import pdb; pdb.set_trace()
     nwb_files = list(organized_nwb_dir2.glob(f"*{os.sep}*.nwb"))
     assert len(nwb_files) == 2
     dirname1 = nwb_files[0].parent.name
```

thus hardcoding my external IP (docker serves on it as well as localhost) to be pointed to by the redirector for the services.

May be you see @jwodder a better way to accomplish the mission?