### PR TITLE
BF: Require pydantic >= 1.8.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
     keyring
     keyrings.alt
     pycryptodomex  # for EncryptedKeyring backend in keyrings.alt
-    pydantic
+    pydantic >= 1.8.1
     pynwb >= 1.0.3,!=1.1.0
     pyout >=0.5, !=0.6.0
     python-dateutil


### PR DESCRIPTION
May be some other release could be fine as well, but with 1.7.3
I do have tests erroring out with

    (git)lena:~/proj/dandi/dandi-cli-master[master]git
    $> python -m pytest -s -v dandi/tests/test_models.py::test_autogenerated_titles
    ============================================================================ test session starts ============================================================================
    platform linux -- Python 3.9.1, pytest-6.2.2, py-1.9.0, pluggy-0.13.0 -- /home/yoh/proj/dandi/dandi-cli-master/venvs/dev3/bin/python
    cachedir: .pytest_cache
    hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/home/yoh/proj/dandi/dandi-cli-master/.hypothesis/examples')
    rootdir: /home/yoh/proj/dandi/dandi-cli-master, configfile: tox.ini
    plugins: mock-3.5.1, pyfakefs-4.1.0, forked-1.3.0, timeout-1.4.1, xdist-1.32.0, hypothesis-5.41.2, xonsh-0.9.24
    collected 1 item

    dandi/tests/test_models.py::test_autogenerated_titles FAILED

    ================================================================================= FAILURES ==================================================================================
    _________________________________________________________________________ test_autogenerated_titles _________________________________________________________________________
    dandi/tests/test_models.py:150: in test_autogenerated_titles
        schema = AssetMeta.schema()
    pydantic/main.py:642: in pydantic.main.BaseModel.schema
        ???
    pydantic/schema.py:153: in pydantic.schema.model_schema
        ???
    pydantic/schema.py:525: in pydantic.schema.model_process_schema
        ???
    pydantic/schema.py:566: in pydantic.schema.model_type_schema
        ???
    pydantic/schema.py:222: in pydantic.schema.field_schema
        ???
    pydantic/schema.py:421: in pydantic.schema.field_type_schema
        ???
    pydantic/schema.py:751: in pydantic.schema.field_singleton_schema
        ???
    pydantic/schema.py:645: in pydantic.schema.field_singleton_sub_fields_schema
        ???
    pydantic/schema.py:476: in pydantic.schema.field_type_schema
        ???
    pydantic/schema.py:751: in pydantic.schema.field_singleton_schema
        ???
    pydantic/schema.py:657: in pydantic.schema.field_singleton_sub_fields_schema
        ???
    pydantic/schema.py:476: in pydantic.schema.field_type_schema
        ???
    pydantic/schema.py:805: in pydantic.schema.field_singleton_schema
        ???
    pydantic/schema.py:525: in pydantic.schema.model_process_schema
        ???
    pydantic/schema.py:566: in pydantic.schema.model_type_schema
        ???
    pydantic/schema.py:222: in pydantic.schema.field_schema
        ???
    pydantic/schema.py:421: in pydantic.schema.field_type_schema
        ???
    pydantic/schema.py:751: in pydantic.schema.field_singleton_schema
        ???
    pydantic/schema.py:645: in pydantic.schema.field_singleton_sub_fields_schema
        ???
    pydantic/schema.py:476: in pydantic.schema.field_type_schema
        ???
    pydantic/schema.py:805: in pydantic.schema.field_singleton_schema
        ???
    pydantic/schema.py:525: in pydantic.schema.model_process_schema
        ???
    pydantic/schema.py:566: in pydantic.schema.model_type_schema
        ???
    pydantic/schema.py:222: in pydantic.schema.field_schema
        ???
    pydantic/schema.py:421: in pydantic.schema.field_type_schema
        ???
    pydantic/schema.py:751: in pydantic.schema.field_singleton_schema
        ???
    pydantic/schema.py:645: in pydantic.schema.field_singleton_sub_fields_schema
        ???
    pydantic/schema.py:476: in pydantic.schema.field_type_schema
        ???
    pydantic/schema.py:805: in pydantic.schema.field_singleton_schema
        ???
    pydantic/schema.py:539: in pydantic.schema.model_process_schema
        ???
    dandi/models.py:179: in schema_extra
        if len(value["enum"]) == 1:
    E   KeyError: 'enum'