### PR TITLE
Get hdmf, pynwb, h5py versions without importing

### DIFF
--- a/dandi/cli/command.py
+++ b/dandi/cli/command.py
@@ -107,16 +107,12 @@ def main(ctx, log_level, pdb=False):
     handler.setFormatter(fmter)
     root.addHandler(handler)
 
-    import h5py
-    import hdmf
-    import pynwb
-
     lgr.info(
         "dandi v%s, hdmf v%s, pynwb v%s, h5py v%s",
         __version__,
-        get_module_version(hdmf),
-        get_module_version(pynwb),
-        get_module_version(h5py),
+        get_module_version("hdmf"),
+        get_module_version("pynwb"),
+        get_module_version("h5py"),
         extra={"file_only": True},
     )
     lgr.info("sys.argv = %r", sys.argv, extra={"file_only": True})

--- a/dandi/utils.py
+++ b/dandi/utils.py
@@ -699,7 +699,7 @@ def is_url(s):
 def get_module_version(module: Union[str, types.ModuleType]) -> Optional[str]:
     """Return version of the module
 
-    Return module's `__version__` and if present, or use importlib
+    Return module's `__version__` if present, or use importlib
     to get version.
 
     Returns
@@ -708,13 +708,14 @@ def get_module_version(module: Union[str, types.ModuleType]) -> Optional[str]:
     """
     if isinstance(module, str):
         mod_name = module
-        if module not in sys.modules:
-            return None
-        module = sys.modules[module]
+        module = sys.modules.get(module)
     else:
         mod_name = module.__name__.split(".", 1)[0]
 
-    version = getattr(module, "__version__", None)
+    if module is not None:
+        version = getattr(module, "__version__", None)
+    else:
+        version = None
     if version is None:
         # Let's use the standard Python mechanism if underlying module
         # did not provide __version__


### PR DESCRIPTION
This cuts off about a second and a half from the dandi command's load time.