### PR TITLE
BF: add h5py.__version__ into the list of tokens for caching

### DIFF
--- a/dandi/pynwb_utils.py
+++ b/dandi/pynwb_utils.py
@@ -26,7 +26,7 @@ lgr = get_logger()
 
 # strip away possible development version marker
 dandi_rel_version = __version__.split("+", 1)[0]
-dandi_cache_tokens = [pynwb.__version__, dandi_rel_version]
+dandi_cache_tokens = [pynwb.__version__, dandi_rel_version, h5py.__version__]
 metadata_cache = PersistentCache(name="metadata", tokens=dandi_cache_tokens)
 validate_cache = PersistentCache(name="validate", tokens=dandi_cache_tokens)
 


### PR DESCRIPTION
h5py 3.0 introduced breaking changes (see e.g. https://github.com/dandi/dandi-cli/issues/282)
and hdmf yet to account for them.  We better cache that version too to improve
consistency of outputs etc