### PR TITLE
RF/NF: Identifiable and BareAssetMeta to describe an asset anywhere

### DIFF
--- a/dandi/metadata.py
+++ b/dandi/metadata.py
@@ -3,7 +3,7 @@ import json
 import os.path as op
 from pathlib import Path
 import re
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 import jsonschema
 
@@ -270,13 +270,6 @@ def extract_digest(metadata):
         return ...
 
 
-def extract_identifier(metadata):
-    try:
-        return UUID(metadata["identifier"])
-    except Exception:
-        return ...
-
-
 FIELD_EXTRACTORS = {
     "wasDerivedFrom": extract_wasDerivedFrom,
     "wasAttributedTo": extract_wasAttributedTo,
@@ -286,7 +279,6 @@ FIELD_EXTRACTORS = {
     "anatomy": extract_anatomy,
     "digest": extract_digest,
     "species": extract_species,
-    "identifier": extract_identifier,
 }
 
 
@@ -327,7 +319,7 @@ def nwb2asset(nwb_path, digest=None, digest_type=None):
 
 
 def metadata2asset(metadata):
-    return extract_model(models.AssetMeta, metadata)
+    return extract_model(models.BareAssetMeta, metadata)
 
 
 """

--- a/dandi/models.py
+++ b/dandi/models.py
@@ -792,6 +792,12 @@ class BareAssetMeta(CommonModel):
         None, description="Participant(s) to which this file belongs to", nskey="prov"
     )
 
+    _ldmeta = {
+        "rdfs:subClassOf": ["schema:CreativeWork", "prov:Entity"],
+        "rdfs:label": "Information about the asset",
+        "nskey": "dandi",
+    }
+
 
 class AssetMeta(BareAssetMeta, Identifiable):
     """Metadata used to describe an asset on the server.
@@ -802,12 +808,6 @@ class AssetMeta(BareAssetMeta, Identifiable):
 
     # on publish or set by server
     contentUrl: Optional[List[HttpUrl]] = Field(None, readOnly=True, nskey="schema")
-
-    _ldmeta = {
-        "rdfs:subClassOf": ["schema:CreativeWork", "prov:Entity"],
-        "rdfs:label": "Information about the asset",
-        "nskey": "dandi",
-    }
 
 
 class PublishedAssetMeta(AssetMeta):

--- a/dandi/models.py
+++ b/dandi/models.py
@@ -599,9 +599,12 @@ class Project(Activity):
     )
 
 
+class Identifiable(DandiBaseModel):
+    identifier: Identifier = Field(readOnly=True, nskey="schema")
+
+
 class CommonModel(DandiBaseModel):
     schemaVersion: str = Field(default="1.0.0-rc1", readOnly=True, nskey="schema")
-    identifier: Identifier = Field(readOnly=True, nskey="schema")
     name: Optional[str] = Field(
         None,
         title="Title",
@@ -670,7 +673,7 @@ class CommonModel(DandiBaseModel):
         return json.loads(self.json(exclude_unset=True, exclude_none=True))
 
 
-class DandiMeta(CommonModel):
+class DandiMeta(CommonModel, Identifiable):
     """A body of structured information describing a DANDI dataset."""
 
     @validator("contributor")
@@ -748,13 +751,11 @@ class PublishedDandiMeta(DandiMeta):
     datePublished: date = Field(readOnly=True, nskey="schema")
 
 
-class AssetMeta(CommonModel):
-    """Metadata used to describe an asset.
+class BareAssetMeta(CommonModel):
+    """Metadata used to describe an asset anywhere (local or server).
 
     Derived from C2M2 (Level 0 and 1) and schema.org
     """
-
-    identifier: UUID4 = Field(readOnly=True, nskey="schema")
 
     # Overrides CommonModel.license
     # TODO: https://github.com/NeurodataWithoutBorders/nwb-schema/issues/320
@@ -790,6 +791,14 @@ class AssetMeta(CommonModel):
     wasAttributedTo: List[Participant] = Field(
         None, description="Participant(s) to which this file belongs to", nskey="prov"
     )
+
+
+class AssetMeta(BareAssetMeta, Identifiable):
+    """Metadata used to describe an asset on the server.
+
+    """
+
+    identifier: UUID4 = Field(readOnly=True, nskey="schema")
 
     # on publish or set by server
     contentUrl: Optional[List[HttpUrl]] = Field(None, readOnly=True, nskey="schema")

--- a/dandi/tests/test_metadata.py
+++ b/dandi/tests/test_metadata.py
@@ -13,7 +13,7 @@ from ..metadata import (
     validate_asset_json,
     validate_dandiset_json,
 )
-from ..models import AssetMeta, DandiMeta
+from ..models import BareAssetMeta, DandiMeta
 
 
 @pytest.fixture(scope="module")
@@ -149,7 +149,7 @@ def test_metadata2asset(schema_dir):
   ]
 }"""
     data_as_dict = json.loads(json_data)
-    assert data == AssetMeta(**data_as_dict)
+    assert data == BareAssetMeta(**data_as_dict)
     validate_asset_json(data_as_dict, schema_dir)
 
 
@@ -211,7 +211,7 @@ def test_metadata2asset_simple1(schema_dir):
   "wasAttributedTo": []
 }"""
     data_as_dict = json.loads(json_data)
-    assert data == AssetMeta(**data_as_dict)
+    assert data == BareAssetMeta(**data_as_dict)
     validate_asset_json(data_as_dict, schema_dir)
 
 

--- a/dandi/validate.py
+++ b/dandi/validate.py
@@ -89,11 +89,11 @@ def validate_dandi_nwb(filepath, schema_version=None):
         from pydantic import ValidationError
 
         from .metadata import nwb2asset
-        from .models import AssetMeta
+        from .models import BareAssetMeta
 
         try:
             asset = nwb2asset(filepath, digest="dummy_value", digest_type="sha1")
-            AssetMeta(**asset.dict())
+            BareAssetMeta(**asset.dict())
         except ValidationError as e:
             return [str(e)]
         except Exception as e:


### PR DESCRIPTION
Identifiable is a mix-in class for anything with an identifier.
It is "extracted" from the CommonModel since we might not have identifiers defined locally.

BareAssetMeta provides a base class to AssetMeta which could then be populated only on the server side.

This PR is more of an experiment as a possible solution to #369 .  In converted schema it should all still look the same (didn't check though), may be only for some reordering of keys within schema.
