### PR TITLE
Require keyring backends to be initialized before running any tests

### DIFF
--- a/dandi/tests/test_girder.py
+++ b/dandi/tests/test_girder.py
@@ -1,7 +1,7 @@
 import os.path
 
+from keyring.backend import get_all_keyring
 from keyring.backends import fail, null
-from keyring.core import init_backend
 from keyring.errors import KeyringError
 from keyrings.alt import file as keyfile
 
@@ -9,10 +9,18 @@ import pytest
 from ..exceptions import LockingError
 from .. import girder
 
-# Ensure that keyring backends are initialized before running any tests, as
-# EncryptedKeyring cannot be initialized (on macOS, at least) while pyfakefs is
-# in effect.
-init_backend()
+
+@pytest.fixture(scope="module", autouse=True)
+def ensure_keyring_backends():
+    # Ensure that keyring backends are initialized before running any tests, as
+    # EncryptedKeyring cannot be initialized (on macOS, at least) while
+    # pyfakefs is in effect.
+    get_all_keyring()
+    # This function caches its results, so it's safe to call if the backends
+    # have already been initialized.
+    # We need to call get_all_keyring() instead of init_backend() because the
+    # latter's behavior can be affected by any keyring config files the user
+    # happens to have.
 
 
 def test_lock_dandiset(local_docker_compose_env):

--- a/dandi/tests/test_girder.py
+++ b/dandi/tests/test_girder.py
@@ -1,12 +1,18 @@
 import os.path
 
 from keyring.backends import fail, null
+from keyring.core import init_backend
 from keyring.errors import KeyringError
 from keyrings.alt import file as keyfile
 
 import pytest
 from ..exceptions import LockingError
 from .. import girder
+
+# Ensure that keyring backends are initialized before running any tests, as
+# EncryptedKeyring cannot be initialized (on macOS, at least) while pyfakefs is
+# in effect.
+init_backend()
 
 
 def test_lock_dandiset(local_docker_compose_env):


### PR DESCRIPTION
On December 22, keyring released version 21.6, which no longer initializes keyring backends on import, instead delaying initialization until any functions are called.  As a result, when dandi-cli’s tests are run, the EncryptedKeyring backend is only initialized in the middle of individual tests, and these tests happen to use pyfakefs.  However, initializing EncryptedKeyring leads to a use of the subprocess module, which is unusable while pyfakefs is in effect, and the tests end up failing.

This PR forces the keyring backends to be initialized when the tests are loaded, before any of them run, thereby fixing the currently-failing tests.

The only thing I don’t understand is why this was only causing a problem on macOS.