### PR TITLE
Report dandi version in User-Agent header

### DIFF
--- a/dandi/dandiapi.py
+++ b/dandi/dandiapi.py
@@ -8,6 +8,7 @@ import requests
 from .consts import MAX_CHUNK_SIZE, known_instances_rev
 from .girder import keyring_lookup
 from . import get_logger
+from .utils import USER_AGENT
 
 lgr = get_logger()
 
@@ -21,7 +22,7 @@ class RESTFullAPIClient(object):
     def __init__(self, api_url):
         self.api_url = api_url
         self._session = None
-        self._headers = {}
+        self._headers = {"User-Agent": USER_AGENT}
 
     @contextmanager
     def session(self, session=None):

--- a/dandi/utils.py
+++ b/dandi/utils.py
@@ -42,6 +42,13 @@ on_msys_tainted_paths = (
     and os.environ.get("MSYSTEM", "")[:4] in ("MSYS", "MING")
 )
 
+USER_AGENT = "dandi/{} requests/{} {}/{}".format(
+    __version__,
+    requests.__version__,
+    platform.python_implementation(),
+    platform.python_version(),
+)
+
 
 def is_interactive():
     """Return True if all in/outs are tty"""


### PR DESCRIPTION
This PR sets a User-Agent header when communicating with the new API that contains the version of dandi in use.