### PR TITLE
List extra auto labels in DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -118,3 +118,6 @@ organized by label.  `auto` recognizes the following PR labels:
   component; this is the default label for unlabelled PRs
 - `internal` — for changes only affecting the internal API
 - `documentation` — for changes only affecting the documentation
+- `tests` — for changes to tests
+- `dependencies` — for updates to dependency versions
+- `performance` — for performance improvements


### PR DESCRIPTION
These labels are not listed in auto's documentation, but they are still recognized & used, as can be seen by dumping a repository's auto config with `auto info -v`.