### PR TITLE
[wip] changes in navigate_urp for api

### DIFF
--- a/dandi/dandiarchive.py
+++ b/dandi/dandiarchive.py
@@ -71,7 +71,9 @@ def navigate_url(url):
                         asset = client.get_asset_bypath(*args, asset_id["location"])
                         assets = [asset] if asset is not None else []
                     else:
-                        assets = [client.get_asset(*args, asset_id["asset_id"])]
+                        assets = client.get_asset(*args, asset_id["asset_id"])[
+                            "results"
+                        ]
                 else:
                     raise NotImplementedError(
                         f"Do not know how to handle asset type {asset_type} with location"

--- a/dandi/tests/test_download.py
+++ b/dandi/tests/test_download.py
@@ -90,6 +90,24 @@ def test_download_000027_assets_only(url, tmpdir):
     assert sorted(downloads) == ["sub-RAT123", op.join("sub-RAT123", "sub-RAT123.nwb")]
 
 
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://api.dandiarchive.org/api/dandisets/000027",
+        # TODO
+        #'https://api.dandiarchive.org/api/dandisets/000027/versions/draft/assets/?path=sub-RAT123'
+    ],
+)
+def test_download_000027_assets_api(url, tmpdir):
+    # TODO: the test doesn't work with get_metadata=False
+    ret = download(url, tmpdir)  # , get_metadata=False)
+    assert not ret  # we return nothing ATM, might want to "generate"
+    dsdir = tmpdir / "000027"
+    assert dsdir.exists()
+    # downloads = (x.relto(dsdir) for x in dsdir.visit())
+    # assert sorted(downloads) == ["sub-RAT123", op.join("sub-RAT123", "sub-RAT123.nwb")]
+
+
 def test_girder_tqdm(monkeypatch):
     # smoke test to ensure we do not blow up
     def raise_assertion_error(*args, **kwargs):

--- a/dandi/tests/test_download.py
+++ b/dandi/tests/test_download.py
@@ -94,8 +94,8 @@ def test_download_000027_assets_only(url, tmpdir):
     "url",
     [
         "https://api.dandiarchive.org/api/dandisets/000027",
-        # TODO
-        #'https://api.dandiarchive.org/api/dandisets/000027/versions/draft/assets/?path=sub-RAT123'
+        # TODO: can't find any assets for 27
+        # 'https://api.dandiarchive.org/api/dandisets/000027/versions/draft/assets/?path=sub-RAT123'
     ],
 )
 def test_download_000027_assets_api(url, tmpdir):


### PR DESCRIPTION
this is an attempt to fix #550 

I believe the `asset` created by `navigate_url` should be changed, but I might have broken something else (haven't see any tests for this part of the code).

with this change the example from #550 seems to work, but I was having issue wit creating a test. Couldn't use `00003` since is too big, but for `000027` I don't get any files and I don't see any assets when I'm checking directly in my website `https://api.dandiarchive.org/api/dandisets/000027/versions/draft/assets/`, so my example for `https://api.dandiarchive.org/api/dandisets/000027/versions/draft/assets/?path=sub-RAT123` doesn't work.