### PR TITLE
Temporary workaround: prevent upload of files larger than 67108864000

### DIFF
--- a/dandi/upload.py
+++ b/dandi/upload.py
@@ -166,6 +166,14 @@ def upload(
             try:
                 path_stat = path.stat()
                 yield {"size": path_stat.st_size}
+                size_cut_off = 67108864000
+                if path_stat.st_size > size_cut_off:
+                    raise RuntimeError(
+                        "Too large! We are experiencing problems uploading files larger than %s. "
+                        "See https://github.com/dandi/dandiarchive/issues/517 and update "
+                        "client when the issue is resolved."
+                        % (naturalsize(size_cut_off))
+                    )
             except FileNotFoundError:
                 yield skip_file("ERROR: File not found")
                 return


### PR DESCRIPTION
See https://github.com/dandi/dandiarchive/issues/517 for more information

If looks kosher and doesn't break anything, we should get it into the masses, unless we find a proper solution to that issue.

we might want to announce all prior versions of dandi-cli as "bad" in .et