### PR TITLE
Use environment file instead of set-env

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install ".[test]"
     - name: Set environment variable when using Python 3.6 to cover more code
-      run: echo "::set-env name=DANDI_LOG_GIRDER::1"
+      run: echo DANDI_LOG_GIRDER=1 >> $GITHUB_ENV
       if: matrix.python == '3.6'
     - name: ${{ matrix.module }} tests
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install ".[test]"
     - name: Set environment variable when using Python 3.6 to cover more code
-      run: echo DANDI_LOG_GIRDER=1 >> $GITHUB_ENV
+      run: echo DANDI_LOG_GIRDER=1 >> "$GITHUB_ENV"
       if: matrix.python == '3.6'
     - name: ${{ matrix.module }} tests
       run: |


### PR DESCRIPTION
The set-env workflow command is deprecated in favor of environment files: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/