### PR TITLE
Update for the version /info endpoint in dandi-api

### DIFF
--- a/dandi/dandiapi.py
+++ b/dandi/dandiapi.py
@@ -275,7 +275,7 @@ class DandiAPIClient(RESTFullAPIClient):
 
     def get_dandiset(self, dandiset_id, version):
         return self._migrate_dandiset_metadata(
-            self.get(f"/dandisets/{dandiset_id}/versions/{version}/")
+            self.get(f"/dandisets/{dandiset_id}/versions/{version}/info/")
         )
 
     def set_dandiset_metadata(self, dandiset_id, *, metadata):


### PR DESCRIPTION
Required by https://github.com/dandi/dandi-api/pull/236

As described in https://github.com/dandi/dandi-api/pull/236, the
original `.../versions/{version_id}/` has been updated to only return
the version metadata. Because clients are still relying on the Django
serialized information about the version, that data can now be found at
`.../versions/{version_id}/info/`.