### PR TITLE
Update upload code for changes in API

### DIFF
--- a/dandi/core/digests/dandietag.py
+++ b/dandi/core/digests/dandietag.py
@@ -117,6 +117,9 @@ class DandiETag:
         else:
             return None
 
+    def get_part_etag(self, p: Part) -> Optional[str]:
+        return self._md5_digests[p.number - 1].hex()
+
     def as_str(self) -> str:
         if not self.complete:
             raise ValueError("Not all part hashes submitted")

--- a/dandi/dandiapi.py
+++ b/dandi/dandiapi.py
@@ -442,8 +442,6 @@ class DandiAPIClient(RESTFullAPIClient):
                 },
             )
             blob_uuid = resp["uuid"]
-            # object_key = resp["multipart_upload"]["object_key"]
-            # upload_id = resp["multipart_upload"]["upload_id"]
             parts = resp["multipart_upload"].get("parts", [])
             if len(parts) != etagger.part_qty:
                 raise RuntimeError(

--- a/dandi/dandiapi.py
+++ b/dandi/dandiapi.py
@@ -406,15 +406,14 @@ class DandiAPIClient(RESTFullAPIClient):
         etagger = get_dandietag(filepath)
         filetag = etagger.as_str()
         lgr.debug("Calculated dandi-etag of %s for %s", filetag, filepath)
-        # TODO: Uncomment this once dandi-etags have a DigestType enum value:
-        # for digest in asset_metadata.get("digest", []):
-        #     if digest["cryptoType"] == ??? :
-        #         if digest["value"] != filetag:
-        #             raise RuntimeError(
-        #                 f"{filepath}: File etag changed; was originally"
-        #                 f" {asset_metadata['digest']} but is now {filetag}"
-        #             )
-        #         break
+        for digest in asset_metadata.get("digest", []):
+            if digest["cryptoType"] == "dandi:dandi-etag":
+                if digest["value"] != filetag:
+                    raise RuntimeError(
+                        f"{filepath}: File etag changed; was originally"
+                        f" {digest['value']} but is now {filetag}"
+                    )
+                break
         try:
             resp = self.post(
                 "/blobs/digest/",

--- a/dandi/download.py
+++ b/dandi/download.py
@@ -167,7 +167,7 @@ def download_generator(
                 down_args = (
                     dandiset["dandiset"]["identifier"],
                     dandiset["version"],
-                    asset["uuid"],
+                    asset["asset_id"],
                 )
                 metadata = client.get_asset(*down_args)
                 for d in metadata.get("digest", []):

--- a/dandi/download.py
+++ b/dandi/download.py
@@ -169,19 +169,13 @@ def download_generator(
                     dandiset["version"],
                     asset["uuid"],
                 )
-                if "sha256" not in asset:
-                    raise RuntimeError("sha256 hash not available for asset")
+                metadata = client.get_asset(*down_args)
+                for d in metadata.get("digest", []):
+                    if d["cryptoType"] == "dandi:SHA256":
+                        digests = {"sha256": d["value"]}
+                        break
                 else:
-                    digests = {"sha256": asset["sha256"]}
-                    if (
-                        "sha256" in digests_from_metadata
-                        and asset["sha256"] != digests_from_metadata["sha256"]
-                    ):
-                        lgr.warning(
-                            "Metadata seems to be outdated since API returned different "
-                            "sha256 for %(path)s",
-                            asset,
-                        )
+                    raise RuntimeError("sha256 hash not available for asset")
             else:
                 raise TypeError(f"Don't know here how to handle {client}")
 

--- a/dandi/download.py
+++ b/dandi/download.py
@@ -171,7 +171,7 @@ def download_generator(
                 )
                 metadata = client.get_asset(*down_args)
                 for d in metadata.get("digest", []):
-                    if d["cryptoType"] == "dandi:dandi_etag":
+                    if d["cryptoType"] == "dandi:dandi-etag":
                         digests = {"dandi-etag": d["value"]}
                         break
                 else:
@@ -445,7 +445,7 @@ def _download_file(
         # TODO: reuse that sorting based on speed
         for algo, digest in digests.items():
             if algo == "dandi-etag":
-                from .core.digests import ETagHashlike
+                from .core.digests.dandietag import ETagHashlike
 
                 digester = lambda: ETagHashlike(size)  # noqa: E731
             else:

--- a/dandi/pynwb_utils.py
+++ b/dandi/pynwb_utils.py
@@ -261,19 +261,20 @@ def validate(path, devel_debug=False):
         # we just will not remove any errors, it is required so should be some
         pass
     else:
-        # Explicitly sanitize so we collect warnings.
-        # TODO: later cast into proper ERRORs
-        version = _sanitize_nwb_version(version, log=errors.append)
-        loosever = LooseVersion(version)
-        if loosever and loosever < "2.1.0":
-            errors_ = errors[:]
-            errors = [e for e in errors if not re_ok_prior_210.search(str(e))]
-            if errors != errors_:
-                lgr.debug(
-                    "Filtered out %d validation errors on %s",
-                    len(errors_) - len(errors),
-                    path,
-                )
+        if version is not None:
+            # Explicitly sanitize so we collect warnings.
+            # TODO: later cast into proper ERRORs
+            version = _sanitize_nwb_version(version, log=errors.append)
+            loosever = LooseVersion(version)
+            if loosever and loosever < "2.1.0":
+                errors_ = errors[:]
+                errors = [e for e in errors if not re_ok_prior_210.search(str(e))]
+                if errors != errors_:
+                    lgr.debug(
+                        "Filtered out %d validation errors on %s",
+                        len(errors_) - len(errors),
+                        path,
+                    )
     return errors
 
 

--- a/dandi/support/digests.py
+++ b/dandi/support/digests.py
@@ -79,7 +79,7 @@ checksums = PersistentCache(name="dandi-checksums", envvar="DANDI_CACHE")
 @checksums.memoize_path
 def get_digest(filepath, digest="sha256") -> str:
     if digest == "dandi-etag":
-        return DandiETag.from_file(filepath).as_str()
+        return get_dandietag(filepath).as_str()
     else:
         return Digester([digest])(filepath)[digest]
 

--- a/dandi/support/digests.py
+++ b/dandi/support/digests.py
@@ -77,8 +77,13 @@ checksums = PersistentCache(name="dandi-checksums", envvar="DANDI_CACHE")
 
 
 @checksums.memoize_path
-def get_digest(filepath, digest="sha256"):
+def get_digest(filepath, digest="sha256") -> str:
     if digest == "dandi-etag":
         return DandiETag.from_file(filepath).as_str()
     else:
         return Digester([digest])(filepath)[digest]
+
+
+@checksums.memoize_path
+def get_dandietag(filepath) -> DandiETag:
+    return DandiETag.from_file(filepath)

--- a/dandi/tests/test_upload.py
+++ b/dandi/tests/test_upload.py
@@ -352,7 +352,18 @@ def test_new_upload_extant_bad_existing(mocker, text_dandiset):
     iter_upload_spy.assert_not_called()
 
 
-@pytest.mark.parametrize("contents", [b"", b"x"])
+@pytest.mark.parametrize(
+    "contents",
+    [
+        pytest.param(
+            b"",
+            marks=pytest.mark.xfail(
+                reason="https://github.com/dandi/dandi-api/issues/168"
+            ),
+        ),
+        b"x",
+    ],
+)
 def test_upload_download_small_file(contents, local_dandi_api, monkeypatch, tmp_path):
     client = DandiAPIClient(
         api_url=local_dandi_api["instance"].api, token=local_dandi_api["api_key"]

--- a/dandi/upload.py
+++ b/dandi/upload.py
@@ -717,7 +717,7 @@ def _new_upload(
                 local_mtime = ensure_datetime(path_stat.st_mtime)
                 remote_mtime_str = metadata.get("blobDateModified")
                 for d in metadata.get("digest", []):
-                    if d["cryptoType"] == "dandi:dandi_etag":
+                    if d["cryptoType"] == "dandi:dandi-etag":
                         extant_etag = d["value"]
                         break
                 else:
@@ -814,13 +814,13 @@ def _new_upload(
             yield {"status": "extracting metadata"}
             try:
                 asset_metadata = nwb2asset(
-                    path, digest=file_etag, digest_type="dandi-etag"
+                    path, digest=file_etag, digest_type="dandi_etag"
                 )
             except Exception as exc:
                 if allow_any_path:
                     yield {"status": "failed to extract metadata"}
                     asset_metadata = get_default_metadata(
-                        path, digest=file_etag, digest_type="dandi-etag"
+                        path, digest=file_etag, digest_type="dandi_etag"
                     )
                 else:
                     yield skip_file("failed to extract metadata: %s" % str(exc))

--- a/dandi/upload.py
+++ b/dandi/upload.py
@@ -713,7 +713,7 @@ def _new_upload(
             if extant is not None:
                 # The endpoint used to search by paths doesn't include asset
                 # metadata, so we need to make another API call:
-                metadata = client.get_asset(ds_identifier, "draft", extant["uuid"])
+                metadata = client.get_asset(ds_identifier, "draft", extant["asset_id"])
                 local_mtime = ensure_datetime(path_stat.st_mtime)
                 remote_mtime_str = metadata.get("blobDateModified")
                 for d in metadata.get("digest", []):

--- a/dandi/upload.py
+++ b/dandi/upload.py
@@ -704,9 +704,9 @@ def _new_upload(
             #
             yield {"status": "digesting"}
             try:
-                sha256_digest = get_digest(path)
+                file_etag = get_digest(path, digest="dandi-etag")
             except Exception as exc:
-                yield skip_file("failed to compute digests: %s" % str(exc))
+                yield skip_file("failed to compute digest: %s" % str(exc))
                 return
 
             extant = client.get_asset_bypath(ds_identifier, "draft", str(relpath))
@@ -717,18 +717,17 @@ def _new_upload(
                 local_mtime = ensure_datetime(path_stat.st_mtime)
                 remote_mtime_str = metadata.get("blobDateModified")
                 for d in metadata.get("digest", []):
-                    if d["cryptoType"] == "dandi:SHA256":
-                        extant_sha256 = d["value"]
+                    if d["cryptoType"] == "dandi:dandi_etag":
+                        extant_etag = d["value"]
                         break
                 else:
                     # TODO: Should this error instead?
-                    extant_sha256 = None
+                    extant_etag = None
                 if remote_mtime_str is not None:
                     remote_mtime = ensure_datetime(remote_mtime_str)
                     remote_file_status = (
                         "same"
-                        if extant_sha256 == sha256_digest
-                        and remote_mtime == local_mtime
+                        if extant_etag == file_etag and remote_mtime == local_mtime
                         else (
                             "newer"
                             if remote_mtime > local_mtime
@@ -749,11 +748,11 @@ def _new_upload(
                     return
                 # Logic below only for overwrite and reupload
                 if existing == "overwrite":
-                    if extant_sha256 == sha256_digest:
+                    if extant_etag == file_etag:
                         yield skip_file(exists_msg)
                         return
                 elif existing == "refresh":
-                    if extant_sha256 == sha256_digest:
+                    if extant_etag == file_etag:
                         yield skip_file("file exists")
                         return
                     elif remote_mtime is not None and remote_mtime >= local_mtime:
@@ -815,13 +814,13 @@ def _new_upload(
             yield {"status": "extracting metadata"}
             try:
                 asset_metadata = nwb2asset(
-                    path, digest=sha256_digest, digest_type="SHA256"
+                    path, digest=file_etag, digest_type="dandi-etag"
                 )
             except Exception as exc:
                 if allow_any_path:
                     yield {"status": "failed to extract metadata"}
                     asset_metadata = get_default_metadata(
-                        path, digest=sha256_digest, digest_type="SHA256"
+                        path, digest=file_etag, digest_type="dandi-etag"
                     )
                 else:
                     yield skip_file("failed to extract metadata: %s" % str(exc))


### PR DESCRIPTION
Closes #478.

TODOs:
- [x] test upload/download cycle on ~~0-length and~~ (delaying fixing for 0 length for now, see e.g. #488) some small (1 byte) files: should be coded in a test against a fixture instance and manually on e.g. https://gui-beta-dandiarchive-org.netlify.app/#/dandiset/000029
- [x] test upload/download/reupload (manually) on a heavy in number of files dandiset, e.g. https://gui.dandiarchive.org/#/dandiset/000008
- [ ] test upload/download/reupload cycle on some heavy (>1TB) file: could be the `drogon:/mnt/backup/dandi/dandiarchive-s3-backup/largeuploads/blobs/f5d/aac/79d9c6c1ba2439200d45680f1cb941087750a000e484ea2973232709d2` (again -- to be placed somewhere in 000029, validation could be ignored since IIRC it is not necessarily nwb)