### PR TITLE
Remove "current" column from upload progress display

### DIFF
--- a/dandi/upload.py
+++ b/dandi/upload.py
@@ -829,8 +829,7 @@ def _new_upload(
             validating = False
             for r in client.iter_upload(ds_identifier, "draft", metadata, str(path)):
                 if r["status"] == "uploading":
-                    uploaded_paths[str(path)]["size"] = r["current"]
-                    r.pop("current")
+                    uploaded_paths[str(path)]["size"] = r.pop("current")
                     yield r
                 elif r["status"] == "post-validating":
                     # Only yield the first "post-validating" status

--- a/dandi/upload.py
+++ b/dandi/upload.py
@@ -830,6 +830,7 @@ def _new_upload(
             for r in client.iter_upload(ds_identifier, "draft", metadata, str(path)):
                 if r["status"] == "uploading":
                     uploaded_paths[str(path)]["size"] = r["current"]
+                    r.pop("current")
                     yield r
                 elif r["status"] == "post-validating":
                     # Only yield the first "post-validating" status


### PR DESCRIPTION
When uploading to the new API, when the code actually reaches the point at which the upload proper happens, a "CURRENT" column appears at the right side of the pyout display containing the current number of bytes uploaded per file.  As this column is not declared in the list passed to the pyout table constructor, I assume it is not supposed to be displayed in the first place.  This PR removes the "current" field from the upload progress dict before yielding it to pyout, which should get rid of the column.