### PR TITLE
Set up workflow with auto for releasing & PyPI uploads

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -1,0 +1,7 @@
+{
+    "onlyPublishWithReleaseLabel": true,
+    "baseBranch": "master",
+    "author": "auto <auto@nil>",
+    "noVersionPrefix": true,
+    "plugins": ["git-tag"]
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,19 +10,69 @@ jobs:
   auto-release:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
+    outputs:
+      auto-version: ${{ steps.auto-version.outputs.version }}
     steps:
-    - name: Checkout source
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-        #token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout source
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
-    - name: Download latest auto
-      run: |
-        curl -vL -o - "$(curl -fsSL https://api.github.com/repos/intuit/auto/releases/latest | jq -r '.assets[] | select(.name == "auto-linux.gz") | .browser_download_url')" | gunzip > ~/auto
-        chmod a+x ~/auto
+      - name: Download latest auto
+        run: |
+          auto_download_url="$(curl -fsSL https://api.github.com/repos/intuit/auto/releases/latest | jq -r '.assets[] | select(.name == "auto-linux.gz") | .browser_download_url')"
+          wget -O- "$auto_download_url" | gunzip > ~/auto
+          chmod a+x ~/auto
 
-    - name: Create release
-      run: ~/auto shipit -vv
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check whether a release is due
+        id: auto-version
+        run: |
+          version="$(~/auto version)"
+          echo "::set-output name=version::$version"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create release
+        run: ~/auto shipit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  pypi:
+    runs-on: ubuntu-latest
+    needs: auto-release
+    if: "needs.auto-release.outputs.auto-version != ''"
+    steps:
+      # By default, actions/checkout will checkout the commit that that was
+      # pushed to master and triggered the workflow, but this does not include
+      # the commit & tag created by `auto`.  In order to get that, we need to
+      # look up the tag for the latest release.
+      - name: Get tag of latest release
+        id: latest-release
+        run: |
+          latest_tag="$(curl -fsSL https://api.github.com/repos/$GITHUB_REPOSITORY/releases/latest | jq -r .tag_name)"
+          echo "::set-output name=tag::$latest_tag"
+
+      - name: Checkout source
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.latest-release.outputs.tag }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.6
+
+      - name: Install build & twine
+        run: python -m pip install build twine
+
+      - name: Build
+        run: python -m build
+
+      - name: Upload
+        run: twine upload dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+
+# vim:set sts=2:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Auto-release on PR merge
+
+on:
+  # ATM, this is the closest trigger to a PR merging
+  push:
+    branches:
+      - master
+
+jobs:
+  auto-release:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        #token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Download latest auto
+      run: |
+        curl -vL -o - "$(curl -fsSL https://api.github.com/repos/intuit/auto/releases/latest | jq -r '.assets[] | select(.name == "auto-linux.gz") | .browser_download_url')" | gunzip > ~/auto
+        chmod a+x ~/auto
+
+    - name: Create release
+      run: ~/auto shipit -vv
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,32 +1,25 @@
-# Changelog
-All notable changes to this project will be documented (for humans) in this file.
+# [0.7.0] - 2020-11-04
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
-and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
-
-
-## [0.7.0] - 2020-11-04
-
-### Added
+## Added
 - Files are now stored in temporary directories while downloading alongside
   metadata for use in resuming interrupted downloads
 
-### Changed
+## Changed
 - Moved code for navigating Dandi Archive into new `dandiarchive` submodule
 - YAML output now sorts keys
 - `dandiset.yaml` is no longer uploaded to the archive
 - Restrict h5py dependency to pre-v3.0
 
-## [0.6.4] - 2020-09-04
+# [0.6.4] - 2020-09-04
 
 Primarily a range of bugfixes to ensure correct operation with current state
 of other components of DANDI, and use of the client on Windows OS.
 
-### Added
+## Added
 - Initial DANDI schema files
 - More tests for various code paths
 - `download`: new option `--download [assets,dandiset.yaml,all]`
-### Fixed
+## Fixed
 - `download` - account for changes in DANDI API (relevant only for released
   datasets, of which we do not have any "real" ones yet)
 - `upload` - various Windows specific fixes
@@ -34,26 +27,26 @@ of other components of DANDI, and use of the client on Windows OS.
 Note: [0.6.3] was released under missing some of the fixes, so overall
 abandoned.
 
-## [0.6.2] - 2020-08-19
+# [0.6.2] - 2020-08-19
 
-### Fixed
+## Fixed
 - `organize` treatment of paths on window (gh-204)
 
-## [0.6.1] - 2020-08-18
+# [0.6.1] - 2020-08-18
 
-### Changed
+## Changed
 - CLI modules RF to avoid circular imports
 - `pytest` default traceback style is short and shows 10 slowest tsts
-### Fixed
+## Fixed
 - `download` of draft datasets from Windows (gh-202)
 - `upload` and other tests to account for new web UI
 
-## [0.6.0] - 2020-08-12
+# [0.6.0] - 2020-08-12
 
 A variety of improvements and bug fixes, with major changes toward support
 of a new DANDI API, and improving DX (Development eXperience).
 
-### Added
+## Added
 - Support for WiP DANDI API service.
   `download` now can download from "published" (versioned) dandisets.
 - A wide range of development enhancements
@@ -65,7 +58,7 @@ of a new DANDI API, and improving DX (Development eXperience).
 - Locking of the dandiset during upload to prevent multiple sessions modifying
   the same dandiset in the archive
 - `upload` now adds `uploaded_by` field into the item metadata
-### Changed
+## Changed
 - `download` was refactored and new UI also uses pyout (as
   `upload` and `ls`) so there will be no tqdm progress bar indicators.
   `download` also does "on-the-fly" integrity of the data as received
@@ -74,12 +67,12 @@ of a new DANDI API, and improving DX (Development eXperience).
 - Unified YAML operations to `ruamel.yaml`
 - Avoid hardcoded URLs for dandiarchive components by querying `/server-info`
 - Improved logging for interactions with girder server
-### Fixed
+## Fixed
 - minor compatibility issues across OSes
 
-## [0.5.0] - 2020-06-04
+# [0.5.0] - 2020-06-04
 
-### Added
+## Added
 - `metadata` and `organize`: extract and use `probe_ids` metadata to
   disambiguate (if needed)
 - `organize`: `--devel-debug` option to perform metadata extraction serially
@@ -93,126 +86,114 @@ of a new DANDI API, and improving DX (Development eXperience).
     download
   - follow redirections from arbitrary redirector (e.g., bit.ly). Succeeds
     only if the final URL is known to DANDI.
-### Fixed
+## Fixed
 - `upload`: a crash while issuing a record to update about deleted empty item
-### Refactored
+## Refactored
 - `organize`: disambiguation process now could use a flexible list of metadata
   fields (ATM only `probe_ids` and `obj_id`)
 - `download`: handling of redirection - now uses `HEAD` request instead of `GET`
 
-## [0.4.6] - 2020-05-07
+# [0.4.6] - 2020-05-07
 
-### Fixed
+## Fixed
 - invoke etelemetry only in command line (at click interface level)
 - download of updated dandiset landing page url (`/dandiset` not `/dandiset-meta`)
 
-## [0.4.5] - 2020-05-01
+# [0.4.5] - 2020-05-01
 
-### Added
+## Added
 - support for downloading dandisets and files in the just released
   gui.dandiarchive.org UI refactor
-### Fixed
+## Fixed
 - `validate` should no longer crash if loading metadata raises an exception
-### Refactored
+## Refactored
 - the way URLs are mapped into girder instances. Now more regex driven
 
-## [0.4.4] - 2020-04-14
+# [0.4.4] - 2020-04-14
 
-### Added
+## Added
 - `validate` now will report absent `subject_id` as an error
-### Fixed
+## Fixed
 - Caching of multiple functions re-using the same cache -- it could
   have resulted in our case neural data types returned where full metadata
   was requested, or vise vera
 - Tolerate outdated (before 2.0.0) etelemetry
 
 
-## [0.4.3] - 2020-04-14
+# [0.4.3] - 2020-04-14
 
-### Added
+## Added
 - Ability to download (multiple) individual files (using URL from
   gui.dandiarchive.org having files selected)
-### Changed
+## Changed
 - `DANDI_CACHE_CLEAR` -> `DANDI_CACHE=(ignore|clear)` env variable.
 - Sanitize and tollerate better incorrect `nwb_version` field.
-### Fixed
+## Fixed
 - Test to not invoke Popen with shell=True to avoid stalling.
 - Explicit `NO_ET=1` in workflows to avoid overreporting to etelemetry.
 
 
-## [0.4.2] - 2020-03-18
+# [0.4.2] - 2020-03-18
 
-### Added
+## Added
 - Use of etelemetry for informing about new (or bad) versions
-### Changed
+## Changed
 - Fixed saving into yaml so it is consistently not using a flow style
   (#59)
 - All file names starting with a period are not considered (#63)
 
-## [0.4.1] - 2020-03-16
+# [0.4.1] - 2020-03-16
 
-### Changed
+## Changed
 - `organize` -- now would add `_obj-` key with the crc32 checksum
   of the nwb file `object_id` if files could not be otherwise
   disambiguated
 - variety of small tune ups and fixes
-### Removed
+## Removed
 - `organize` -- not implemented option `--format`
 - `upload` -- not properly implemented option `-d|--dandiset-path`
 
-## [0.4.0] - 2020-03-13
+# [0.4.0] - 2020-03-13
 
 Provides interfaces for a full cycle of dandiset preparation,
 registration, upload, and download.
 
-### Added
+## Added
 - caching of read metadata and validation results for .nwb files.
   Typically those take too long and as long as dandi and pynwb
   versions do not change -- results should not change.
   Set `DANDI_DEVEL` variable to forcefully reset all the caches.
-### Changed
+## Changed
 - DEVELOPMENT.md provides more information about full local
   test setup of the dandiarchive, and description of
   environment variables which could assist in development.
 
-## [0.3.0] - 2020-02-28
+# [0.3.0] - 2020-02-28
 
-### Added
+## Added
 - `organize`: organize files into hierarchy using metadata.
   ATM operates only in "simulate" mode using .json files dumped by `ls`
-### Changed
+## Changed
 - various refactorings and minor improvements (docs, testing, etc).
 
 
-## [0.2.0] - 2020-02-04
+# [0.2.0] - 2020-02-04
 
 Improvements to `ls` and `upload` commands
 
-### Added
+## Added
 - `ls`: include a list (with counts) of neural datatypes in the file
 - `upload`:
   - ability to reupload files (by removing already existing ones)
   - ability to "sync" (skip if not modified) to girder based on mtime
     and size
 - CI (github actions): testing on macos-latest
-### Changed
+## Changed
 - removed `hdmf !=` statement in setup.cfg to not confuse pypi.
-### Fixed
+## Fixed
 - `upload` - assure string for an error message
 - mitigated crashes in pynwb if neural data type schema is not cached
   in the file and requires import of the extension module.  ATM the
   known/handled only the `AIBS_ecephys` from `allensdk`
-
-
-## [Unreleased]
-
-TODO Summary
-
-### Added
-### Changed
-### Fixed
-### Removed
-### Security
-
 
 [0.2.0]: https://github.com/dandi/dandi-cli/commits/0.2.0

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -85,3 +85,29 @@ view code coverage information as follows:
    pull request diff), there will be a "Coverage: X%" button at the top of the
    source listing.  Pressing this button will toggle highlighting of the source
    lines based on whether they are covered by tests or not.
+
+
+## Releasing with GitHub Actions, auto, and pull requests
+
+New releases of dandi-cli are created via a GitHub Actions workflow built
+around [`auto`](https://github.com/intuit/auto).  Whenever a pull request is
+merged that has the "`release`" label, `auto` updates the changelog based on
+the pull requests since the last release, commits the results, tags the new
+commit with the next version number, and creates a GitHub release for the tag.
+This in turn triggers a job for building an sdist & wheel for the project and
+uploading them to PyPI.
+
+### Labelling pull requests
+
+The section that `auto` adds to the changelog on a new release consists of the
+titles of all pull requests merged into master since the previous release,
+organized by label.  `auto` recognizes the following PR labels:
+
+- `major` — for changes corresponding to an increase in the major version
+  component
+- `minor` — for changes corresponding to an increase in the minor version
+  component
+- `patch` — for changes corresponding to an increase in the patch/micro version
+  component; this is the default label for unlabelled PRs
+- `internal` — for changes only affecting the internal API
+- `documentation` — for changes only affecting the documentation


### PR DESCRIPTION
Addresses part of #252.

**Note:** I would recommend not merging this PR until after the next release of dandi-cli so that we can start fresh with labelling all of our PRs.

This PR also needs to be accompanied by the following changes:
- [x] Create the necessary labels for `auto` by running `GH_TOKEN=... auto create-labels` in a copy of this repository containing `.autorc`
- [x] A GitHub release must be created for the most recent version of dandi-cli
- [x] An auth token for uploading assets for the `dandi` project to PyPI must be saved as a secret named "`PYPI_TOKEN`"
- [x] Modify `CHANGELOG.md` so its sectioning matches the format used by `auto`; specifically, eliminate the part above the topmost version section and remove a `#` from all remaining headers