### PR TITLE
Install hdf5 for Python 3.9 tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,8 @@ jobs:
           - 3.8
           - 3.9
         exclude:
+          # Temporarily disabled due to h5py/hdf5 dependency issue
+          # See <https://github.com/dandi/dandi-cli/pull/315>
           - os: windows-2019
             python: 3.9
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,9 @@ jobs:
           - 3.7
           - 3.8
           - 3.9
+        exclude:
+          - os: windows-2019
+            python: 3.9
 
     steps:
     - name: Set up environment
@@ -36,10 +39,20 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python }}
+
+    - name: Install hdf5 (Ubuntu)
+      if: matrix.python == '3.9' && startsWith(matrix.os, 'ubuntu')
+      run: sudo apt-get update && sudo apt-get install -y libhdf5-dev
+
+    - name: Install hdf5 (macOS)
+      if: matrix.python == '3.9' && startsWith(matrix.os, 'macos')
+      run: brew install hdf5
+
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip wheel
         pip install ".[test]"
+
     - name: Set environment variable when using Python 3.6 to cover more code
       run: echo DANDI_LOG_GIRDER=1 >> "$GITHUB_ENV"
       if: matrix.python == '3.6'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,9 @@ jobs:
 
     - name: Install hdf5 (macOS)
       if: matrix.python == '3.9' && startsWith(matrix.os, 'macos')
-      run: brew install hdf5
+      run: |
+        brew install hdf5@1.8
+        brew link hdf5@1.8
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
On December 9, hdmf released a new version that restricted its h5py dependency version range to `<3,>=2.9`; as a result, installing dandi with a recent version of pip will install a pre-3.0 version of h5py.  However, pre-3.0 versions of h5py do not have Python 3.9 wheels available on PyPI, and so the package must be built from source for Python 3.9, which requires an hdf5 library to be installed.  This PR installs such a library for Ubuntu and macOS when testing Python 3.9; testing Python 3.9 on Windows is disabled for now as installing hdf5 on that OS is apparently quite involved.