### PR TITLE
Fixes conversion of existing dandiset metadata with sub-object validation

### DIFF
--- a/dandi/consts.py
+++ b/dandi/consts.py
@@ -156,4 +156,4 @@ class routes(object):
     dandiset_draft = "{dandi_instance.redirector}/dandiset/{dandiset[identifier]}/draft"
 
 
-DANDI_SCHEMA_VERSION = "0.1.1"
+DANDI_SCHEMA_VERSION = "0.1.2"

--- a/dandi/metadata.py
+++ b/dandi/metadata.py
@@ -424,7 +424,6 @@ def toContributor(value, contrib_type):
         value = [value]
     out = []
     for item in value:
-        print(item)
         if item == {"orcid": "", "roles": []}:
             continue
         contrib = {}

--- a/dandi/metadata.py
+++ b/dandi/metadata.py
@@ -521,7 +521,6 @@ def convertv1(data):
                                 item["relation"] = models.RelationType.IsDerivedFrom
                         out.append(models.Resource(**item))
                     elif not any(item in val.dict().values() for val in out):
-                        print(item)
                         out.append(
                             models.Resource(
                                 url=item, relation=models.RelationType.IsDescribedBy

--- a/dandi/metadata.py
+++ b/dandi/metadata.py
@@ -452,10 +452,10 @@ def toContributor(value, contrib_type):
             #    contrib["identifier"] = models.PropertyValue()
             del item["orcid"]
         if "affiliation" in item:
-            item["affiliation"] = [models.Organization(**{"name": item["affiliation"]})]
+            item["affiliation"] = [models.Organization(name=item["affiliation"])]
         if "affiliations" in item:
             item["affiliation"] = [
-                models.Organization(**{"name": affiliate})
+                models.Organization(name=affiliate)
                 for affiliate in item["affiliations"]
             ]
             del item["affiliations"]

--- a/dandi/metadata.py
+++ b/dandi/metadata.py
@@ -424,6 +424,9 @@ def toContributor(value, contrib_type):
         value = [value]
     out = []
     for item in value:
+        print(item)
+        if item == {"orcid": "", "roles": []}:
+            continue
         contrib = {}
         if "name" in item:
             name = item["name"].split()
@@ -449,18 +452,21 @@ def toContributor(value, contrib_type):
             # else:
             #    contrib["identifier"] = models.PropertyValue()
             del item["orcid"]
+        if "affiliation" in item:
+            item["affiliation"] = [models.Organization(**{"name": item["affiliation"]})]
         if "affiliations" in item:
             item["affiliation"] = [
-                models.Organization.unvalidated(**{"name": affiliate})
+                models.Organization(**{"name": affiliate})
                 for affiliate in item["affiliations"]
             ]
-
             del item["affiliations"]
         contrib.update(**{f"{k}": v for k, v in item.items()})
         if "awardNumber" in contrib or contrib_type == "sponsors":
-            contrib = models.Organization.unvalidated(**contrib)
+            contrib = models.Organization(**contrib)
         else:
-            contrib = models.Person.unvalidated(**contrib)
+            if "name" not in contrib:
+                contrib["name"] = "Last, First"
+            contrib = models.Person(**contrib)
         out.append(contrib)
     return out
 
@@ -504,9 +510,24 @@ def convertv1(data):
                 out = []
                 for item in value:
                     if isinstance(item, dict):
-                        out.append(models.Resource.unvalidated(**item))
+                        if (
+                            "relation" in item
+                            and "publication" in item["relation"].lower()
+                        ):
+                            del item["relation"]
+                        if "relation" not in item:
+                            if oldkey == "publications":
+                                item["relation"] = models.RelationType.IsDescribedBy
+                            if oldkey == "associatedData":
+                                item["relation"] = models.RelationType.IsDerivedFrom
+                        out.append(models.Resource(**item))
                     elif not any(item in val.dict().values() for val in out):
-                        out.append(models.Resource.unvalidated(url=item))
+                        print(item)
+                        out.append(
+                            models.Resource(
+                                url=item, relation=models.RelationType.IsDescribedBy
+                            )
+                        )
                 value = out
             if oldkey in [
                 "number_of_subjects",

--- a/dandi/models.py
+++ b/dandi/models.py
@@ -269,10 +269,10 @@ class Disorder(TypeModel):
     schemaKey: Literal["Disorder"] = Field("Disorder", readOnly=True)
 
 
-class ModalityType(TypeModel):
-    """Identifier for modality used"""
+class ApproachType(TypeModel):
+    """Identifier for approach used"""
 
-    schemaKey: Literal["ModalityType"] = Field("ModalityType", readOnly=True)
+    schemaKey: Literal["ApproachType"] = Field("ApproachType", readOnly=True)
 
 
 class MeasurementTechniqueType(TypeModel):
@@ -475,7 +475,7 @@ class AssetsSummary(DandiBaseModel):
         readOnly=True
     )  # TODO: types of things NWB, BIDS
     # Web UI: icons per each modality?
-    modality: List[ModalityType] = Field(
+    approach: List[ApproachType] = Field(
         readOnly=True
     )  # TODO: types of things, BIDS etc...
     # Web UI: could be an icon with number, which if hovered on  show a list?
@@ -853,7 +853,7 @@ class BareAssetMeta(CommonModel):
     sameAs: Optional[List[HttpUrl]] = Field(None, nskey="schema")
 
     # TODO
-    modality: Optional[List[ModalityType]] = Field(None, readOnly=True, nskey="dandi")
+    approach: Optional[List[ApproachType]] = Field(None, readOnly=True, nskey="dandi")
     measurementTechnique: Optional[List[MeasurementTechniqueType]] = Field(
         None, readOnly=True, nskey="schema"
     )


### PR DESCRIPTION
closes #503 

Current dandiset metadata conversion was generating invalid values for some properties (Person, Resources, etc.,.). This updates the migration code to address these issues.

Also the current assets metadata uses modality, which is being renamed to approach.