### PR TITLE
a script to validate dandi-api collection listing against girder

### DIFF
--- a/tools/validate-api-against-girder.py
+++ b/tools/validate-api-against-girder.py
@@ -7,6 +7,32 @@ from dandi.dandiset import APIDandiset
 from dandi.girder import GirderCli
 
 
+def adhoc_list_girder(_id, client, prefix=""):
+    """Pure girder API has no recursive listing, so let's do it manually"""
+    res = list()
+    ret = []
+    for r in client.listItem(_id):
+        assert r.get("_modelType", None) == "item"
+        f = list(client.listFile(r["_id"]))
+        if len(f) == 0:
+            print(f"  Empty item with prefix={prefix}: {r}")
+            continue
+        if len(f) != 1:
+            print("Multiple files for an item still found!")
+            print(f)
+            import pdb
+
+            pdb.set_trace()
+        else:
+            f = f[0]
+            assert f["size"] == r["size"]
+        yield (f"{prefix}{r['name']}", r["size"])
+
+    for r in client.listFolder(_id, "folder"):
+        assert r.get("_modelType", None) == "folder"
+        yield from adhoc_list_girder(r["_id"], client, f"{prefix}{r['name']}/")
+
+
 @click.command()
 def main():
     g_client = GirderCli("http://3.19.164.171")
@@ -19,12 +45,23 @@ def main():
             g_client.listFolder("5e59bb0af19e820ab6ea6c62", "collection")
         )
         for dandiset, girder_id in [(x["name"], x["_id"]) for x in g_dandisets]:
+            if dandiset != "000026":
+                continue
             print(f"DANDI:{dandiset}", end="\t")
             g_meta, g_assets_ = g_client.get_dandiset_and_assets(girder_id, "folder")
             g_assets = list(g_assets_)
             # harmonize and get only what we care about ATM - path and size,
             # or otherwise we would need to query each asset for metadata
             g_assets_h = set((a["path"].lstrip("/"), a["size"]) for a in g_assets)
+
+            # Yarik trusts nobody.  Two identical bugs are less likely!
+            g_assets_adhoc = set(adhoc_list_girder(girder_id, g_client))
+
+            if g_assets_h != g_assets_adhoc:
+                print("ad-hoc and dandi listing of girder differs!")
+                import pdb
+
+                pdb.set_trace()
 
             a_meta, a_assets_ = a_client.get_dandiset_and_assets(dandiset, "draft")
             a_assets = list(a_assets_)

--- a/tools/validate-api-against-girder.py
+++ b/tools/validate-api-against-girder.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+import click
+import requests
+
+from dandi.dandiapi import DandiAPIClient
+from dandi.dandiset import APIDandiset
+from dandi.girder import GirderCli
+
+
+@click.command()
+def main():
+    g_client = GirderCli("http://3.19.164.171")
+    a_client = DandiAPIClient("https://api.dandiarchive.org/api")
+
+    with a_client.session():
+        g_client.dandi_authenticate()
+        # gather all dandisets known to girder: hardcoded _id for "drafts" collection
+        g_dandisets = list(
+            g_client.listFolder("5e59bb0af19e820ab6ea6c62", "collection")
+        )
+        for dandiset, girder_id in [(x["name"], x["_id"]) for x in g_dandisets]:
+            print(f"DANDI:{dandiset}", end="\t")
+            g_meta, g_assets_ = g_client.get_dandiset_and_assets(girder_id, "folder")
+            g_assets = list(g_assets_)
+            # harmonize and get only what we care about ATM - path and size,
+            # or otherwise we would need to query each asset for metadata
+            g_assets_h = set((a["path"].lstrip("/"), a["size"]) for a in g_assets)
+
+            a_meta, a_assets_ = a_client.get_dandiset_and_assets(dandiset, "draft")
+            a_assets = list(a_assets_)
+            a_assets_h = set((a["path"].lstrip("/"), a["size"]) for a in a_assets)
+
+            if a_assets_h != g_assets_h:
+                print("differs")
+                import pdb
+
+                pdb.set_trace()
+            else:
+                print(f"{len(a_assets)} assets the same")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
for total paranoia - reimplemented logic for recursion through girder folders.  So comparing that one also against the one we get from our existing helpers, and then against output from API.

it is still running, but TODOs
- [x] dump here a full report

<details>
<summary>Full report</summary> 

```shell
$> python tools/validate-api-against-girder.py
DANDI:000003    101 assets the same
DANDI:000004    87 assets the same
DANDI:000005    148 assets the same
DANDI:000006    53 assets the same
DANDI:000007    54 assets the same
DANDI:000008    1328 assets the same
DANDI:000009    173 assets the same
DANDI:000010    158 assets the same
DANDI:000011    92 assets the same
DANDI:000012    297 assets the same
DANDI:000013    52 assets the same
DANDI:000015    210 assets the same
DANDI:000016    135 assets the same
DANDI:000017    39 assets the same
DANDI:000018    0 assets the same
DANDI:000019    31 assets the same
DANDI:000020    4435 assets the same
DANDI:000021    214 assets the same
DANDI:000022    169 assets the same
DANDI:000023    318 assets the same
DANDI:000024    0 assets the same
DANDI:000025    1 assets the same
Ran into an empty item: {'_id': '602ee37302cb75004f0af67b', '_modelType': 'item', 'baseParentId': '5e59bb0af19e820ab6ea6c62', 'baseParentType': 'collection', 'created': '2021-02-18T22:00:19.531000+00:00', 'creatorId': '5f106a1a18eb78d1fe6511af', 'description': '', 'folderId': '5f15f7f5f63d62e1dbd068d9', 'meta': {}, 'name': 'volume_high_res.mat', 'size': 0, 'updated': '2021-02-18T22:00:19.531000+00:00'}
Ran into an empty item: {'_id': '607475c002cb75004f0b2b17', '_modelType': 'item', 'baseParentId': '5e59bb0af19e820ab6ea6c62', 'baseParentType': 'collection', 'created': '2021-04-12T16:30:56.265000+00:00', 'creatorId': '5f158b6ef63d62e1dbd068d4', 'description': '', 'folderId': '606d7d0f02cb75004f0b2057', 'meta': {}, 'name': 'sub-I46_sample-MotorCortexS01_stain-Calretinin_chunk-03_SPIM.ome.tiff', 'size': 0, 'updated': '2021-04-12T16:30:56.265000+00:00'}
Ran into an empty item: {'_id': '6074764f02cb75004f0b2b20', '_modelType': 'item', 'baseParentId': '5e59bb0af19e820ab6ea6c62', 'baseParentType': 'collection', 'created': '2021-04-12T16:33:19.482000+00:00', 'creatorId': '5f158b6ef63d62e1dbd068d4', 'description': '', 'folderId': '606d7d0f02cb75004f0b2057', 'meta': {}, 'name': 'sub-I46_sample-MotorCortexS01_stain-Calretinin_chunk-10_SPIM.ome.tiff', 'size': 0, 'updated': '2021-04-12T16:33:19.482000+00:00'}
Ran into an empty item: {'_id': '607476f102cb75004f0b2b26', '_modelType': 'item', 'baseParentId': '5e59bb0af19e820ab6ea6c62', 'baseParentType': 'collection', 'created': '2021-04-12T16:36:01.638000+00:00', 'creatorId': '5f158b6ef63d62e1dbd068d4', 'description': '', 'folderId': '606d7d0f02cb75004f0b2057', 'meta': {}, 'name': 'sub-I46_sample-MotorCortexS03_stain-Calretinin_chunk-04_SPIM.ome.tiff', 'size': 0, 'updated': '2021-04-12T16:36:01.638000+00:00'}
Ran into an empty item: {'_id': '6074780e02cb75004f0b2b29', '_modelType': 'item', 'baseParentId': '5e59bb0af19e820ab6ea6c62', 'baseParentType': 'collection', 'created': '2021-04-12T16:40:46.977000+00:00', 'creatorId': '5f158b6ef63d62e1dbd068d4', 'description': '', 'folderId': '606d7d0f02cb75004f0b2057', 'meta': {}, 'name': 'sub-I46_sample-MotorCortexS03_stain-Calretinin_chunk-08_SPIM.ome.tiff', 'size': 0, 'updated': '2021-04-12T16:40:46.977000+00:00'}
Ran into an empty item: {'_id': '60747a8b02cb75004f0b2b31', '_modelType': 'item', 'baseParentId': '5e59bb0af19e820ab6ea6c62', 'baseParentType': 'collection', 'created': '2021-04-12T16:51:23.575000+00:00', 'creatorId': '5f158b6ef63d62e1dbd068d4', 'description': '', 'folderId': '606d7d0f02cb75004f0b2057', 'meta': {}, 'name': 'sub-I46_sample-MotorCortexS03_stain-NeuN_chunk-00_SPIM.ome.tiff', 'size': 0, 'updated': '2021-04-12T16:51:23.575000+00:00'}
Ran into an empty item: {'_id': '60747c0102cb75004f0b2b35', '_modelType': 'item', 'baseParentId': '5e59bb0af19e820ab6ea6c62', 'baseParentType': 'collection', 'created': '2021-04-12T16:57:37.964000+00:00', 'creatorId': '5f158b6ef63d62e1dbd068d4', 'description': '', 'folderId': '606d7d0f02cb75004f0b2057', 'meta': {}, 'name': 'sub-I46_sample-MotorCortexS03_stain-NeuN_chunk-10_SPIM.ome.tiff', 'size': 0, 'updated': '2021-04-12T16:57:37.964000+00:00'}
Ran into an empty item: {'_id': '60747a6602cb75004f0b2b2c', '_modelType': 'item', 'baseParentId': '5e59bb0af19e820ab6ea6c62', 'baseParentType': 'collection', 'created': '2021-04-12T16:50:46.835000+00:00', 'creatorId': '5f158b6ef63d62e1dbd068d4', 'description': '', 'folderId': '606d7d0f02cb75004f0b2057', 'meta': {}, 'name': 'sub-I46_sample-MotorCortexS03_stain-Nuclei_chunk-00_SPIM.ome.tiff', 'size': 0, 'updated': '2021-04-12T16:50:46.835000+00:00'}
Ran into an empty item: {'_id': '60747a8b02cb75004f0b2b30', '_modelType': 'item', 'baseParentId': '5e59bb0af19e820ab6ea6c62', 'baseParentType': 'collection', 'created': '2021-04-12T16:51:23.142000+00:00', 'creatorId': '5f158b6ef63d62e1dbd068d4', 'description': '', 'folderId': '606d7d0f02cb75004f0b2057', 'meta': {}, 'name': 'sub-I46_sample-MotorCortexS03_stain-Nuclei_chunk-05_SPIM.ome.tiff', 'size': 0, 'updated': '2021-04-12T16:51:23.142000+00:00'}
Ran into an empty item: {'_id': '60747c7d02cb75004f0b2b38', '_modelType': 'item', 'baseParentId': '5e59bb0af19e820ab6ea6c62', 'baseParentType': 'collection', 'created': '2021-04-12T16:59:41.590000+00:00', 'creatorId': '5f158b6ef63d62e1dbd068d4', 'description': '', 'folderId': '606d7d0f02cb75004f0b2057', 'meta': {}, 'name': 'sub-I46_sample-MotorCortexS04_stain-Calretinin_chunk-01_SPIM.ome.tiff', 'size': 0, 'updated': '2021-04-12T16:59:41.590000+00:00'}
Ran into an empty item: {'_id': '60747c8a02cb75004f0b2b3b', '_modelType': 'item', 'baseParentId': '5e59bb0af19e820ab6ea6c62', 'baseParentType': 'collection', 'created': '2021-04-12T16:59:54.535000+00:00', 'creatorId': '5f158b6ef63d62e1dbd068d4', 'description': '', 'folderId': '606d7d0f02cb75004f0b2057', 'meta': {}, 'name': 'sub-I46_sample-MotorCortexS04_stain-Calretinin_chunk-10_SPIM.ome.tiff', 'size': 0, 'updated': '2021-04-12T16:59:54.535000+00:00'}
DANDI:000026      Empty item with prefix=rawdata/sub-I46/ses-OCT/: {'_id': '602ee37302cb75004f0af67b', '_modelType': 'item', 'baseParentId': '5e59bb0af19e820ab6ea6c62', 'baseParentType': 'collection', 'created': '2021-02-18T22:00:19.531000+00:00', 'creatorId': '5f106a1a18eb78d1fe6511af', 'description': '', 'folderId': '5f15f7f5f63d62e1dbd068d9', 'meta': {}, 'name': 'volume_high_res.mat', 'size': 0, 'updated': '2021-02-18T22:00:19.531000+00:00'}
  Empty item with prefix=sub-I46/microscopy/: {'_id': '607475c002cb75004f0b2b17', '_modelType': 'item', 'baseParentId': '5e59bb0af19e820ab6ea6c62', 'baseParentType': 'collection', 'created': '2021-04-12T16:30:56.265000+00:00', 'creatorId': '5f158b6ef63d62e1dbd068d4', 'description': '', 'folderId': '606d7d0f02cb75004f0b2057', 'meta': {}, 'name': 'sub-I46_sample-MotorCortexS01_stain-Calretinin_chunk-03_SPIM.ome.tiff', 'size': 0, 'updated': '2021-04-12T16:30:56.265000+00:00'}
  Empty item with prefix=sub-I46/microscopy/: {'_id': '6074764f02cb75004f0b2b20', '_modelType': 'item', 'baseParentId': '5e59bb0af19e820ab6ea6c62', 'baseParentType': 'collection', 'created': '2021-04-12T16:33:19.482000+00:00', 'creatorId': '5f158b6ef63d62e1dbd068d4', 'description': '', 'folderId': '606d7d0f02cb75004f0b2057', 'meta': {}, 'name': 'sub-I46_sample-MotorCortexS01_stain-Calretinin_chunk-10_SPIM.ome.tiff', 'size': 0, 'updated': '2021-04-12T16:33:19.482000+00:00'}
  Empty item with prefix=sub-I46/microscopy/: {'_id': '607476f102cb75004f0b2b26', '_modelType': 'item', 'baseParentId': '5e59bb0af19e820ab6ea6c62', 'baseParentType': 'collection', 'created': '2021-04-12T16:36:01.638000+00:00', 'creatorId': '5f158b6ef63d62e1dbd068d4', 'description': '', 'folderId': '606d7d0f02cb75004f0b2057', 'meta': {}, 'name': 'sub-I46_sample-MotorCortexS03_stain-Calretinin_chunk-04_SPIM.ome.tiff', 'size': 0, 'updated': '2021-04-12T16:36:01.638000+00:00'}
  Empty item with prefix=sub-I46/microscopy/: {'_id': '6074780e02cb75004f0b2b29', '_modelType': 'item', 'baseParentId': '5e59bb0af19e820ab6ea6c62', 'baseParentType': 'collection', 'created': '2021-04-12T16:40:46.977000+00:00', 'creatorId': '5f158b6ef63d62e1dbd068d4', 'description': '', 'folderId': '606d7d0f02cb75004f0b2057', 'meta': {}, 'name': 'sub-I46_sample-MotorCortexS03_stain-Calretinin_chunk-08_SPIM.ome.tiff', 'size': 0, 'updated': '2021-04-12T16:40:46.977000+00:00'}
  Empty item with prefix=sub-I46/microscopy/: {'_id': '60747a8b02cb75004f0b2b31', '_modelType': 'item', 'baseParentId': '5e59bb0af19e820ab6ea6c62', 'baseParentType': 'collection', 'created': '2021-04-12T16:51:23.575000+00:00', 'creatorId': '5f158b6ef63d62e1dbd068d4', 'description': '', 'folderId': '606d7d0f02cb75004f0b2057', 'meta': {}, 'name': 'sub-I46_sample-MotorCortexS03_stain-NeuN_chunk-00_SPIM.ome.tiff', 'size': 0, 'updated': '2021-04-12T16:51:23.575000+00:00'}
  Empty item with prefix=sub-I46/microscopy/: {'_id': '60747c0102cb75004f0b2b35', '_modelType': 'item', 'baseParentId': '5e59bb0af19e820ab6ea6c62', 'baseParentType': 'collection', 'created': '2021-04-12T16:57:37.964000+00:00', 'creatorId': '5f158b6ef63d62e1dbd068d4', 'description': '', 'folderId': '606d7d0f02cb75004f0b2057', 'meta': {}, 'name': 'sub-I46_sample-MotorCortexS03_stain-NeuN_chunk-10_SPIM.ome.tiff', 'size': 0, 'updated': '2021-04-12T16:57:37.964000+00:00'}
  Empty item with prefix=sub-I46/microscopy/: {'_id': '60747a6602cb75004f0b2b2c', '_modelType': 'item', 'baseParentId': '5e59bb0af19e820ab6ea6c62', 'baseParentType': 'collection', 'created': '2021-04-12T16:50:46.835000+00:00', 'creatorId': '5f158b6ef63d62e1dbd068d4', 'description': '', 'folderId': '606d7d0f02cb75004f0b2057', 'meta': {}, 'name': 'sub-I46_sample-MotorCortexS03_stain-Nuclei_chunk-00_SPIM.ome.tiff', 'size': 0, 'updated': '2021-04-12T16:50:46.835000+00:00'}
  Empty item with prefix=sub-I46/microscopy/: {'_id': '60747a8b02cb75004f0b2b30', '_modelType': 'item', 'baseParentId': '5e59bb0af19e820ab6ea6c62', 'baseParentType': 'collection', 'created': '2021-04-12T16:51:23.142000+00:00', 'creatorId': '5f158b6ef63d62e1dbd068d4', 'description': '', 'folderId': '606d7d0f02cb75004f0b2057', 'meta': {}, 'name': 'sub-I46_sample-MotorCortexS03_stain-Nuclei_chunk-05_SPIM.ome.tiff', 'size': 0, 'updated': '2021-04-12T16:51:23.142000+00:00'}
  Empty item with prefix=sub-I46/microscopy/: {'_id': '60747c7d02cb75004f0b2b38', '_modelType': 'item', 'baseParentId': '5e59bb0af19e820ab6ea6c62', 'baseParentType': 'collection', 'created': '2021-04-12T16:59:41.590000+00:00', 'creatorId': '5f158b6ef63d62e1dbd068d4', 'description': '', 'folderId': '606d7d0f02cb75004f0b2057', 'meta': {}, 'name': 'sub-I46_sample-MotorCortexS04_stain-Calretinin_chunk-01_SPIM.ome.tiff', 'size': 0, 'updated': '2021-04-12T16:59:41.590000+00:00'}
  Empty item with prefix=sub-I46/microscopy/: {'_id': '60747c8a02cb75004f0b2b3b', '_modelType': 'item', 'baseParentId': '5e59bb0af19e820ab6ea6c62', 'baseParentType': 'collection', 'created': '2021-04-12T16:59:54.535000+00:00', 'creatorId': '5f158b6ef63d62e1dbd068d4', 'description': '', 'folderId': '606d7d0f02cb75004f0b2057', 'meta': {}, 'name': 'sub-I46_sample-MotorCortexS04_stain-Calretinin_chunk-10_SPIM.ome.tiff', 'size': 0, 'updated': '2021-04-12T16:59:54.535000+00:00'}
1196 assets the same
DANDI:000027    1 assets the same
DANDI:000028    3 assets the same
Ran into an empty item: {'_id': '5f244abe79d3faee686c7495', '_modelType': 'item', 'baseParentId': '5e59bb0af19e820ab6ea6c62', 'baseParentType': 'collection', 'created': '2020-07-31T16:45:50.199000+00:00', 'creatorId': '5d978d9ecc10d1bc31040bc9', 'description': '', 'folderId': '5f244abd79d3faee686c7494', 'meta': {}, 'name': 'sub-759711149_probe-792602650_ecephys.nwb', 'size': 0, 'updated': '2020-07-31T16:45:50.199000+00:00'}
DANDI:000029      Empty item with prefix=sub-759711149/: {'_id': '5f244abe79d3faee686c7495', '_modelType': 'item', 'baseParentId': '5e59bb0af19e820ab6ea6c62', 'baseParentType': 'collection', 'created': '2020-07-31T16:45:50.199000+00:00', 'creatorId': '5d978d9ecc10d1bc31040bc9', 'description': '', 'folderId': '5f244abd79d3faee686c7494', 'meta': {}, 'name': 'sub-759711149_probe-792602650_ecephys.nwb', 'size': 0, 'updated': '2020-07-31T16:45:50.199000+00:00'}
5 assets the same
DANDI:000030    0 assets the same
DANDI:000031    0 assets the same
DANDI:000032    0 assets the same
DANDI:000033    0 assets the same
DANDI:000034    6 assets the same
DANDI:000035    185 assets the same
DANDI:000036    57 assets the same
DANDI:000037    47 assets the same
DANDI:000038    0 assets the same
DANDI:000039    100 assets the same
DANDI:000040    0 assets the same
DANDI:000041    22 assets the same
DANDI:000042    0 assets the same
DANDI:000043    64 assets the same
DANDI:000044    8 assets the same
DANDI:000045    6615 assets the same
DANDI:000046    0 assets the same
DANDI:000047    0 assets the same
DANDI:000048    1 assets the same
DANDI:000049    78 assets the same
DANDI:000050    56 assets the same
DANDI:000051    1 assets the same
DANDI:000052    518 assets the same
Ran into an empty item: {'_id': '5fe272551eee1c6740c2d636', '_modelType': 'item', 'baseParentId': '5e59bb0af19e820ab6ea6c62', 'baseParentType': 'collection', 'created': '2020-12-22T22:25:25.534000+00:00', 'creatorId': '5da4b8fe51c340795cb18fd0', 'description': '', 'folderId': '5fe272551eee1c6740c2d635', 'meta': {'experiment_description': 'trial contrast: 100', 'identifier': '0413_baseline_2', 'institution': 'stanford university', 'lab': 'giocomo', 'md5': '136d964a399f536cb9b828258b8c8121', 'nwb_version': '2.2.5', 'session_description': 'straight track.', 'session_start_time': '2019-04-13T00:00:00-07:00', 'sha1': 'f87b3fcaec1775b8ceb971eb2fec1c429b5613bc', 'sha256': 'e577e3e995cffbe8b58e56b360c3f424394093147461e99b9ca811fcc12a1c78', 'sha512': 'e5620608f27c31484dcabd035e12cd386f2e7ec7ec63df44784b6d749e71ebf4f1e62b46237714577ec13e77f9b8cc711e25a0be6ce9c4ceae5fb1e48be9d760', 'subject_id': 'npi1', 'uploaded_by': 'dandi 0.10.0', 'uploaded_datetime': '2020-12-22T17:29:17.680182-05:00', 'uploaded_mtime': '2020-12-22T15:20:04.650000-05:00', 'uploaded_nwb_object_id': '325ce9d6-2dd2-4d43-933b-77fb439893bd', 'uploaded_size': 19000808}, 'name': 'sub-npI1_ses-20190413_behavior.nwb', 'size': 19000808, 'updated': '2020-12-22T22:29:38.842000+00:00'}
DANDI:000053      Empty item with prefix=sub-npI1/: {'_id': '5fe272551eee1c6740c2d636', '_modelType': 'item', 'baseParentId': '5e59bb0af19e820ab6ea6c62', 'baseParentType': 'collection', 'created': '2020-12-22T22:25:25.534000+00:00', 'creatorId': '5da4b8fe51c340795cb18fd0', 'description': '', 'folderId': '5fe272551eee1c6740c2d635', 'meta': {'experiment_description': 'trial contrast: 100', 'identifier': '0413_baseline_2', 'institution': 'stanford university', 'lab': 'giocomo', 'md5': '136d964a399f536cb9b828258b8c8121', 'nwb_version': '2.2.5', 'session_description': 'straight track.', 'session_start_time': '2019-04-13T00:00:00-07:00', 'sha1': 'f87b3fcaec1775b8ceb971eb2fec1c429b5613bc', 'sha256': 'e577e3e995cffbe8b58e56b360c3f424394093147461e99b9ca811fcc12a1c78', 'sha512': 'e5620608f27c31484dcabd035e12cd386f2e7ec7ec63df44784b6d749e71ebf4f1e62b46237714577ec13e77f9b8cc711e25a0be6ce9c4ceae5fb1e48be9d760', 'subject_id': 'npi1', 'uploaded_by': 'dandi 0.10.0', 'uploaded_datetime': '2020-12-22T17:29:17.680182-05:00', 'uploaded_mtime': '2020-12-22T15:20:04.650000-05:00', 'uploaded_nwb_object_id': '325ce9d6-2dd2-4d43-933b-77fb439893bd', 'uploaded_size': 19000808}, 'name': 'sub-npI1_ses-20190413_behavior.nwb', 'size': 19000808, 'updated': '2020-12-22T22:29:38.842000+00:00'}
359 assets the same
DANDI:000054    85 assets the same
DANDI:000055    55 assets the same
DANDI:000056    40 assets the same
DANDI:000057    0 assets the same
DANDI:000058    0 assets the same
DANDI:000059    54 assets the same
DANDI:000060    98 assets the same
DANDI:000061    40 assets the same
DANDI:000062    0 assets the same
DANDI:000063    0 assets the same
DANDI:000064    1 assets the same
DANDI:000065    1 assets the same
DANDI:000066    4 assets the same
DANDI:000067    28 assets the same

```
</details>

- [x] file an issue with listing of empty "items" on girder - I guess transmission of a file was interrupted while uploading, and user did not reupload.  There is a number of those
  - [ ] https://github.com/dandisets/000026/issues/1
  - [ ] https://github.com/dandisets/000029/issues/1
  - [ ] https://github.com/dandisets/000053/issues/1
- [x] hopefully script doesn't fall into pdb if smth goes unexpected (e.g. still multiple files per item) etc
- [x] I think it will be ok to merge the script but better to remove TEMP commit which just hardcodes new girder address (no https) so that just auth etc just works 
