### PR TITLE
Add and use get_module_version for cache tokens

### DIFF
--- a/dandi/pynwb_utils.py
+++ b/dandi/pynwb_utils.py
@@ -19,16 +19,17 @@ from .consts import (
     metadata_nwb_subject_fields,
 )
 from . import __version__, get_logger
+from .utils import get_module_version
 
 lgr = get_logger()
 
 # strip away possible development version marker
 dandi_rel_version = __version__.split("+", 1)[0]
 dandi_cache_tokens = [
-    pynwb.__version__,
+    get_module_version(pynwb),
     dandi_rel_version,
-    hdmf.__version__,
-    h5py.__version__,
+    get_module_version(hdmf),
+    get_module_version(h5py),
 ]
 metadata_cache = PersistentCache(
     name="dandi-metadata", tokens=dandi_cache_tokens, envvar="DANDI_CACHE"

--- a/dandi/tests/test_utils.py
+++ b/dandi/tests/test_utils.py
@@ -15,6 +15,7 @@ from ..utils import (
     flatten,
     flattened,
     get_instance,
+    get_module_version,
     get_utcnow_datetime,
     is_same_time,
     name2title,
@@ -341,3 +342,14 @@ def test_get_instance_bad_version_from_server():
 )
 def test_name2title(name, title):
     assert name2title(name) == title
+
+
+def test_get_module_version():
+    import pynwb
+
+    import dandi
+
+    assert get_module_version(dandi) == __version__
+    assert get_module_version("dandi") == __version__
+    assert get_module_version("pynwb") == pynwb.__version__
+    assert get_module_version("abracadabra123") is None

--- a/dandi/utils.py
+++ b/dandi/utils.py
@@ -16,7 +16,6 @@ import types
 from typing import Optional, Union
 
 import dateutil.parser
-import pkg_resources
 import requests
 import ruamel.yaml
 from semantic_version import Version
@@ -695,7 +694,7 @@ def is_url(s):
 def get_module_version(module: Union[str, types.ModuleType]) -> Optional[str]:
     """Return version of the module
 
-    Return module's `__version__` and if present, or use pkg_resources
+    Return module's `__version__` and if present, or use importlib
     to get version.
 
     Returns

--- a/dandi/utils.py
+++ b/dandi/utils.py
@@ -11,8 +11,10 @@ import re
 import shutil
 import subprocess
 import sys
+from typing import Union
 
 import dateutil.parser
+import pkg_resources
 import requests
 import ruamel.yaml
 from semantic_version import Version
@@ -686,3 +688,30 @@ def is_url(s):
     TODO: redo
     """
     return s.lower().startswith(("http://", "https://", "dandi://"))
+
+
+def get_module_version(module: Union[str, "Module"]) -> object:
+    """Return version of the module
+
+    Return module's `__version__` and if present, or use pkg_resources
+    to get version.
+
+    Returns
+    -------
+    object
+    """
+    if isinstance(module, str):
+        mod_name = module
+        module = sys.modules.get(module, None)
+    else:
+        mod_name = module.__name__.split(".", 1)[0]
+
+    version = getattr(module, "__version__", None)
+    if version is None:
+        # Let's use the standard Python mechanism if underlying module
+        # did not provide __version__
+        try:
+            version = pkg_resources.get_distribution(mod_name).version
+        except Exception as exc:
+            lgr.debug("Failed to determine version of the %s: %s", mod_name, exc)
+    return version

--- a/dandi/utils.py
+++ b/dandi/utils.py
@@ -1,5 +1,10 @@
 import datetime
-import importlib.metadata
+
+try:
+    from importlib.metadata import version as importlib_version
+except ImportError:
+    # TODO - remove whenever python >= 3.8
+    from importlib_metadata import version as importlib_version
 import inspect
 import io
 import itertools
@@ -714,7 +719,7 @@ def get_module_version(module: Union[str, types.ModuleType]) -> Optional[str]:
         # Let's use the standard Python mechanism if underlying module
         # did not provide __version__
         try:
-            version = importlib.metadata.version(mod_name)
+            version = importlib_version(mod_name)
         except Exception as exc:
             lgr.debug("Failed to determine version of the %s: %s", mod_name, exc)
     return version

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ install_requires =
     # pinned by pynwb version.
     #hdmf != 1.1.2
     humanize
+    importlib-metadata;  python_version < "3.8"
     joblib
     jsonschema
     keyring


### PR DESCRIPTION
Ran into crash of dandi-cli tests on our docker `dandiarchive/nwb-healthstatus:pynwb-1.2.0` with some arbitrarily old hdmf before it got `__version__`.  I do not think we should puke like that so decided to resort to asking pkg_resources if no `__version__`

Learning typing while at it -- @jwodder, how to properly annotate for a Module?  please suggest a fix