### PR TITLE
Give AssetMeta and DandiMeta `json_dict()` methods for better dictification

### DIFF
--- a/dandi/models.py
+++ b/dandi/models.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 from datetime import date
 from enum import Enum
+import json
 import sys
 from typing import Any, Dict, List, Optional, Type, Union
 
@@ -659,6 +660,14 @@ class CommonModel(DandiBaseModel):
     relatedResource: Optional[List[Resource]] = Field(None, nskey="dandi")
 
     wasGeneratedBy: Optional[Activity] = Field(None, nskey="prov")
+
+    def asdict(self):
+        """
+        Recursively convert the instance to a `dict` of JSONable values,
+        including converting enum values to strings.  Unset and `None` fields
+        are omitted.
+        """
+        return json.loads(self.json(exclude_unset=True, exclude_none=True))
 
 
 class DandiMeta(CommonModel):

--- a/dandi/models.py
+++ b/dandi/models.py
@@ -661,7 +661,7 @@ class CommonModel(DandiBaseModel):
 
     wasGeneratedBy: Optional[Activity] = Field(None, nskey="prov")
 
-    def asdict(self):
+    def json_dict(self):
         """
         Recursively convert the instance to a `dict` of JSONable values,
         including converting enum values to strings.  Unset and `None` fields

--- a/dandi/upload.py
+++ b/dandi/upload.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-import json
 import os.path
 
 # PurePosixPath to be cast to for paths on girder
@@ -801,11 +800,7 @@ def _new_upload(
                     yield skip_file("failed to extract metadata: %s" % str(exc))
                     return
             else:
-                # We need to convert to a `dict` this way instead of with
-                # `.dict()` so that enums will be converted to strings.
-                metadata = json.loads(
-                    asset_metadata.json(exclude_unset=True, exclude_none=True)
-                )
+                metadata = asset_metadata.asdict()
 
             #
             # Upload file

--- a/dandi/upload.py
+++ b/dandi/upload.py
@@ -800,7 +800,7 @@ def _new_upload(
                     yield skip_file("failed to extract metadata: %s" % str(exc))
                     return
             else:
-                metadata = asset_metadata.asdict()
+                metadata = asset_metadata.json_dict()
 
             #
             # Upload file


### PR DESCRIPTION
Since it seems we're going to be doing this sort of conversion frequently, this PR adds a method to `CommonModel` for recursively converting to a `dict` while also converting enum values to strings.