### PR TITLE
Add option for only running new Dandi API tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,11 +23,18 @@ jobs:
           - 3.7
           - 3.8
           - 3.9
+        dandi_api:
+          - false
         dev_deps:
           - false
         include:
           - os: ubuntu-18.04
             python: 3.7
+            dandi_api: true
+            dev_deps: false
+          - os: ubuntu-18.04
+            python: 3.7
+            dandi_api: false
             dev_deps: true
         exclude:
           # Temporarily disabled due to h5py/hdf5 dependency issue
@@ -78,9 +85,17 @@ jobs:
     - name: Set environment variable when using Python 3.7 to cover more code
       run: echo DANDI_LOG_GIRDER=1 >> "$GITHUB_ENV"
       if: matrix.python == '3.7'
-    - name: Run tests
+
+    - name: Run all tests
+      if: "!matrix.dandi_api"
       run: |
         python -m pytest -s -v --cov=dandi --cov-report=xml dandi
+
+    - name: Run Dandi API tests only
+      if: matrix.dandi_api
+      run: |
+        python -m pytest -s -v --cov=dandi --cov-report=xml --dandi-api dandi
+
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:

--- a/dandi/conftest.py
+++ b/dandi/conftest.py
@@ -1,1 +1,25 @@
 from .tests.fixtures import *  # noqa: F401, F403
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--dandi-api",
+        action="store_true",
+        default=False,
+        help="Only run tests of the new Django Dandi API",
+    )
+
+
+def pytest_collection_modifyitems(items, config):
+    # Based on <https://pythontesting.net/framework/pytest/pytest-run-tests
+    # -using-particular-fixture/>
+    if config.getoption("--dandi-api"):
+        selected_items = []
+        deselected_items = []
+        for item in items:
+            if "local_dandi_api" in getattr(item, "fixturenames", ()):
+                selected_items.append(item)
+            else:
+                deselected_items.append(item)
+        config.hook.pytest_deselected(items=deselected_items)
+        items[:] = selected_items


### PR DESCRIPTION
Part of https://github.com/dandi/dandi-api/issues/42.

Note that this PR will need to be part of a release of dandi-cli before the dandi-api+dandi-cli integration tests can use the released version of dandi-cli.  If you are OK with releasing immediately, add the "release" tag to this PR before merging.