### PR TITLE
ls - avoid workaround, more consistent reporting of errors

### DIFF
--- a/dandi/cli/cmd_ls.py
+++ b/dandi/cli/cmd_ls.py
@@ -1,6 +1,5 @@
 import os
 import os.path as op
-import time
 
 import click
 
@@ -8,7 +7,6 @@ from collections import defaultdict
 
 from .base import lgr, map_to_click_exceptions
 
-from ..utils import safe_call
 
 # TODO: all the recursion options etc
 
@@ -36,9 +34,16 @@ from ..utils import safe_call
     "be considered.",
     is_flag=True,
 )
+@click.option(
+    "-J",
+    "--jobs",
+    help="Number of parallel download jobs.",
+    default=6,  # TODO: come up with smart auto-scaling etc
+    show_default=True,
+)
 @click.argument("paths", nargs=-1, type=click.Path(exists=False, dir_okay=True))
 @map_to_click_exceptions
-def ls(paths, fields=None, format="auto", recursive=False):
+def ls(paths, fields=None, format="auto", recursive=False, jobs=6):
     """List .nwb files and dandisets metadata.
     """
     from ..consts import metadata_all_fields
@@ -104,7 +109,7 @@ def ls(paths, fields=None, format="auto", recursive=False):
         if fields and fields[0] != "path":
             # we must always have path - our "id"
             fields = ["path"] + fields
-        out = PYOUTFormatter(fields=fields)
+        out = PYOUTFormatter(fields=fields, wait_for_top=3, max_workers=jobs)
     elif format == "json":
         out = JSONFormatter()
     elif format == "json_pp":
@@ -119,16 +124,10 @@ def ls(paths, fields=None, format="auto", recursive=False):
         async_keys = async_keys.intersection(fields)
     async_keys = tuple(async_keys.difference(common_fields))
 
-    process_assets = set()
     errors = defaultdict(list)  # problem: [] paths
     with out:
         for asset in assets_gen():
-            while len(process_assets) >= 10:
-                lgr.log(2, "Sleep waiting for some paths to finish processing")
-                time.sleep(0.5)
-
             if isinstance(asset, str):  # path
-                process_assets.add(asset)
                 rec = {}
                 rec["path"] = asset
 
@@ -138,11 +137,7 @@ def ls(paths, fields=None, format="auto", recursive=False):
 
                     if async_keys:
                         cb = get_metadata_ls(
-                            asset,
-                            async_keys,
-                            process_assets,
-                            errors=errors,
-                            flatten=format == "pyout",
+                            asset, async_keys, errors=errors, flatten=format == "pyout"
                         )
                         if format == "pyout":
                             rec[async_keys] = cb
@@ -264,7 +259,7 @@ def flatten_meta_to_pyout(meta):
     return out
 
 
-def get_metadata_ls(path, keys, process_paths, errors, flatten=False):
+def get_metadata_ls(path, keys, errors, flatten=False):
     from ..pynwb_utils import get_nwb_version, ignore_benign_pynwb_warnings
     from ..metadata import get_metadata
 
@@ -295,10 +290,7 @@ def get_metadata_ls(path, keys, process_paths, errors, flatten=False):
                     _add_exc_error(path, rec, errors, exc)
             return rec
         finally:
-            # TODO: this is a workaround, remove after
-            # https://github.com/pyout/pyout/issues/87 is resolved
-            if process_paths is not None and path in process_paths:
-                process_paths.remove(path)
+            pass
 
     return fn
 

--- a/dandi/cli/formatter.py
+++ b/dandi/cli/formatter.py
@@ -59,10 +59,11 @@ class YAMLFormatter(Formatter):
 
 
 class PYOUTFormatter(pyout.Tabular):
-    def __init__(self, fields):
+    def __init__(self, fields, **kwargs):
         PYOUT_STYLE = pyouts.get_style(hide_if_missing=not fields)
 
         kw = dict(style=PYOUT_STYLE)
+        kw.update(kwargs)
         if fields:
             kw["columns"] = fields
         super().__init__(**kw)

--- a/dandi/pynwb_utils.py
+++ b/dandi/pynwb_utils.py
@@ -68,7 +68,7 @@ def _sanitize_nwb_version(v, filename=None, log=None):
     return v
 
 
-def get_nwb_version(filepath, sanitize=True):
+def get_nwb_version(filepath, sanitize=False):
     """Return a version of the NWB standard used by a file
 
     Parameters

--- a/dandi/pynwb_utils.py
+++ b/dandi/pynwb_utils.py
@@ -273,13 +273,20 @@ def validate(path):
 # way to get relevant warnings (not errors) from PyNWB.  It is a bad manner
 # to have this as a side effect of the importing this module, we should add/remove
 # that filter in our top level commands
+_ignored_benign_pynwb_warnings = False
+
+
 def ignore_benign_pynwb_warnings():
+    global _ignored_benign_pynwb_warnings
+    if _ignored_benign_pynwb_warnings:
+        return
     #   See https://github.com/dandi/dandi-cli/issues/14 for more info
     for s in (
         "No cached namespaces found .*",
         "ignoring namespace '.*' because it already exists",
     ):
         warnings.filterwarnings("ignore", s, UserWarning)
+    _ignored_benign_pynwb_warnings = True
 
 
 def get_object_id(path):

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ install_requires =
     joblib
     pycryptodomex  # for EncryptedKeyring backend in keyrings.alt
     pydantic
-    pyout != 0.6.0
+    pyout >=0.5, !=0.6.0
     humanize
     requests ~= 2.20
     ruamel.yaml >=0.15, <1


### PR DESCRIPTION
TODOs
- [x] test drive on a large collection of nwb on drogon

Closes #282

oh well -- migrating away from ad-hoc limit to max_workers + wait_for_top of pyout does change UX since for long lists of files we would have only the top of the terminal "busy" while the bottom just with the filenames and sizes.  But I decided to stick with that for now, although may be I would whine to @kyleam later on or just reintroduce ad-hoc solution, or may be it would be somehow more natively resolved within dandi-cli upon RFing to use ProducerConsumer pattern outside of pyout.