### PR TITLE
Discard invalid asset identifiers when extracting metadata

### DIFF
--- a/dandi/metadata.py
+++ b/dandi/metadata.py
@@ -271,7 +271,10 @@ def extract_digest(metadata):
 
 
 def extract_identifier(metadata):
-    return UUID(metadata["identifier"])
+    try:
+        return UUID(metadata["identifier"])
+    except Exception:
+        return ...
 
 
 FIELD_EXTRACTORS = {


### PR DESCRIPTION
Fixes #370.