### PR TITLE
Remove numpy pre-pinning in test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,14 +67,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip wheel
-        # As of 2021-02-01, the latest version of hdmf (v2.3.0) requires numpy
-        # >=1.16, <1.19.4, so we end up with numpy 1.19.3 installed.  However,
-        # due to the release of numpy 1.20.0 on January 30, h5py gets built
-        # against the later version instead, and because numpy 1.20.0 changed
-        # the size of ndarray, an error results at runtime.  This can be worked
-        # around by installing numpy before the other dependencies so that it
-        # is available when h5py is built.
-        pip install 'numpy<1.19.4'
         pip install ".[test]"
 
     - name: Install dev version of pynwb

--- a/tox.ini
+++ b/tox.ini
@@ -31,10 +31,11 @@ filterwarnings =
     ignore::DeprecationWarning:requests_toolbelt
     # <https://github.com/h5py/h5py/issues/1765>
     # <https://github.com/dandi/dandi-cli/pull/275>
-    ignore:numpy.ufunc size changed, may indicate binary incompatibility.*:RuntimeWarning
+    ignore:.* size changed, may indicate binary incompatibility.*:RuntimeWarning
     # <https://github.com/hdmf-dev/hdmf/issues/547>
     ignore:\s*safe_load will be removed.*:PendingDeprecationWarning:hdmf
     ignore:\s*load will be removed.*:PendingDeprecationWarning:ruamel.yaml
+    ignore:Passing None into shape arguments.*:DeprecationWarning:h5py
 
 [coverage:run]
 parallel = True


### PR DESCRIPTION
This started out as a test to see what happened, but with the adjustment of pytest's warning settings, I've gotten the change to work.