### PR TITLE
ENH: prototype for the DANDIEtag "digester"

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ Please see [DEVELOPMENT.md](./DEVELOPMENT.md) file.
 
 ## 3rd party components included
 
+### dandi/core/digests/dandietag.py
+
+From <https://github.com/girder/django-s3-file-field> as of v0.1.1-10-g829b9b0
+Copyright (c) 2019-2021 Kitware, Inc., Apache 2.0 license
+
 ### dandi/support/generatorify.py
 
 From https://github.com/eric-wieser/generatorify, as of 7bd759ecf88f836ece6cdbcf7ce1074260c0c5ef

--- a/dandi/core/__init__.py
+++ b/dandi/core/__init__.py
@@ -1,0 +1,3 @@
+"""
+Various functionality to constitute a stable core to be reused by other dandiarchive components.
+"""

--- a/dandi/core/digests/__init__.py
+++ b/dandi/core/digests/__init__.py
@@ -1,0 +1,3 @@
+"""
+Digest algorithms interfaces
+"""

--- a/dandi/core/digests/dandietag.py
+++ b/dandi/core/digests/dandietag.py
@@ -40,11 +40,11 @@ class DandiETag:
             self._part_sizes = self.gen_part_sizes(self._file_size)
         return self._part_sizes
 
-    def __str__(self) -> str:
+    def as_str(self) -> str:
         if len(self._md5_digests) != len(self._part_sizes):
-            # TODO: too harsh for __str__? just say "incomplete"?
-            raise RuntimeError(
-                f"Collected {len(self._md5_digests)} out of {len(self._part_sizes)}"
+            raise ValueError(
+                f"Cannot compute ETag with only {len(self._md5_digests)} out of"
+                f" {len(self._part_sizes)} parts collected"
             )
         parts_digest = md5(b"".join(self._md5_digests)).hexdigest()
         return f"{parts_digest}-{len(self._md5_digests)}"
@@ -89,8 +89,8 @@ class DandiETag:
         """Update etag with the new block of data"""
         if len(self._md5_digests) == self.part_sizes:
             raise RuntimeError(
-                f"Trying to update {self} with a new block having already"
-                f" processed {len(self._md5_digests)}"
+                "Trying to update DandiETag with a new block having already"
+                f" processed all {len(self._md5_digests)} parts"
             )
         self._md5_digests.append(md5(block).digest())
 
@@ -100,4 +100,4 @@ if __name__ == "__main__":
 
     print(f"Get {len(DandiETag.gen_part_sizes(tb(5)))} parts for 5TB file")
     for p in sys.argv[1:]:
-        print(f"{p}: {DandiETag.from_file(p)}")
+        print(f"{p}: {DandiETag.from_file(p).as_str()}")

--- a/dandi/core/digests/dandietag.py
+++ b/dandi/core/digests/dandietag.py
@@ -55,11 +55,7 @@ class PartGenerator:
         if math.ceil(file_size / part_size) >= cls.MAX_PARTS:
             part_size = math.ceil(file_size / cls.MAX_PARTS)
 
-        if part_size < cls.MIN_PART_SIZE:
-            part_size = cls.MIN_PART_SIZE
-
-        if part_size > cls.MAX_PART_SIZE:
-            part_size = cls.MAX_PART_SIZE
+        assert cls.MIN_PART_SIZE <= part_size <= cls.MAX_PART_SIZE
 
         part_qty, final_part_size = divmod(file_size, part_size)
         if final_part_size == 0:

--- a/dandi/core/digests/dandietag.py
+++ b/dandi/core/digests/dandietag.py
@@ -44,6 +44,9 @@ class PartGenerator:
     @classmethod
     def for_file_size(cls, file_size: int) -> "PartGenerator":
         """Method to calculate sequential part sizes given a file size"""
+        if file_size == 0:
+            return cls(0, 0, 0)
+
         part_size = mb(64)
 
         if file_size > tb(5):
@@ -75,7 +78,7 @@ class PartGenerator:
             return Part(
                 index, self.initial_part_size * (index - 1), self.initial_part_size
             )
-        elif index == self.part_qty:
+        elif 1 <= index == self.part_qty:
             return Part(
                 index, self.initial_part_size * (index - 1), self.final_part_size
             )
@@ -83,6 +86,8 @@ class PartGenerator:
             raise IndexError(index)
 
     def __iter__(self) -> Iterator[Part]:
+        if self.part_qty == 0:
+            return
         offset = 0
         for number in range(1, self.part_qty):
             yield Part(number, offset, self.initial_part_size)
@@ -161,9 +166,4 @@ class DandiETag:
 
     def update(self, block):
         """Update etag with the new block of data"""
-        if self.complete:
-            raise RuntimeError(
-                "Trying to update DandiETag with a new block having already"
-                f" processed all {self.part_qty} parts"
-            )
         self.add_next_digest(md5(block).digest())

--- a/dandi/core/digests/dandietag.py
+++ b/dandi/core/digests/dandietag.py
@@ -3,7 +3,7 @@ import math
 import os
 
 # from https://github.com/girder/django-s3-file-field/blob/master/s3_file_field/_multipart.py
-from typing import Iterator, List, Tuple
+from typing import Iterator, List, Optional, Tuple
 
 
 def mb(bytes_size: int) -> int:
@@ -25,16 +25,16 @@ class DANDIEtag(object):
 
     def __init__(self, file_size: int):
         self._file_size: int = file_size
-        self._part_sizes: Tuple[int] = None
+        self._part_sizes: Optional[Tuple[int, ...]] = None
         self._md5_digests: List[bytes] = []
 
     @property
-    def part_sizes(self) -> Tuple[int]:
+    def part_sizes(self) -> Tuple[int, ...]:
         if self._part_sizes is None:
             self._part_sizes = tuple(self.gen_part_sizes(self._file_size))
         return self._part_sizes
 
-    def __str__(self):
+    def __str__(self) -> str:
         if len(self._md5_digests) != len(self._part_sizes):
             # TODO: too harsh for __str__? just say "incomplete"?
             raise RuntimeError(
@@ -84,7 +84,7 @@ class DANDIEtag(object):
             remaining_file_size -= part_size
 
     @classmethod
-    def from_file(cls, path: str):
+    def from_file(cls, path: str) -> "DANDIEtag":
         etag = cls(file_size=os.path.getsize(path))
         with open(path, "rb") as f:
             for part in etag.part_sizes:

--- a/dandi/core/digests/dandietag.py
+++ b/dandi/core/digests/dandietag.py
@@ -165,11 +165,3 @@ class DandiETag:
                 f" processed all {self.part_qty} parts"
             )
         self.add_next_digest(md5(block).digest())
-
-
-if __name__ == "__main__":
-    import sys
-
-    print(f"Get {len(DandiETag.gen_part_sizes(tb(5)))} parts for 5TB file")
-    for p in sys.argv[1:]:
-        print(f"{p}: {DandiETag.from_file(p).as_str()}")

--- a/dandi/core/digests/dandietag.py
+++ b/dandi/core/digests/dandietag.py
@@ -18,8 +18,8 @@ def tb(bytes_size: int) -> int:
 
 
 class DandiETag:
-    REGEX = r"[0-9a-f]{32}-\d{1,4}"
-    MAX_STR_LENGTH = 37
+    REGEX = r"[0-9a-f]{32}-\d{1,5}"
+    MAX_STR_LENGTH = 38
 
     # S3 multipart limits: https://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html
     # 10k is the maximum number of allowed parts allowed by S3

--- a/dandi/core/digests/dandietag.py
+++ b/dandi/core/digests/dandietag.py
@@ -2,7 +2,7 @@
 from hashlib import md5
 import math
 import os
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 
 def mb(bytes_size: int) -> int:
@@ -76,7 +76,9 @@ class DandiETag:
         return tuple(sizes)
 
     @classmethod
-    def from_file(cls, path: str) -> "DandiETag":
+    def from_file(
+        cls, path: Union[str, bytes, "os.PathLike[str]", "os.PathLike[bytes]"]
+    ) -> "DandiETag":
         etag = cls(file_size=os.path.getsize(path))
         with open(path, "rb") as f:
             for part in etag.part_sizes:

--- a/dandi/core/digests/dandietag.py
+++ b/dandi/core/digests/dandietag.py
@@ -18,7 +18,7 @@ def tb(bytes_size: int) -> int:
     return bytes_size * 2 ** 40
 
 
-class DANDIEtag:
+class DandiETag:
 
     REGEX = r"[0-9a-f]{32}-\d{1,4}"
     MAX_LENGTH = 37
@@ -78,7 +78,7 @@ class DANDIEtag:
         return tuple(sizes)
 
     @classmethod
-    def from_file(cls, path: str) -> "DANDIEtag":
+    def from_file(cls, path: str) -> "DandiETag":
         etag = cls(file_size=os.path.getsize(path))
         with open(path, "rb") as f:
             for part in etag.part_sizes:
@@ -98,6 +98,6 @@ class DANDIEtag:
 if __name__ == "__main__":
     import sys
 
-    print(f"Get {len(DANDIEtag.gen_part_sizes(tb(5)))} parts for 5TB file")
+    print(f"Get {len(DandiETag.gen_part_sizes(tb(5)))} parts for 5TB file")
     for p in sys.argv[1:]:
-        print(f"{p}: {DANDIEtag.from_file(p)}")
+        print(f"{p}: {DandiETag.from_file(p)}")

--- a/dandi/core/digests/dandietag.py
+++ b/dandi/core/digests/dandietag.py
@@ -108,7 +108,7 @@ class DandiETag:
     def get_parts(self) -> Iterator[Part]:
         return iter(self._part_gen)
 
-    def next_part(self) -> Optional[Part]:
+    def get_next_part(self) -> Optional[Part]:
         if self._next_index < self.part_qty:
             return self._part_gen[self._next_index + 1]
         else:

--- a/dandi/core/digests/dandietag.py
+++ b/dandi/core/digests/dandietag.py
@@ -1,4 +1,7 @@
-# from https://github.com/girder/django-s3-file-field/blob/master/s3_file_field/_multipart.py
+# Derived from <https://github.com/girder/django-s3-file-field/blob/master/
+# s3_file_field/_multipart.py>, copyright Kitware, Inc. <kitware@kitware.com>
+# under the Apache 2.0 license
+
 from dataclasses import dataclass
 from hashlib import md5
 import math
@@ -38,7 +41,6 @@ class PartGenerator:
     # 5GB is the maximum part size allowed by S3
     MAX_PART_SIZE = gb(5)
 
-    # from https://github.com/girder/django-s3-file-field/blob/master/s3_file_field/_multipart.py
     @classmethod
     def for_file_size(cls, file_size: int) -> "PartGenerator":
         """Method to calculate sequential part sizes given a file size"""

--- a/dandi/core/digests/dandietag.py
+++ b/dandi/core/digests/dandietag.py
@@ -18,7 +18,7 @@ def tb(bytes_size: int) -> int:
     return bytes_size * 2 ** 40
 
 
-class DANDIEtag(object):
+class DANDIEtag:
 
     REGEX = r"[0-9a-f]{32}-\d{1,4}"
     MAX_LENGTH = 37
@@ -38,7 +38,7 @@ class DANDIEtag(object):
         if len(self._md5_digests) != len(self._part_sizes):
             # TODO: too harsh for __str__? just say "incomplete"?
             raise RuntimeError(
-                f"Collected {len(self._md5_digests)} out from {len(self._part_sizes)}"
+                f"Collected {len(self._md5_digests)} out of {len(self._part_sizes)}"
             )
         parts_digest = md5(b"".join(self._md5_digests)).hexdigest()
         return f"{parts_digest}-{len(self._md5_digests)}"
@@ -89,7 +89,8 @@ class DANDIEtag(object):
         """Update etag with the new block of data"""
         if len(self._md5_digests) == self.part_sizes:
             raise RuntimeError(
-                "Trying to update {self} with a new block having already processed {len(self._md5_digests)"
+                f"Trying to update {self} with a new block having already"
+                f" processed {len(self._md5_digests)}"
             )
         self._md5_digests.append(md5(block).digest())
 

--- a/dandi/core/digests/dandietag.py
+++ b/dandi/core/digests/dandietag.py
@@ -1,0 +1,108 @@
+from hashlib import md5
+import math
+import os
+
+# from https://github.com/girder/django-s3-file-field/blob/master/s3_file_field/_multipart.py
+from typing import Iterator, List, Tuple
+
+
+def mb(bytes_size: int) -> int:
+    return bytes_size * 2 ** 20
+
+
+def gb(bytes_size: int) -> int:
+    return bytes_size * 2 ** 30
+
+
+def tb(bytes_size: int) -> int:
+    return bytes_size * 2 ** 40
+
+
+class DANDIEtag(object):
+
+    REGEX = r"[0-9a-f]{32}-\d{1,4}"
+    MAX_LENGTH = 37
+
+    def __init__(self, file_size: int):
+        self._file_size: int = file_size
+        self._part_sizes: Tuple[int] = None
+        self._md5_digests: List[bytes] = []
+
+    @property
+    def part_sizes(self) -> Tuple[int]:
+        if self._part_sizes is None:
+            self._part_sizes = tuple(self.gen_part_sizes(self._file_size))
+        return self._part_sizes
+
+    def __str__(self):
+        if len(self._md5_digests) != len(self._part_sizes):
+            # TODO: too harsh for __str__? just say "incomplete"?
+            raise RuntimeError(
+                f"Collected {len(self._md5_digests)} out from {len(self._part_sizes)}"
+            )
+        parts_digest = md5(b"".join(self._md5_digests)).hexdigest()
+        return f"{parts_digest}-{len(self._md5_digests)}"
+
+    # from https://github.com/girder/django-s3-file-field/blob/master/s3_file_field/_multipart.py
+    # but removing yielding sequential index. Could be wrapped
+    # with enumerate where needed
+    @classmethod
+    def gen_part_sizes(cls, file_size: int) -> Iterator[int]:
+        """Generator to yield sequential part sizes given a file size"""
+        part_size = mb(64)  # cls.part_size
+
+        # S3 multipart limits: https://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html
+
+        if file_size > tb(5):
+            raise ValueError("File is larger than the S3 maximum object size.")
+
+        # 10k is the maximum number of allowed parts allowed by S3
+        max_parts = 10_000
+        if math.ceil(file_size / part_size) >= max_parts:
+            part_size = math.ceil(file_size / max_parts)
+
+        # 5MB is the minimum part size allowed by S3
+        min_part_size = mb(5)
+        if part_size < min_part_size:
+            part_size = min_part_size
+
+        # 5GB is the maximum part size allowed by S3
+        max_part_size = gb(5)
+        if part_size > max_part_size:
+            part_size = max_part_size
+
+        remaining_file_size = file_size
+        while remaining_file_size > 0:
+            current_part_size = (
+                part_size
+                if remaining_file_size - part_size > 0
+                else remaining_file_size
+            )
+
+            yield current_part_size
+
+            remaining_file_size -= part_size
+
+    @classmethod
+    def from_file(cls, path: str):
+        etag = cls(file_size=os.path.getsize(path))
+        with open(path, "rb") as f:
+            for part in etag.part_sizes:
+                etag.update(f.read(part))
+        return etag
+
+    def update(self, block):
+        """Update etag with the new block of data"""
+        if len(self._md5_digests) == self.part_sizes:
+            raise RuntimeError(
+                "Trying to update {self} with a new block having already processed {len(self._md5_digests)"
+            )
+        self._md5_digests.append(md5(block).digest())
+
+
+if __name__ == "__main__":
+    import sys
+
+    print(f"Get {len(list(DANDIEtag.gen_part_sizes(tb(5))))} parts for 5TB file")
+    for p in sys.argv[1:]:
+        print(f"{p}: {DANDIEtag.from_file(p)}")

--- a/dandi/core/digests/tests/test_dandietag.py
+++ b/dandi/core/digests/tests/test_dandietag.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ..dandietag import Part, PartGenerator, mb, tb
+from ..dandietag import DandiETag, Part, PartGenerator, mb, tb
 
 
 @pytest.mark.parametrize(
@@ -10,6 +10,7 @@ from ..dandietag import Part, PartGenerator, mb, tb
         (mb(50), mb(50), mb(50), 1),
         (mb(70), mb(64), mb(6), 2),
         (mb(140), mb(64), mb(12), 3),
+        (mb(640), mb(64), mb(64), 10),
         (tb(5), 549755814, 549754694, 10000),
     ],
 )
@@ -29,3 +30,66 @@ def test_part_generator(file_size, initial_part_size, final_part_size, part_coun
     assert pg[part_count] == Part(
         part_count, initial_part_size * (part_count - 1), final_part_size
     )
+
+
+def test_dandietag_tiny(tmp_path):
+    f = tmp_path / "sample.txt"
+    f.write_bytes(b"123")
+    assert DandiETag.from_file(f).as_str() == "d022646351048ac0ba397d12dfafa304-1"
+
+
+def test_dandietag_null(tmp_path):
+    f = tmp_path / "sample.dat"
+    f.write_bytes(b"\0")
+    assert DandiETag.from_file(f).as_str() == "7e4696ef25d5faececd853ce5e2a233b-1"
+
+
+PART_DIGESTS = [
+    b"\x06\x1c\x9a\xee\xac\x02\x0f\xd8\xa1\xd1\xc9\xcbb\x1d'V",
+    b"\xd5z\x92\x92\t\xdd\xfbX\xf6\x05\x83\xcb\xcf\x96\xde%",
+    b"z\x88\x9e\xe7m\x9a\n{=\x85,\xc2t_\x1e#",
+    b"\x84\xc6<M\x1a$%\xac?\x1a\x0bt\xf0|sY",
+    b"\xa3\x98\xc1d\xf5e\xdb;\xd0\xe5\x87\x19\x8d\xcd5\xe9",
+    b"\xd7\xe1\x0c\xf2\xfa\x985)\xa8\x8a\xa7\x19z%)\x96",
+    b"\xfe\x12\x82\xdb^\x0fr|\x9f\xd5\x924\xba?\xd5D",
+    b"*~@\xb4\x19:\xa0\xa2\xc0\xa5q\x82\xcdgv@",
+    b"\xaf\x89\x88V^\x00\x9f\x8f\xeb\xf8\x1e\x90\x17\xe4\xf7\xf4",
+    b"\xf8\t\xb3fn!\x9c\x13\x8e\x1d\x86\xfd}\x91H\xbf",
+]
+
+ETAG = "8e5394f58846c6874be226c5a251f780-10"
+
+
+def test_add_next_digest():
+    etagger = DandiETag(mb(640))
+    assert etagger.part_qty == 10
+    for i, d in enumerate(PART_DIGESTS):
+        assert not etagger.complete
+        assert etagger.next_part().number == i + 1
+        etagger.add_next_digest(d)
+    assert etagger.complete
+    assert etagger.get_next_part() is None
+    assert etagger.as_str() == ETAG
+
+
+def test_add_digest_reversed():
+    etagger = DandiETag(mb(640))
+    assert etagger.part_qty == 10
+    assert not etagger.complete
+    for p, d in reversed(list(zip(etagger.get_parts(), PART_DIGESTS))):
+        assert not etagger.complete
+        etagger.add_digest(p, d)
+    assert etagger.complete
+    assert etagger.as_str() == ETAG
+
+
+def test_add_digest_out_of_order():
+    etagger = DandiETag(mb(640))
+    assert etagger.part_qty == 10
+    assert not etagger.complete
+    pieces = list(zip(etagger.get_parts(), PART_DIGESTS))
+    for p, d in pieces[::2] + pieces[1::2]:
+        assert not etagger.complete
+        etagger.add_digest(p, d)
+    assert etagger.complete
+    assert etagger.as_str() == ETAG

--- a/dandi/core/digests/tests/test_dandietag.py
+++ b/dandi/core/digests/tests/test_dandietag.py
@@ -65,7 +65,7 @@ def test_add_next_digest():
     assert etagger.part_qty == 10
     for i, d in enumerate(PART_DIGESTS):
         assert not etagger.complete
-        assert etagger.next_part().number == i + 1
+        assert etagger.get_next_part().number == i + 1
         etagger.add_next_digest(d)
     assert etagger.complete
     assert etagger.get_next_part() is None

--- a/dandi/core/digests/tests/test_dandietag.py
+++ b/dandi/core/digests/tests/test_dandietag.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ..dandietag import DandiETag, mb, tb
+from ..dandietag import Part, PartGenerator, mb, tb
 
 
 @pytest.mark.parametrize(
@@ -13,8 +13,19 @@ from ..dandietag import DandiETag, mb, tb
         (tb(5), 549755814, 549754694, 10000),
     ],
 )
-def test_gen_part_sizes(file_size, initial_part_size, final_part_size, part_count):
-    sizes = DandiETag.gen_part_sizes(file_size)
-    assert len(sizes) == part_count
-    assert all(sz == initial_part_size for sz in sizes[:-1])
-    assert sizes[-1] == final_part_size
+def test_part_generator(file_size, initial_part_size, final_part_size, part_count):
+    pg = PartGenerator.for_file_size(file_size)
+    assert pg == PartGenerator(part_count, initial_part_size, final_part_size)
+    assert len(pg) == part_count
+    parts = list(pg)
+    assert [p.number for p in parts] == list(range(1, part_count + 1))
+    assert all(p.size == initial_part_size for p in parts[:-1])
+    assert parts[-1].size == final_part_size
+    offset = 0
+    for p in parts:
+        assert p.offset == offset
+        offset += p.size
+    assert pg[1] == Part(1, 0, initial_part_size)
+    assert pg[part_count] == Part(
+        part_count, initial_part_size * (part_count - 1), final_part_size
+    )

--- a/dandi/core/digests/tests/test_dandietag.py
+++ b/dandi/core/digests/tests/test_dandietag.py
@@ -93,7 +93,7 @@ def test_add_next_digest():
             etagger.as_str()
         assert str(excinfo.value) == "Not all part hashes submitted"
         assert etagger.get_next_part().number == i + 1
-        etagger.add_next_digest(d)
+        etagger._add_next_digest(d)
     assert etagger.complete
     assert etagger.get_next_part() is None
     s = etagger.as_str()
@@ -108,7 +108,7 @@ def test_add_digest_reversed():
     assert not etagger.complete
     for p, d in reversed(list(zip(etagger.get_parts(), PART_DIGESTS))):
         assert not etagger.complete
-        etagger.add_digest(p, d)
+        etagger._add_digest(p, d)
     assert etagger.complete
     assert etagger.as_str() == ETAG
 
@@ -120,6 +120,6 @@ def test_add_digest_out_of_order():
     pieces = list(zip(etagger.get_parts(), PART_DIGESTS))
     for p, d in pieces[::2] + pieces[1::2]:
         assert not etagger.complete
-        etagger.add_digest(p, d)
+        etagger._add_digest(p, d)
     assert etagger.complete
     assert etagger.as_str() == ETAG

--- a/dandi/core/digests/tests/test_dandietag.py
+++ b/dandi/core/digests/tests/test_dandietag.py
@@ -1,0 +1,20 @@
+import pytest
+
+from ..dandietag import DANDIEtag, mb, tb
+
+
+@pytest.mark.parametrize(
+    "file_size,initial_part_size,final_part_size,part_count",
+    [
+        (mb(64), mb(64), mb(64), 1),
+        (mb(50), mb(50), mb(50), 1),
+        (mb(70), mb(64), mb(6), 2),
+        (mb(140), mb(64), mb(12), 3),
+        (tb(5), 549755814, 549754694, 10000),
+    ],
+)
+def test_gen_part_sizes(file_size, initial_part_size, final_part_size, part_count):
+    sizes = DANDIEtag.gen_part_sizes(file_size)
+    assert len(sizes) == part_count
+    assert all(sz == initial_part_size for sz in sizes[:-1])
+    assert sizes[-1] == final_part_size

--- a/dandi/core/digests/tests/test_dandietag.py
+++ b/dandi/core/digests/tests/test_dandietag.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ..dandietag import DANDIEtag, mb, tb
+from ..dandietag import DandiETag, mb, tb
 
 
 @pytest.mark.parametrize(
@@ -14,7 +14,7 @@ from ..dandietag import DANDIEtag, mb, tb
     ],
 )
 def test_gen_part_sizes(file_size, initial_part_size, final_part_size, part_count):
-    sizes = DANDIEtag.gen_part_sizes(file_size)
+    sizes = DandiETag.gen_part_sizes(file_size)
     assert len(sizes) == part_count
     assert all(sz == initial_part_size for sz in sizes[:-1])
     assert sizes[-1] == final_part_size

--- a/dandi/support/digests.py
+++ b/dandi/support/digests.py
@@ -14,6 +14,7 @@ import logging
 
 from fscacher import PersistentCache
 
+from ..core.digests.dandietag import DandiETag
 from ..utils import auto_repr
 
 lgr = logging.getLogger("dandi.support.digests")
@@ -78,8 +79,6 @@ checksums = PersistentCache(name="dandi-checksums", envvar="DANDI_CACHE")
 @checksums.memoize_path
 def get_digest(filepath, digest="sha256"):
     if digest == "dandi-etag":
-        from ..core.digests.dandietag import DandiETag
-
         return DandiETag.from_file(filepath).as_str()
     else:
         return Digester([digest])(filepath)[digest]

--- a/dandi/support/digests.py
+++ b/dandi/support/digests.py
@@ -77,4 +77,9 @@ checksums = PersistentCache(name="dandi-checksums", envvar="DANDI_CACHE")
 
 @checksums.memoize_path
 def get_digest(filepath, digest="sha256"):
-    return Digester([digest])(filepath)[digest]
+    if digest == "dandi-etag":
+        from ..core.digests.dandietag import DandiETag
+
+        return DandiETag.from_file(filepath).as_str()
+    else:
+        return Digester([digest])(filepath)[digest]


### PR DESCRIPTION
This is an initial interface which could be used to get a complete
digest for a file (serially ATM, but could be parallelized across parts),
just a list of part sizes, or be used iteratively to update a digest
e.g. during upload or download as more data comes in.

Closes #464 

TODOs
- [x] refine design/interface given the feedback
- [x] add copyright/license terms for borrowed piece of code
- [x] add tests for some sample files with known etags, mocking for some large ones

Later, after merge so could be used by dandi-api:
- use within `upload` and `download` for new dandi-api
- verify etag matching for some large files already uploaded to S3