### PR TITLE
Make test_server_info use Docker fixture if DANDI_REDIRECTOR_BASE is set

### DIFF
--- a/dandi/tests/test_utils.py
+++ b/dandi/tests/test_utils.py
@@ -1,4 +1,5 @@
 import inspect
+import os
 import os.path as op
 import time
 
@@ -321,7 +322,16 @@ def test_get_instance_actual_dandi():
     assert inst.api is not None
 
 
+if "DANDI_REDIRECTOR_BASE" in os.environ:
+    using_docker = pytest.mark.usefixtures("local_dandi_api")
+else:
+
+    def using_docker(f):
+        return f
+
+
 @pytest.mark.redirector
+@using_docker
 def test_server_info():
     r = requests.get(f"{redirector_base}/server-info")
     r.raise_for_status()


### PR DESCRIPTION
This is needed for https://github.com/dandi/redirector/pull/47.