### PR TITLE
Add dandi_etag digest type to schema

### DIFF
--- a/dandi/consts.py
+++ b/dandi/consts.py
@@ -156,4 +156,4 @@ class routes(object):
     dandiset_draft = "{dandi_instance.redirector}/dandiset/{dandiset[identifier]}/draft"
 
 
-DANDI_SCHEMA_VERSION = "0.1.0"
+DANDI_SCHEMA_VERSION = "0.1.1"

--- a/dandi/model_types.py
+++ b/dandi/model_types.py
@@ -62,7 +62,7 @@ DigestTypeDict = {
             "rdfs:label": "SHA-512",
         },
         {
-            "@id": "dandi:dandi_etag",
+            "@id": "dandi:dandi-etag",
             "@type": "dandi:DigestType",
             "rdfs:comment": "S3-style ETag",
             "rdfs:label": "DANDI ETag",

--- a/dandi/model_types.py
+++ b/dandi/model_types.py
@@ -61,6 +61,12 @@ DigestTypeDict = {
             "rdfs:comment": "SHA-512 checksum",
             "rdfs:label": "SHA-512",
         },
+        {
+            "@id": "dandi:dandi_etag",
+            "@type": "dandi:DigestType",
+            "rdfs:comment": "S3-style ETag",
+            "rdfs:label": "DANDI ETag",
+        },
     ]
 }
 

--- a/dandi/models.py
+++ b/dandi/models.py
@@ -42,7 +42,7 @@ def create_enum(data):
                 key = item["@id"].split(":")[-1]
             if key in items:
                 key = item["@id"].replace(":", "_")
-            items[f"{key}"] = item["@id"]
+            items[key.replace("-", "_")] = item["@id"]
     if klass is None or len(items) == 0:
         raise ValueError(f"Could not generate a klass or items from {data}")
     newklass = Enum(klass, items)

--- a/dandi/tests/test_metadata.py
+++ b/dandi/tests/test_metadata.py
@@ -105,7 +105,7 @@ def test_metadata2asset(schema_dir):
     # data.json(exclude_unset=True, exclude_none=True, indent=2)
     json_data = """{
   "identifier": "0b0a1a0b-e3ea-4cf6-be94-e02c830d54be",
-  "schemaVersion": "0.1.0",
+  "schemaVersion": "0.1.1",
   "keywords": [
     "test",
     "sample",
@@ -219,7 +219,7 @@ def test_metadata2asset_simple1(schema_dir):
     )
     # data.json(exclude_unset=True, exclude_none=True, indent=2)
     json_data = """{
-  "schemaVersion": "0.1.0",
+  "schemaVersion": "0.1.1",
   "identifier": "bfc23fb6192b41c083a7257e09a3702b",
   "keywords": [
     "keyword1",
@@ -973,7 +973,7 @@ def test_dandimeta_migration(schema_dir):
     "dandi:CCBY40"
   ],
   "name": "A NWB-based dataset and processing pipeline of human single-neuron activity during a declarative memory task",
-  "schemaVersion": "0.1.0",
+  "schemaVersion": "0.1.1",
   "repository": "https://dandiarchive.org/"
 }"""
     data_as_dict = json.loads(json_data)

--- a/dandi/tests/test_models.py
+++ b/dandi/tests/test_models.py
@@ -138,6 +138,7 @@ def test_asset():
                 "sha1": "dandi:sha1",
                 "SHA256": "dandi:SHA256",
                 "sha512": "dandi:sha512",
+                "dandi_etag": "dandi:dandi-etag",
             },
         ),
     ],


### PR DESCRIPTION
See [here](https://github.com/dandi/dandi-cli/pull/479#discussion_r598897361) and related conversation.

Note that I changed the name of the enum from `dandi-etag` to `dandi_etag` so that it would be a valid Python identifier.