### PR TITLE
fix: change enum to const for single enums

### DIFF
--- a/dandi/models.py
+++ b/dandi/models.py
@@ -172,6 +172,13 @@ class DandiBaseModel(BaseModel):
                         and any(["$ref" in val for val in anyOf])
                     ):
                         value["items"]["type"] = "object"
+                # In pydantic 1.8+ all Literals are mapped on to enum
+                # This presently breaks the schema editor UI. Revert
+                # to const when generating the schema.
+                if prop == "schemaKey":
+                    if len(value["enum"]) == 1:
+                        value["const"] = value["enum"][0]
+                        del value["enum"]
 
 
 class PropertyValue(DandiBaseModel):


### PR DESCRIPTION
This should address the change to using `Enum` for `Literal` in pydantic 1.8+. This reverts the schema generation to use `const`. This change can be reverted once https://github.com/koumoul-dev/vuetify-jsonschema-form/issues/212 is addressed.