### PR TITLE
Use iter_content() instead of raw.stream()

### DIFF
--- a/dandi/dandiapi.py
+++ b/dandi/dandiapi.py
@@ -330,7 +330,7 @@ class DandiAPIClient(RESTFullAPIClient):
             # if result.status_code not in (200, 201):
             result.raise_for_status()
 
-            for chunk in result.raw.stream(chunk_size, decode_content=False):
+            for chunk in result.iter_content(chunk_size=chunk_size):
                 if chunk:  # could be some "keep alive"?
                     yield chunk
             lgr.info("Asset %s successfully downloaded", uuid)


### PR DESCRIPTION
I believe that `iter_content()` is the preferred way to iterate over a streaming `requests.Response`.  Note that this comes with a slight change in behavior, as `iter_content()` calls `raw.stream()` with `decode_content=True`, which causes Content-Encodings to be decoded, which I believe is the correct thing to do.