### PR TITLE
BF: dandiset metadata record structure/assumptions

### DIFF
--- a/dandi/cli/cmd_register.py
+++ b/dandi/cli/cmd_register.py
@@ -6,8 +6,7 @@ from .base import dandiset_path_option, instance_option, map_to_click_exceptions
 @click.command()
 @dandiset_path_option(
     help="Top directory (local) for the dandiset, where dandi will download "
-    "(or update existing) dandiset.yaml upon successful registration.  If not "
-    "specified, content for the file will be printed to the screen."
+    "(or update existing) dandiset.yaml upon successful registration."
 )
 @click.option(
     "-n", "--name", help="Short name or title for the dandiset.", prompt="Name"
@@ -34,4 +33,5 @@ def register(name, description, dandiset_path=None, dandi_instance="dandi"):
     """
     from ..register import register
 
-    register(name, description, dandiset_path, dandi_instance)
+    dandiset = register(name, description, dandiset_path, dandi_instance)
+    print("identifier:", dandiset.identifier)

--- a/dandi/cli/cmd_register.py
+++ b/dandi/cli/cmd_register.py
@@ -34,6 +34,4 @@ def register(name, description, dandiset_path=None, dandi_instance="dandi"):
     """
     from ..register import register
 
-    output = register(name, description, dandiset_path, dandi_instance)
-    if output is not None:
-        print(output)
+    register(name, description, dandiset_path, dandi_instance)

--- a/dandi/dandiset.py
+++ b/dandi/dandiset.py
@@ -47,7 +47,7 @@ class Dandiset(object):
 
     @classmethod
     def get_dandiset_record(cls, meta):
-        dandiset_identifier = meta.get("identifier")
+        dandiset_identifier = cls._get_identifier(meta)
         if not dandiset_identifier:
             lgr.warning("No identifier for a dandiset was provided in %s", str(meta))
             obtain_msg = ""
@@ -85,6 +85,26 @@ class Dandiset(object):
         # and reload now by a pure yaml
         self._load_metadata()
 
+    @classmethod
+    def _get_identifier(cls, metadata):
+        """Given a metadata record, determine identifier"""
+        # ATM since we have dichotomy in dandiset metadata schema from drafts
+        # and from published versions, we will just test both locations
+        id_ = metadata.get("dandiset", {}).get("identifier")
+        if id_:
+            lgr.debug("Found identifier %s in 'dandiset.identifier'", id_)
+
+        if not id_ and "identifier" in metadata:
+            id_ = metadata["identifier"]
+            lgr.debug("Found identifier %s in top level 'identifier'", id_)
+
+        return id_
+
     @property
     def identifier(self):
-        return self.metadata["identifier"]
+        id_ = self._get_identifier(self.metadata)
+        if not id_:
+            raise ValueError(
+                f"Found no dandiset.identifier in metadata record: {self.metadata}"
+            )
+        return id_

--- a/dandi/download.py
+++ b/dandi/download.py
@@ -124,9 +124,11 @@ def download_generator(
 
         # TODO: if we are ALREADY in a dandiset - we can validate that it is the
         # same dandiset and use that dandiset path as the one to download under
-
         if dandiset:
-            output_path = op.join(output_dir, dandiset["dandiset"]["identifier"])
+            identifier = Dandiset._get_identifier(dandiset)
+            if not identifier:
+                raise ValueError(f"Cannot deduce dandiset identifier from {dandiset}")
+            output_path = op.join(output_dir, identifier)
             if get_metadata:
                 dandiset_metadata = dandiset.get("metadata", {})
                 for resp in _populate_dandiset_yaml(

--- a/dandi/girder.py
+++ b/dandi/girder.py
@@ -567,7 +567,7 @@ correspond in case of a draft, as it is served by girder ATM:
     return remap_dict(
         rec,
         {
-            "metadata": "metadata",  # 1-to-1 for now
+            "metadata": "metadata.dandiset",  # 1-to-1 for now
             "dandiset.created": "attrs.ctime",
             "created": "attrs.ctime",
             "dandiset.uptimed": "attrs.mtime",

--- a/dandi/register.py
+++ b/dandi/register.py
@@ -43,6 +43,12 @@ def register(name, description, dandiset_path=None, dandi_instance="dandi"):
                     dandiset_metadata_file,
                     dandiset.path,
                 )
+        else:
+            lgr.info(
+                "No dandiset path was provided and no dandiset detected in the path."
+                " No %s will be modified",
+                dandiset_metadata_file,
+            )
 
     client = girder.get_client(dandi_instance.girder)
     dandiset = client.register_dandiset(name, description)

--- a/dandi/register.py
+++ b/dandi/register.py
@@ -11,6 +11,20 @@ lgr = get_logger()
 
 
 def register(name, description, dandiset_path=None, dandi_instance="dandi"):
+    """Register a dandiset
+
+    Parameters
+    ----------
+    name: str
+    description: str
+    dandiset_path: str, optional
+    dandi_instance: str, optional
+
+    Returns
+    -------
+    dict
+      Metadata record of the registered dandiset
+    """
     dandi_instance = get_instance(dandi_instance)
     if not dandiset_path and op.exists(dandiset_metadata_file):
         dandiset = Dandiset.find(os.getcwd())
@@ -35,15 +49,13 @@ def register(name, description, dandiset_path=None, dandi_instance="dandi"):
 
     url = routes.dandiset_draft.format(**locals())
 
-    lgr.info(f"Registered dandiset at {url}. Please visit and adjust metadata.")
+    lgr.info(
+        f"Registered dandiset {dandiset['identifier']} at {url}. Please visit and adjust metadata."
+    )
+
     if dandiset_path:
+        lgr.info(f"Adjusting {dandiset_path} with obtained metadata")
         ds = Dandiset(dandiset_path, allow_empty=True)
         ds.update_metadata(dandiset)
-        return None
-    else:
-        lgr.info(
-            "No dandiset path was provided and no dandiset detected in the path."
-            " Here is a record for %s",
-            dandiset_metadata_file,
-        )
-        return Dandiset.get_dandiset_record(dandiset)
+
+    return dandiset

--- a/dandi/tests/test_register.py
+++ b/dandi/tests/test_register.py
@@ -4,43 +4,28 @@ from ..consts import dandiset_identifier_regex, dandiset_metadata_file
 from ..register import register
 from ..utils import yaml_load
 
+import pytest
 
-def test_smoke_metadata_present(local_docker_compose_env, tmp_path):
-    (tmp_path / dandiset_metadata_file).write_text("{}\n")
-    assert (
-        register(
-            "Dandiset Name",
-            "Dandiset Description",
-            dandiset_path=tmp_path,
-            dandi_instance=local_docker_compose_env["instance_id"],
-        )
-        is None
+
+@pytest.mark.parametrize("present", [True, False])
+def test_smoke_register(local_docker_compose_env, tmp_path, present):
+    if present:
+        (tmp_path / dandiset_metadata_file).write_text("{}\n")
+    dandiset_metadata = register(
+        "Dandiset Name",
+        "Dandiset Description",
+        dandiset_path=tmp_path,
+        dandi_instance=local_docker_compose_env["instance_id"],
     )
+    assert dandiset_metadata
+    assert dandiset_metadata["name"] == "Dandiset Name"
+    assert dandiset_metadata["description"] == "Dandiset Description"
+    assert re.match(dandiset_identifier_regex, dandiset_metadata["identifier"])
+
+    # Verify that dandiset.yaml was updated or generated
     with (tmp_path / dandiset_metadata_file).open() as fp:
         metadata = yaml_load(fp, typ="base")
-    assert metadata
-    assert metadata["name"] == "Dandiset Name"
-    assert metadata["description"] == "Dandiset Description"
-    assert re.match(dandiset_identifier_regex, metadata["identifier"])
-    # TODO: Check that a Dandiset exists in the local-docker-tests instance
-    # with the given identifier
+    assert metadata == dandiset_metadata
 
-
-def test_smoke_metadata_not_present(local_docker_compose_env, tmp_path):
-    assert (
-        register(
-            "Dandiset Name",
-            "Dandiset Description",
-            dandiset_path=tmp_path,
-            dandi_instance=local_docker_compose_env["instance_id"],
-        )
-        is None
-    )
-    with (tmp_path / dandiset_metadata_file).open() as fp:
-        metadata = yaml_load(fp, typ="base")
-    assert metadata
-    assert metadata["name"] == "Dandiset Name"
-    assert metadata["description"] == "Dandiset Description"
-    assert re.match(dandiset_identifier_regex, metadata["identifier"])
     # TODO: Check that a Dandiset exists in the local-docker-tests instance
     # with the given identifier

--- a/dandi/tests/test_upload.py
+++ b/dandi/tests/test_upload.py
@@ -4,6 +4,7 @@ import pytest
 
 from .. import girder
 from ..consts import collection_drafts, dandiset_metadata_file
+from ..download import download
 from ..register import register
 from ..upload import upload
 from ..utils import yaml_load
@@ -143,3 +144,18 @@ def test_upload_stat_failure(local_docker_compose_env, organized_nwb_dir):
         )
     finally:
         baddir.rmdir()
+
+
+def test_upload_external_download(local_docker_compose_env, monkeypatch, tmp_path):
+    download("https://dandiarchive.org/dandiset/000027", tmp_path)
+    dandiset_path = tmp_path / "000027"
+    dandi_instance_id = local_docker_compose_env["instance_id"]
+    # (dandiset_path / dandiset_metadata_file).unlink()
+    # register(
+    #     "Download & Upload Test",
+    #     "Download & Upload Test Description",
+    #     dandiset_path=dandiset_path,
+    #     dandi_instance=dandi_instance_id,
+    # )
+    monkeypatch.chdir(dandiset_path)
+    upload(paths=[], dandi_instance=dandi_instance_id, devel_debug=True)

--- a/dandi/upload.py
+++ b/dandi/upload.py
@@ -250,6 +250,11 @@ def upload(
             # Yarik hates it but that is life for now. TODO
             #
             if path.name == dandiset_metadata_file:
+                # TODO This is a temporary measure to avoid breaking web UI
+                # dandiset metadata schema assumptions.  All edits should happen
+                # online.
+                yield skip_file("should be edited online")
+                return
                 # We need to upload its content as metadata for the entire
                 # folder.
                 folder_rec = ensure_folder()

--- a/dandi/upload.py
+++ b/dandi/upload.py
@@ -230,7 +230,8 @@ def upload(
             #
             # 1. Validate first, so we do not bother girder at all if not kosher
             #
-            if validation != "skip":
+            # TODO: enable back validation of dandiset.yaml
+            if path.name != dandiset_metadata_file and validation != "skip":
                 yield {"status": "validating"}
                 validation_errors = validate_file(path)
                 yield {"errors": len(validation_errors)}
@@ -239,6 +240,8 @@ def upload(
                     if validation == "require":
                         yield skip_file("failed validation")
                         return
+                else:
+                    yield {"status": "validated"}
             else:
                 # yielding empty causes pyout to get stuck or crash
                 # https://github.com/pyout/pyout/issues/91


### PR DESCRIPTION
In #233 (post 0.6.4 release, current master) I have tried to unify metadata records, but did that incorrectly for dandisets. I forgot that those would also be used during `upload` which caused fiasco in uploading sample 000029 (web ui is also not tolerant to bad metadata)

As part of this PR I also
- adjuster `register` to always return record given by the server, and adjusted (and refactored a bit) corresponding test of register
- included test by @jwodder from #241 (Closes #240) and adjusted it to use `register`
- `dandiset.yaml` would no longer be uploaded at all to the archive.  we already add a comment that all changes are to be lost, so we should actually do that (i.e. not upload so all changes lost)