### PR TITLE
DOC: strip away duplicate with the handbook information

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,67 +73,9 @@ Options:
   --help                          Show this message and exit.
 ```
 
-## Preparing and uploading a dandiset to dandiarchive.org
-
-Although some functionality and final interface is still Work-in-Progress (WiP),
-overall tentative target workflow will be:
-
-1. Collect or convert your data files to [NWB](https://www.nwb.org) format.
-   Files should have `.nwb` file extension.
-2. Use `dandi validate` to verify that files conform
-   [NWB schema](https://github.com/NeurodataWithoutBorders/nwb-schema/) and
-   [DANDI requirements](TODO) (WiP) on contained in them metadata.
-   If necessary, adjust your conversion scripts or use
-   [helper utilities](TODO) to address concerns identified by `dandi validate`
-   command.
-3. Use `dandi organize` to
-
-   - re-layout (move, rename) your files into a consistent naming convention
-   - generate a template `dataset.yaml` with some fields pre-populated from
-     metadata extracted from the `.nwb` files.
-
-   1. If file names for some files could not be disambiguated, possibly see in
-   providing additional metadata within `.nwb` files so they could be named
-   without collisions, or
-   [file an issue](https://github.com/dandi/dandi-cli/issues) describing your case.
-   `dandi ls` command could come useful to quickly view metadata we consider.
-
-   2. Fill out missing fields marked REQUIRED in the `dataset.yaml`, remove templated
-   RECOMMENDED or OPTIONAL.
-
-   Result of the reorganization is a dandiset -- a dataset with consistent layout,
-   and dataset level metadata.
-
-4. Rerun `dandi validate` on the entire dandiset to assure that everything is
-   correct.
-5. Use `dandi register` to register a new dataset ID on DANDI archive.  If you
-   run it within a dandiset, its `dandiset.yaml` will be automatically updated
-   to contain new dandiset identifier.
-6. Use `dandi upload` to upload your dandiset to the archive
-   ["drafts" collection](https://gui.dandiarchive.org/#/collection/5e59bb0af19e820ab6ea6c62).
-
-If you change anything in your dandiset and decide to update its state in the
-archive, just use `dandi upload` again.
-
-You could also visit [doc/demos/basic-workflow1.sh](./doc/demos/basic-workflow1.sh) for an example script
-which does all above actions (assuming no changes to files are necessary).
-
-
-## Downloading dandiset from the archive
-
-`dandi download` can be used to download full dandisets or individual files or
-folders from the archive.
-
-Using `--existing refresh` option available for
-`dandi upload` and `dandi download` it is possible to avoid transfer if files
-are identical locally and in the archive.
-
-**Warning:**  There is no version control tracking beyond checking correspondence
-of file size and modification time.  So in collaborative setting it is possible
-to "refresh" a file which was modified locally with a version from the archive,
-or vise versa.
-
-
+See [DANDI Handbook](https://www.dandiarchive.org/handbook/10_using_dandi/)
+for examples on how to use this client in various use cases.
+ 
 ## Development/contributing
 
 Please see [DEVELOPMENT.md](./DEVELOPMENT.md) file.


### PR DESCRIPTION
To avoid maintaining two documentations, where each one coughs get out of sync.

Closes #278