### PR TITLE
Remove misleading log message about authenticating with new API

### DIFF
--- a/dandi/dandiapi.py
+++ b/dandi/dandiapi.py
@@ -235,7 +235,6 @@ class DandiAPIClient(RESTFullAPIClient):
         api_key = os.environ.get("DANDI_API_KEY", None)
         if api_key:
             self.authenticate(api_key)
-            lgr.debug("Successfully authenticated using the key from the envvar")
             return
         if self.api_url in known_instances_rev:
             client_name = known_instances_rev[self.api_url]


### PR DESCRIPTION
Due to too much copy & paste, dandi currently logs "Successfully authenticated using the key from the envvar" after setting the authentication token to the new API to a value obtained from the environment.  This is misleading, as no authentication step is actually performed or can be performed with the new API, and so this PR removes that message.  (If we wanted to, we could probably check token validity with a request to `/users/me/`, but that seems a little bit wasteful, especially considering the token can be expected to be used for actualy requests right after anyway.)