### PR TITLE
Restrict numpy version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,8 @@ install_requires =
     jsonschema
     keyring
     keyrings.alt
+    # Remove this line once hdmf supports h5py v3.0+:
+    numpy >=1.16, <1.19.4 ; python_version > "3.8"
     pycryptodomex  # for EncryptedKeyring backend in keyrings.alt
     pydantic >= 1.8.1
     pynwb >= 1.0.3,!=1.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ install_requires =
     keyring
     keyrings.alt
     # Remove this line once hdmf supports h5py v3.0+:
-    numpy >=1.16, <1.19.4 ; python_version > "3.8"
+    numpy >=1.16, <1.19.4
     pycryptodomex  # for EncryptedKeyring backend in keyrings.alt
     pydantic >= 1.8.1
     pynwb >= 1.0.3,!=1.1.0


### PR DESCRIPTION
A recent version of hdmf added support for newer versions of numpy than 1.19, which is the latest version that version 2 of h5py can be built with.  As a result, a newer version of numpy was being installed than h5py could handle.  This patch restricts the numpy version on Python 3.9+, for which h5py 2.x does not provide wheels.  It should become unnecessary once hmdf supports h5py 3.0.