### PR TITLE
Show digest progress when uploading

### DIFF
--- a/dandi/dandiapi.py
+++ b/dandi/dandiapi.py
@@ -464,7 +464,7 @@ class DandiAPIClient(RESTFullAPIClient):
                         bytes_uploaded += len(chunk)
                         yield {
                             "status": "uploading",
-                            "upload": 100 * bytes_uploaded / total_size,
+                            "pct": 100 * bytes_uploaded / total_size,
                             "current": bytes_uploaded,
                         }
                         parts_out.append(

--- a/dandi/dandiapi.py
+++ b/dandi/dandiapi.py
@@ -464,7 +464,7 @@ class DandiAPIClient(RESTFullAPIClient):
                         bytes_uploaded += len(chunk)
                         yield {
                             "status": "uploading",
-                            "pct": 100 * bytes_uploaded / total_size,
+                            "upload": 100 * bytes_uploaded / total_size,
                             "current": bytes_uploaded,
                         }
                         parts_out.append(

--- a/dandi/support/digests.py
+++ b/dandi/support/digests.py
@@ -94,8 +94,7 @@ class Digester(object):
 
 class DigestProgress(TypedDict, total=False):
     status: str
-    size: int
-    pct: float
+    #size: int
     digests: Dict[str, str]
 
 
@@ -144,10 +143,10 @@ def get_progressive_digests(
                 for d in digestions:
                     d.update(block)
                 current += len(block)
+                pct = 100 * current / total_size
                 yield {
-                    "status": "digesting",
-                    "size": current,
-                    "pct": 100 * current / total_size,
+                    "status": f"digesting ({pct:.2f}%)",
+                    #"size": current,
                 }
         digested = {n: d.hexdigest() for n, d in zip(digest_tuple, digestions)}
         # Calculate the key again just in case:

--- a/dandi/support/digests.py
+++ b/dandi/support/digests.py
@@ -11,12 +11,34 @@
 
 import hashlib
 import logging
+import os
+import os.path
+import sys
+from typing import Dict, Iterable, Optional, Tuple
 
-from fscacher import PersistentCache
+import appdirs
+from diskcache import FanoutCache
 
-from ..utils import auto_repr
+from ..utils import AnyPath, auto_repr
+
+if sys.version_info < (3, 8):
+    from typing_extensions import TypedDict
+else:
+    from typing import TypedDict
 
 lgr = logging.getLogger("dandi.support.digests")
+
+# This is the default number of workers for
+# concurrent.futures.ThreadPoolExecutor (as of Python 3.8) and pyout, which
+# means it's also the number of concurrent uploads/downloads dandi performs at
+# once.
+SHARD_QTY = min(32, os.cpu_count() + 4)
+
+CACHE_DIR = os.path.join(appdirs.user_cache_dir("dandi", "dandi"), "digests")
+
+DEFAULT_DIGESTS = ["md5", "sha1", "sha256", "sha512"]
+
+DEFAULT_BLOCKSIZE = 1 << 16
 
 
 @auto_repr
@@ -29,9 +51,7 @@ class Digester(object):
     # Ideally we should find an efficient way to parallelize this but
     # atm this one is sufficiently speedy
 
-    DEFAULT_DIGESTS = ["md5", "sha1", "sha256", "sha512"]
-
-    def __init__(self, digests=None, blocksize=1 << 16):
+    def __init__(self, digests=None, blocksize=DEFAULT_BLOCKSIZE):
         """
         Parameters
         ----------
@@ -42,7 +62,7 @@ class Digester(object):
         blocksize : int
           Chunk size (in bytes) by which to consume a file.
         """
-        self._digests = digests or self.DEFAULT_DIGESTS
+        self._digests = digests or DEFAULT_DIGESTS
         self._digest_funcs = [getattr(hashlib, digest) for digest in self._digests]
         self.blocksize = blocksize
 
@@ -72,9 +92,82 @@ class Digester(object):
         return {n: d.hexdigest() for n, d in zip(self.digests, digests)}
 
 
-checksums = PersistentCache(name="dandi-checksums", envvar="DANDI_CACHE")
+class DigestProgress(TypedDict, total=False):
+    status: str
+    size: int
+    current: int
+    pct: float
+    digests: Dict[str, str]
 
 
-@checksums.memoize_path
-def get_digest(filepath, digest="sha256"):
-    return Digester([digest])(filepath)[digest]
+digest_cache = FanoutCache(
+    directory=CACHE_DIR, shards=SHARD_QTY, eviction_policy="least-recently-used"
+)
+
+
+def get_progressive_digests(
+    path: AnyPath,
+    digests: Optional[Iterable[str]] = None,
+    blocksize: int = DEFAULT_BLOCKSIZE,
+) -> Iterable[DigestProgress]:
+    if not os.path.isfile(path):
+        raise ValueError(f"{os.fsdecode(path)}: Cannot hash a directory")
+    if digests is None:
+        digests = DEFAULT_DIGESTS
+    digest_tuple = tuple(sorted(digests))
+    if not digest_tuple:
+        raise ValueError("No digests specified")
+
+    def mkkey() -> Tuple[str, Tuple[str, ...], int, int, int, int]:
+        pathstr = os.path.realpath(os.fsdecode(path))
+        s = os.stat(pathstr)
+        return (
+            pathstr,
+            digest_tuple,
+            s.st_mtime_ns,
+            s.st_ctime_ns,
+            s.st_size,
+            s.st_ino,
+        )
+
+    try:
+        digested = digest_cache[mkkey()]
+    except KeyError:
+        lgr.debug("Digesting %s", path)
+        digestions = [getattr(hashlib, d)() for d in digest_tuple]
+        size = os.path.getsize(path)
+        current = 0
+        with open(path, "rb") as f:
+            while True:
+                block = f.read(blocksize)
+                if not block:
+                    break
+                for d in digestions:
+                    d.update(block)
+                current += len(block)
+                yield {
+                    "status": "digesting",
+                    "size": size,
+                    "current": current,
+                    "pct": 100 * current / size,
+                }
+        digested = {n: d.hexdigest() for n, d in zip(digest_tuple, digestions)}
+        # Calculate the key again just in case:
+        digest_cache[mkkey()] = digested
+    else:
+        lgr.debug("Digests for %s found in cache", path)
+    yield {"status": "digested", "digests": digested}
+
+
+def get_digests(
+    path: AnyPath,
+    digests: Optional[Iterable[str]] = None,
+    blocksize: int = DEFAULT_BLOCKSIZE,
+) -> Dict[str, str]:
+    for status in get_progressive_digests(path, digests, blocksize):
+        if status["status"] == "digested":
+            return status["digests"]
+
+
+def get_digest(path, digest="sha256"):
+    return get_digests(path)[digest]

--- a/dandi/support/digests.py
+++ b/dandi/support/digests.py
@@ -34,7 +34,7 @@ lgr = logging.getLogger("dandi.support.digests")
 # once.
 SHARD_QTY = min(32, os.cpu_count() + 4)
 
-CACHE_DIR = os.path.join(appdirs.user_cache_dir("dandi", "dandi"), "digests")
+CACHE_DIR = os.path.join(appdirs.user_cache_dir("dandi-cli", "dandi"), "digests")
 
 DEFAULT_DIGESTS = ["md5", "sha1", "sha256", "sha512"]
 

--- a/dandi/support/digests.py
+++ b/dandi/support/digests.py
@@ -95,7 +95,6 @@ class Digester(object):
 class DigestProgress(TypedDict, total=False):
     status: str
     size: int
-    current: int
     pct: float
     digests: Dict[str, str]
 
@@ -135,7 +134,7 @@ def get_progressive_digests(
     except KeyError:
         lgr.debug("Digesting %s", path)
         digestions = [getattr(hashlib, d)() for d in digest_tuple]
-        size = os.path.getsize(path)
+        total_size = os.path.getsize(path)
         current = 0
         with open(path, "rb") as f:
             while True:
@@ -147,9 +146,8 @@ def get_progressive_digests(
                 current += len(block)
                 yield {
                     "status": "digesting",
-                    "size": size,
-                    "current": current,
-                    "pct": 100 * current / size,
+                    "size": current,
+                    "pct": 100 * current / total_size,
                 }
         digested = {n: d.hexdigest() for n, d in zip(digest_tuple, digestions)}
         # Calculate the key again just in case:

--- a/dandi/support/digests.py
+++ b/dandi/support/digests.py
@@ -94,7 +94,7 @@ class Digester(object):
 
 class DigestProgress(TypedDict, total=False):
     status: str
-    #size: int
+    # size: int
     digests: Dict[str, str]
 
 
@@ -146,7 +146,7 @@ def get_progressive_digests(
                 pct = 100 * current / total_size
                 yield {
                     "status": f"digesting ({pct:.2f}%)",
-                    #"size": current,
+                    # "size": current,
                 }
         digested = {n: d.hexdigest() for n, d in zip(digest_tuple, digestions)}
         # Calculate the key again just in case:

--- a/dandi/support/pyout.py
+++ b/dandi/support/pyout.py
@@ -3,6 +3,7 @@
 from collections import Counter
 import datetime
 import logging
+import re
 import sys
 import time
 
@@ -55,6 +56,10 @@ def summary_dates(values):
 
 def counts(values):
     return ["{:d} {}".format(v, k) for k, v in Counter(values).items()]
+
+
+def counts_no_progress(values):
+    return counts(re.sub(r"\s+\(.+\)$", "", v) for v in values)
 
 
 def minmax(values, fmt="%s"):
@@ -166,7 +171,7 @@ def get_style(hide_if_missing=True):
         ),
         "status": dict(
             color=dict(lookup={"skipped": "yellow", "done": "green", "error": "red"}),
-            aggregate=counts,
+            aggregate=counts_no_progress,
         ),
         "message": dict(
             color=dict(

--- a/dandi/support/tests/test_digests.py
+++ b/dandi/support/tests/test_digests.py
@@ -7,7 +7,7 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-from ..digests import Digester
+from ..digests import Digester, get_digests
 
 
 def test_digester(tmp_path):
@@ -38,6 +38,41 @@ def test_digester(tmp_path):
     f = tmp_path / "long.txt"
     f.write_bytes(b"123abz\n" * 1000000)
     assert digester(f) == {
+        "md5": "81b196e3d8a1db4dd2e89faa39614396",
+        "sha1": "5273ac6247322c3c7b4735a6d19fd4a5366e812f",
+        "sha256": "80028815b3557e30d7cbef1d8dbc30af0ec0858eff34b960d2839fd88ad08871",
+        "sha512": "684d23393eee455f44c13ab00d062980937a5d040259d69c6b291c983bf6"
+        "35e1d405ff1dc2763e433d69b8f299b3f4da500663b813ce176a43e29ffc"
+        "c31b0159",
+    }
+
+
+def test_get_digests(tmp_path):
+    f = tmp_path / "sample.txt"
+    f.write_bytes(b"123")
+    assert get_digests(f) == {
+        "md5": "202cb962ac59075b964b07152d234b70",
+        "sha1": "40bd001563085fc35165329ea1ff5c5ecbdbbeef",
+        "sha256": "a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3",
+        "sha512": "3c9909afec25354d551dae21590bb26e38d53f2173b8d3dc3eee4c047e7a"
+        "b1c1eb8b85103e3be7ba613b31bb5c9c36214dc9f14a42fd7a2fdb84856b"
+        "ca5c44c2",
+    }
+
+    f = tmp_path / "0"
+    f.write_bytes(chr(0).encode())
+    assert get_digests(f) == {
+        "md5": "93b885adfe0da089cdf634904fd59f71",
+        "sha1": "5ba93c9db0cff93f52b521d7420e43f6eda2784f",
+        "sha256": "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
+        "sha512": "b8244d028981d693af7b456af8efa4cad63d282e19ff14942c246e50d935"
+        "1d22704a802a71c3580b6370de4ceb293c324a8423342557d4e5c38438f0"
+        "e36910ee",
+    }
+
+    f = tmp_path / "long.txt"
+    f.write_bytes(b"123abz\n" * 1000000)
+    assert get_digests(f) == {
         "md5": "81b196e3d8a1db4dd2e89faa39614396",
         "sha1": "5273ac6247322c3c7b4735a6d19fd4a5366e812f",
         "sha256": "80028815b3557e30d7cbef1d8dbc30af0ec0858eff34b960d2839fd88ad08871",

--- a/dandi/upload.py
+++ b/dandi/upload.py
@@ -705,9 +705,9 @@ def _new_upload(
             yield {"status": "digesting"}
             try:
                 for status in get_progressive_digests(path, ["sha256"]):
-                    yield status
                     if status["status"] == "digested":
-                        sha256_digest = status["digests"]["sha256"]
+                        sha256_digest = status.pop("digests")["sha256"]
+                    yield status
             except Exception as exc:
                 yield skip_file("failed to compute digests: %s" % str(exc))
                 return

--- a/dandi/upload.py
+++ b/dandi/upload.py
@@ -872,7 +872,7 @@ def _new_upload(
     pyout_style = pyouts.get_style(hide_if_missing=False)
     pyout_style["upload"]["aggregate"] = upload_agg
 
-    rec_fields = ["path", "size", "errors", "pct", "status", "message"]
+    rec_fields = ["path", "size", "errors", "upload", "status", "message"]
     out = pyouts.LogSafeTabular(style=pyout_style, columns=rec_fields)
 
     with out, client.session():

--- a/dandi/utils.py
+++ b/dandi/utils.py
@@ -11,6 +11,7 @@ import shutil
 import subprocess
 import sys
 from time import sleep
+from typing import Union
 
 import dateutil.parser
 import requests
@@ -48,6 +49,8 @@ USER_AGENT = "dandi/{} requests/{} {}/{}".format(
     platform.python_implementation(),
     platform.python_version(),
 )
+
+AnyPath = Union[str, bytes, "os.PathLike[str]", "os.PathLike[bytes]"]
 
 
 def is_interactive():

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     appdirs
     click
     click-didyoumean
+    diskcache
     email-validator
     etelemetry >= 0.2.0
     fasteners


### PR DESCRIPTION
Closes #400.

Caveats:

* This means a new cache, so `populate_dandiset_asset_yamls.py` will take 25+ hours the first time it runs after merging this.
* Diskcache is backed by SQLite, which does not do well on NFS filesystems.