### PR TITLE
Ignore warnings from ruamel.yaml caused by hdmf using deprecated functions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,9 @@ filterwarnings =
     # <https://github.com/h5py/h5py/issues/1765>
     # <https://github.com/dandi/dandi-cli/pull/275>
     ignore:numpy.ufunc size changed, may indicate binary incompatibility.*:RuntimeWarning
+    # <https://github.com/hdmf-dev/hdmf/issues/547>
+    ignore:\s*safe_load will be removed.*:PendingDeprecationWarning:hdmf
+    ignore:\s*load will be removed.*:PendingDeprecationWarning:ruamel.yaml
 
 [coverage:run]
 parallel = True


### PR DESCRIPTION
A new version (0.17.0) of ruamel.yaml was released a few hours ago which added deprecation warnings to some top-level functions.  hdmf uses one of these functions, and so our tests were erroring out due to the warnings.  This PR ignores the warnings, and I've already filed [a bug report](https://github.com/hdmf-dev/hdmf/issues/547) with hdmf.