### PR TITLE
Add rudimentary duecredit support using zenodo's dandi-cli DOI

### DIFF
--- a/dandi/__init__.py
+++ b/dandi/__init__.py
@@ -9,6 +9,16 @@ __version__ = _version.get_versions()["version"]
 # Basic logger configuration
 #
 
+from .due import due, Doi
+due.cite(
+    Doi("10.5281/zenodo.3692138"),
+    cite_module=True,  # highly specialized -- if imported, means used.
+    description="Client to interact with DANDI Archive",
+    path='dandi-cli',
+    version=__version__,  # since yoh hijacked dandi for module but is not brave enough
+                          # to claim it to be dandi as the whole
+)
+
 
 def get_logger(name=None):
     """Return a logger to use

--- a/dandi/due.py
+++ b/dandi/due.py
@@ -1,0 +1,74 @@
+# emacs: at the end of the file
+# ex: set sts=4 ts=4 sw=4 et:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### #
+"""
+
+Stub file for a guaranteed safe import of duecredit constructs:  if duecredit
+is not available.
+
+To use it, place it into your project codebase to be imported, e.g. copy as
+
+    cp stub.py /path/tomodule/module/due.py
+
+Note that it might be better to avoid naming it duecredit.py to avoid shadowing
+installed duecredit.
+
+Then use in your code as
+
+    from .due import due, Doi, BibTeX, Text
+
+See  https://github.com/duecredit/duecredit/blob/master/README.md for examples.
+
+Origin:     Originally a part of the duecredit
+Copyright:  2015-2019  DueCredit developers
+License:    BSD-2
+"""
+
+__version__ = '0.0.8'
+
+
+class InactiveDueCreditCollector(object):
+    """Just a stub at the Collector which would not do anything"""
+    def _donothing(self, *args, **kwargs):
+        """Perform no good and no bad"""
+        pass
+
+    def dcite(self, *args, **kwargs):
+        """If I could cite I would"""
+        def nondecorating_decorator(func):
+            return func
+        return nondecorating_decorator
+
+    active = False
+    activate = add = cite = dump = load = _donothing
+
+    def __repr__(self):
+        return self.__class__.__name__ + '()'
+
+
+def _donothing_func(*args, **kwargs):
+    """Perform no good and no bad"""
+    pass
+
+
+try:
+    from duecredit import due, BibTeX, Doi, Url, Text
+    if 'due' in locals() and not hasattr(due, 'cite'):
+        raise RuntimeError(
+            "Imported due lacks .cite. DueCredit is now disabled")
+except Exception as e:
+    if not isinstance(e, ImportError):
+        import logging
+        logging.getLogger("duecredit").error(
+            "Failed to import duecredit due to %s" % str(e))
+    # Initiate due stub
+    due = InactiveDueCreditCollector()
+    BibTeX = Doi = Url = Text = _donothing_func
+
+# Emacs mode definitions
+# Local Variables:
+# mode: python
+# py-indent-offset: 4
+# tab-width: 4
+# indent-tabs-mode: nil
+# End:

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,6 +68,8 @@ include_package_data = True
 # e.g. import whenever pynwb fails without them
 extensions =
     allensdk
+extras =
+    duecredit
 style =
     flake8
     pre-commit
@@ -83,6 +85,7 @@ tools=
 all =
     #%(doc)s
     %(extensions)s
+    %(extras)s
     %(style)s
     %(test)s
     %(tools)s


### PR DESCRIPTION
I am using Zenodo unversioned DOI
```shell
$> DUECREDIT_ENABLE=1 python -m pytest dandi/tests/test_utils.py
====================================================== test session starts ======================================================
platform linux -- Python 3.8.6, pytest-4.6.11, py-1.9.0, pluggy-0.13.0
rootdir: /home/yoh/proj/dandi/dandi-cli, inifile: tox.ini
plugins: mock-3.2.0, cov-2.10.0, pyfakefs-4.1.0, forked-1.3.0, timeout-1.4.1, xdist-1.32.0, hypothesis-5.32.1
collected 19 items                                                                                                              

dandi/tests/test_utils.py ...................                                                                             [100%]

=================================================== slowest 10 test durations ===================================================
0.01s call     dandi/tests/test_utils.py::test_find_files
0.01s setup    dandi/tests/test_utils.py::test_find_files_dotfiles

(0.00 durations hidden.  Use -vv to show these durations.)
=================================================== 19 passed in 0.07 seconds ===================================================

DueCredit Report:
- Client to interact with DANDI Archive / dandi-cli (v 0.7.2+6.g39c62bc.dirty) [1]
- Scientific tools library / numpy (v 1.19.4) [2]

2 packages cited
0 modules cited
0 functions cited

References
----------

[1] Halchenko, Y. et al., 2020. dandi/dandi-cli: 0.7.2.
[2] Van Der Walt, S., Colbert, S.C. & Varoquaux, G., 2011. The NumPy array: a structure for efficient numerical computation. Computing in Science & Engineering, 13(2), pp.22–30.
```