### PR TITLE
ENH: upload: --existing=overwrite-metadata to upload fresh metadata even if file already there

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -72,6 +72,9 @@ development command line options.
   new set on each run.  Set this environment variable to `0` to cause the
   containers to be destroyed at the end of the next run.
 
+- `DANDI_UPLOAD_SAME_MUST_EXIST` -- primarily for internal use with
+ `--existing=overwrite-metadata` so we do not upload some outdated file.
+
 ## Sourcegraph
 
 The [Sourcegraph](https://sourcegraph.com) browser extension can be used to

--- a/dandi/cli/cmd_upload.py
+++ b/dandi/cli/cmd_upload.py
@@ -18,11 +18,14 @@ from ..consts import collection_drafts
 @click.option(
     "-e",
     "--existing",
-    type=click.Choice(["error", "skip", "force", "overwrite", "refresh"]),
+    type=click.Choice(
+        ["error", "skip", "force", "overwrite", "overwrite-metadata", "refresh"]
+    ),
     help="What to do if a file found existing on the server. 'skip' would skip"
     "the file, 'force' - force reupload, 'overwrite' - force upload if "
-    "either size or modification time differs; 'refresh' - upload only if "
-    "local modification time is ahead of the remote.",
+    "either size or modification time differs; 'overwrite-metadata' - like 'overwrite' "
+    "but would still upload metadata record; 'refresh' - upload only if local modification "
+    "time is ahead of the remote.",
     default="refresh",
     show_default=True,
 )

--- a/dandi/upload.py
+++ b/dandi/upload.py
@@ -376,6 +376,15 @@ def upload(
 
                 yield {"message": exists_msg + " - reuploading"}
 
+            # For "internal" use -- primarily for use with existing == "overwrite-metadata"
+            if os.environ.get("DANDI_UPLOAD_SAME_MUST_EXIST"):
+                if not file_recs:
+                    yield skip_file("File does not exist!")
+                    return
+                if remote_file_status != "same":
+                    yield skip_file("File is not the same!")
+                    return
+
             #
             # 4. Extract metadata - delayed since takes time, but is done
             #    before actual upload, so we could skip if this fails
@@ -687,6 +696,10 @@ def _new_upload(
     if existing == "overwrite-metadata":
         raise NotImplementedError(
             "No existing=overwrite-metadata for new dandi-api version (yet)"
+        )
+    if os.environ.get("DANDI_UPLOAD_SAME_MUST_EXIST"):
+        raise NotImplementedError(
+            "Not DANDI_UPLOAD_SAME_MUST_EXIST in new dandi-api version (yet)"
         )
 
     # TODO: we might want to always yield a full record so no field is not


### PR DESCRIPTION
To facilitate cases where we want to ask users to reupload while using newer dandi-cli which would extract metadata differently

Closes #105 

TODOs:
- [x] Development safeguard (`DANDI_UPLOAD_SAME_MUST_EXIST` env var) for paranoids so if we operate under assumption that we have up to date local data files, we do not mistakenly reupload (outdated) data.
- [ ] test on sample cases to verify correct operation (see e.g. #349 as one of the target use cases)