### PR TITLE
Run "provision" container in the foreground

### DIFF
--- a/dandi/tests/fixtures.py
+++ b/dandi/tests/fixtures.py
@@ -189,14 +189,17 @@ def docker_compose_setup():
 
     if create:
         run(
-            ["docker-compose", "up", "-d", "provision"],
+            ["docker-compose", "up", "-d", "client"],
             cwd=str(LOCAL_DOCKER_DIR),
             check=True,
         )
     try:
         if create:
-            run(["docker", "wait", f"{LOCAL_DOCKER_ENV}_provision_1"], check=True)
-            # Should we check that the output of `docker wait` is 0?
+            run(
+                ["docker-compose", "run", "--rm", "provision"],
+                cwd=str(LOCAL_DOCKER_DIR),
+                check=True,
+            )
 
         r = requests.get(
             f"{GIRDER_URL}/api/v1/user/authentication", auth=("admin", "letmein")


### PR DESCRIPTION
This PR causes the Girder "provision" container to be run in the foreground when spinning up the Docker Compose setup.  This allows us to catch provisioning failures early and also causes the logs for the container to be displayed, allowing debugging.  Both are relevant to fixing the failures currently seen on https://github.com/dandi/dandi-api/pull/183.

In case you're wondering why a Girder container is being spun up for dandi-api tests: The dandi-api container requires that a Dandi Girder setup be available for some reason, so we have to spin up all containers.