### PR TITLE
Add dandiset ID override for upload

### DIFF
--- a/dandi/cli/cmd_upload.py
+++ b/dandi/cli/cmd_upload.py
@@ -39,6 +39,8 @@ from ..consts import collection_drafts
 #
 # TODO: should always go to dandi for now
 @instance_option()
+# TODO remove this once migration is complete
+@devel_option("-d", "--identifier", help="Override the identifier in dandiset.yaml")
 # TODO: should always go into 'drafts' (consts.collection_drafts)
 @devel_option(
     "-c", "--girder-collection", help="For development: Girder collection to upload to"
@@ -72,6 +74,8 @@ def upload(
     validation="require",
     dandiset_path=None,
     # Development options should come as kwargs
+    # TODO remove this once migration is complete
+    identifier=None,
     girder_collection=collection_drafts,
     girder_top_folder=None,
     dandi_instance="dandi",
@@ -100,6 +104,8 @@ def upload(
         existing=existing,
         validation=validation,
         dandiset_path=dandiset_path,
+        # TODO remove this once migration is complete
+        identifier=identifier,
         girder_collection=girder_collection,
         girder_top_folder=girder_top_folder,
         dandi_instance=dandi_instance,

--- a/dandi/upload.py
+++ b/dandi/upload.py
@@ -776,7 +776,7 @@ def _new_upload(
                 if upload_dandiset_metadata:
                     yield {"status": "updating metadata"}
                     client.set_dandiset_metadata(
-                        dandiset.identifier, metadata=dandiset.metadata
+                        ds_identifier, metadata=dandiset.metadata
                     )
                     yield {"status": "updated metadata"}
                 else:

--- a/dandi/upload.py
+++ b/dandi/upload.py
@@ -23,6 +23,8 @@ def upload(
     existing="refresh",
     validation="require",
     dandiset_path=None,
+    # TODO remove this once migration is complete
+    identifier=None,
     girder_collection=collection_drafts,
     girder_top_folder=None,
     dandi_instance="dandi",
@@ -58,6 +60,8 @@ def upload(
             allow_any_path,
             upload_dandiset_metadata,
             devel_debug,
+            # TODO remove this once migration is complete
+            identifier,
         )
 
     if upload_dandiset_metadata:
@@ -608,6 +612,8 @@ def _new_upload(
     allow_any_path,
     upload_dandiset_metadata,
     devel_debug,
+    # TODO remove this once migration is complete
+    identifier,
 ):
     from .dandiapi import DandiAPIClient
     from .dandiset import APIDandiset
@@ -618,7 +624,8 @@ def _new_upload(
 
     dandiset = APIDandiset(dandiset.path)  # "cast" to a new API based dandiset
 
-    ds_identifier = dandiset.identifier
+    # TODO remove this once migration is complete
+    ds_identifier = identifier or dandiset.identifier
     # this is a path not a girder id
 
     if not re.match(dandiset_identifier_regex, str(ds_identifier)):


### PR DESCRIPTION
With DANDI_DEVEL on, you can now specify `-d 123456` to upload the
dandiset directly to dandiset `123456`, regardless of the contents of
`dandiset.yaml`. This makes migrating dandisets easier, as the API
server does not have a way to create a dandiset with a given identifier.

I tested this with:
```
dandi download https://dandiarchive.org/dandiset/000027/draft
cd 000027
dandi upload -i dandi-api --validation ignore --allow-any-path --upload-dandiset-metadata -d 001001
```

You can see that https://gui-beta-dandiarchive-org.netlify.app/#/dandiset/001001 now contains 18.35 KB worth of files, exactly the size of dandiset 000027.

Running the `map_ids` script will not work at the moment because dandiset 000027 specifies the identifier as "DANDI:000027" in the metadata which the script does not support, but we're one step closer.