### PR TITLE
BF: address for changes in returned by API records

### DIFF
--- a/dandi/download.py
+++ b/dandi/download.py
@@ -401,10 +401,18 @@ def download_generator(
 
         # Handle our so special dandiset.yaml
         if dandiset and get_metadata:
+            dandiset_metadata = dandiset.get("metadata", {})
+            # DANDI API has no versioning yet, and things are in flux.
+            # It used to have metadata within a key... just in case let's also
+            # be able to handle "old" style
+            # TODO: remove when API stabilizes
+            if (
+                "identifier" not in dandiset_metadata
+                and "dandiset" in dandiset_metadata
+            ):
+                dandiset_metadata = dandiset_metadata["dandiset"]
             for resp in _populate_dandiset_yaml(
-                dandiset_path,
-                dandiset.get("metadata", {}).get("dandiset", {}),
-                existing == "overwrite",
+                dandiset_path, dandiset_metadata, existing == "overwrite"
             ):
                 yield dict(path=dandiset_metadata_file, **resp)
 

--- a/dandi/download.py
+++ b/dandi/download.py
@@ -20,7 +20,7 @@ from .consts import (
 )
 from .dandiset import Dandiset
 from .exceptions import FailedToConnectError, NotFoundError, UnknownURLError
-from .utils import flattened, is_same_time, get_instance
+from .utils import ensure_datetime, flattened, is_same_time, get_instance
 
 import humanize
 from .support.pyout import naturalsize
@@ -798,6 +798,6 @@ def _download_file(
     # TODO: dissolve attrs and pass specific mtime?
     if mtime:
         yield {"status": "setting mtime"}
-        os.utime(path, (time.time(), mtime.timestamp()))
+        os.utime(path, (time.time(), ensure_datetime(mtime).timestamp()))
 
     yield {"status": "done"}

--- a/dandi/utils.py
+++ b/dandi/utils.py
@@ -19,8 +19,7 @@ from . import __version__
 from .consts import dandi_instance, known_instances, known_instances_rev
 from .exceptions import BadCliVersionError, CliVersionTooOldError
 
-if sys.version_info[:2] < (3, 7):
-    import dateutil.parser
+import dateutil.parser
 
 #
 # Additional handlers
@@ -150,7 +149,11 @@ def ensure_strtime(t, isoformat=True):
 
 def fromisoformat(t, impl=None):
     if impl is None:
-        impl = "datetime" if sys.version_info[:2] >= (3, 7) else "dateutil"
+        # datetime parser "does not support parsing arbitrary ISO 8601 strings"
+        # https://docs.python.org/3/library/datetime.html
+        # In particular it does not parse time zone suffix which was recently
+        # introduced into datetime's provided by API
+        impl = "dateutil"
     if impl == "datetime":
         return datetime.datetime.fromisoformat(t)
     elif impl == "dateutil":

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ install_requires =
     ruamel.yaml >=0.15, <1
     keyring
     keyrings.alt
-    python-dateutil;  python_version < "3.7"
+    python-dateutil
     semantic-version
     tqdm
     typing_extensions;  python_version < "3.8"


### PR DESCRIPTION
- datetime stamp now has zone `Z` suffix which breaks "stock" datetime.fromisoformat parsing -- use `datetutil` implementation
- metadata for dandiset now returned not within `dandiset` subkey of metadata record.

"Good" news -- no real released dandisets are out there yet, so no user should be impacted AFAIK.

