### PR TITLE
Make `dandi download -i <instance>` run in a Dandiset download that Dandiset

### DIFF
--- a/dandi/cli/tests/test_download.py
+++ b/dandi/cli/tests/test_download.py
@@ -1,9 +1,12 @@
 import os
+from pathlib import Path
 
 import click
 from click.testing import CliRunner
+import pytest
 
 from ..command import download
+from ...consts import dandiset_metadata_file
 
 
 def test_download_defaults(mocker):
@@ -72,4 +75,90 @@ def test_download_bad_type(mocker):
     assert r.exit_code != 0
     assert isinstance(r.exception, click.UsageError)
     assert str(r.exception) == "'foo': invalid value"
+    mock_download.assert_not_called()
+
+
+@pytest.mark.skipif(
+    not os.environ.get("DANDI_DEVEL"), reason="DANDI_DEVEL required to run"
+)
+def test_download_gui_instance_in_dandiset(mocker):
+    mock_download = mocker.patch("dandi.download.download")
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path(dandiset_metadata_file).write_text("identifier: '123456'\n")
+        r = runner.invoke(download, ["-i", "dandi"])
+    assert r.exit_code == 0
+    mock_download.assert_called_once_with(
+        ["https://gui.dandiarchive.org/#/dandiset/123456/draft"],
+        os.curdir,
+        existing="refresh",
+        format="pyout",
+        jobs=6,
+        get_metadata=True,
+        get_assets=True,
+    )
+
+
+@pytest.mark.skipif(
+    not os.environ.get("DANDI_DEVEL"), reason="DANDI_DEVEL required to run"
+)
+def test_download_api_instance_in_dandiset(mocker):
+    mock_download = mocker.patch("dandi.download.download")
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path(dandiset_metadata_file).write_text("identifier: '123456'\n")
+        r = runner.invoke(download, ["-i", "dandi-api-local-docker-tests"])
+    assert r.exit_code == 0
+    mock_download.assert_called_once_with(
+        ["http://localhost:8000/api/dandisets/123456/"],
+        os.curdir,
+        existing="refresh",
+        format="pyout",
+        jobs=6,
+        get_metadata=True,
+        get_assets=True,
+    )
+
+
+@pytest.mark.skipif(
+    not os.environ.get("DANDI_DEVEL"), reason="DANDI_DEVEL required to run"
+)
+def test_download_url_instance_match(mocker):
+    mock_download = mocker.patch("dandi.download.download")
+    r = CliRunner().invoke(
+        download,
+        [
+            "-i",
+            "dandi-api-local-docker-tests",
+            "http://localhost:8000/api/dandisets/123456/",
+        ],
+    )
+    assert r.exit_code == 0
+    mock_download.assert_called_once_with(
+        ("http://localhost:8000/api/dandisets/123456/",),
+        os.curdir,
+        existing="refresh",
+        format="pyout",
+        jobs=6,
+        get_metadata=True,
+        get_assets=True,
+    )
+
+
+@pytest.mark.skipif(
+    not os.environ.get("DANDI_DEVEL"), reason="DANDI_DEVEL required to run"
+)
+def test_download_url_instance_conflict(mocker):
+    mock_download = mocker.patch("dandi.download.download")
+    r = CliRunner().invoke(
+        download,
+        ["-i", "dandi", "http://localhost:8000/api/dandisets/123456/"],
+        standalone_mode=False,
+    )
+    assert r.exit_code != 0
+    assert isinstance(r.exception, click.UsageError)
+    assert (
+        str(r.exception)
+        == "http://localhost:8000/api/dandisets/123456/ does not point to 'dandi' instance"
+    )
     mock_download.assert_not_called()


### PR DESCRIPTION
Closes #153.

Note that the tests for this change must be run with `DANDI_DEVEL=1`, which also enables `test_enormous_upload_breaks_girder`.  As a result, the new tests are not run under CI.