### PR TITLE
Set DJANGO_DANDI_SCHEMA_VERSION in docker-compose.yml

### DIFF
--- a/dandi/tests/data/dandiarchive-docker/docker-compose.yml
+++ b/dandi/tests/data/dandiarchive-docker/docker-compose.yml
@@ -75,6 +75,7 @@ services:
       DJANGO_MINIO_STORAGE_SECRET_KEY: minioSecretKey
       DJANGO_STORAGE_BUCKET_NAME: django-storage
       DJANGO_MINIO_STORAGE_MEDIA_URL: http://localhost:9000/django-storage
+      DJANGO_DANDI_SCHEMA_VERSION: 1.0.0-rc1
     ports:
       - "8000:8000"
 
@@ -108,6 +109,7 @@ services:
       DJANGO_MINIO_STORAGE_SECRET_KEY: minioSecretKey
       DJANGO_STORAGE_BUCKET_NAME: django-storage
       DJANGO_MINIO_STORAGE_MEDIA_URL: http://localhost:9000/django-storage
+      DJANGO_DANDI_SCHEMA_VERSION: 1.0.0-rc1
 
   minio:
     image: minio/minio:latest


### PR DESCRIPTION
As of https://github.com/dandi/dandi-api/pull/83, the dandi-api Django setup requires the `DJANGO_DANDI_SCHEMA_VERSION` environment variable to be set in order to run; without it, our tests fail.