### PR TITLE
Better filtering of file-only log messages

### DIFF
--- a/dandi/cli/command.py
+++ b/dandi/cli/command.py
@@ -91,7 +91,7 @@ def main(ctx, log_level, pdb=False):
     # console:
     root = logging.getLogger()
     for h in root.handlers:
-        h.addFilter(lambda r: not r.msg.startswith("[META]"))
+        h.addFilter(lambda r: not getattr(r, "file_only", False))
 
     logdir = appdirs.user_log_dir("dandi-cli", "dandi")
     logfile = os.path.join(
@@ -106,8 +106,8 @@ def main(ctx, log_level, pdb=False):
     handler.setFormatter(fmter)
     root.addHandler(handler)
 
-    lgr.info("[META] sys.argv = %r", sys.argv)
-    lgr.info("[META] os.getcwd() = %s", os.getcwd())
+    lgr.info("sys.argv = %r", sys.argv, extra={"file_only": True})
+    lgr.info("os.getcwd() = %s", os.getcwd(), extra={"file_only": True})
 
     ctx.obj = SimpleNamespace(logfile=logfile)
 


### PR DESCRIPTION
This PR modifies the way that logfile-only log messages are filtered out from the stderr logs to be more robust/standard/"the right way to do things" — specifically, by filtering on a custom extra log record attribute instead of the log message.