### PR TITLE
fix: remove unset fields to enable schemaKey

### DIFF
--- a/dandi/models.py
+++ b/dandi/models.py
@@ -735,10 +735,10 @@ class CommonModel(DandiBaseModel):
     def json_dict(self):
         """
         Recursively convert the instance to a `dict` of JSONable values,
-        including converting enum values to strings.  Unset and `None` fields
+        including converting enum values to strings.  `None` fields
         are omitted.
         """
-        return json.loads(self.json(exclude_unset=True, exclude_none=True))
+        return json.loads(self.json(exclude_none=True))
 
 
 class DandisetMeta(CommonModel, Identifiable):


### PR DESCRIPTION
SchemaKey provides type information for disambiguation of certain objects. This is being removed from the generated information. This PR removes the unset keyword which allows the const/Literal fields to be exported.