### PR TITLE
Only call logging.basicConfig() when used as a command

### DIFF
--- a/dandi/__init__.py
+++ b/dandi/__init__.py
@@ -41,7 +41,4 @@ def set_logger_level(lgr, level):
 
 
 lgr = get_logger()
-# Basic settings for output, for now just basic
 set_logger_level(lgr, os.environ.get("DANDI_LOG_LEVEL", logging.INFO))
-FORMAT = "%(asctime)-15s [%(levelname)8s] %(message)s"
-logging.basicConfig(format=FORMAT)

--- a/dandi/cli/command.py
+++ b/dandi/cli/command.py
@@ -84,6 +84,7 @@ def main(ctx, log_level, pdb=False):
 
     e.g. dandi upload --help
     """
+    logging.basicConfig(format="%(asctime)-15s [%(levelname)8s] %(message)s")
     set_logger_level(get_logger(), log_level)
 
     # Ensure that certain log messages are only sent to the log file, not the


### PR DESCRIPTION
Closes #466.