### PR TITLE
Add dandi-staging to known_instances

### DIFF
--- a/dandi/consts.py
+++ b/dandi/consts.py
@@ -86,6 +86,11 @@ known_instances = {
         None,
         None,
     ),
+    "dandi-staging": dandi_instance(
+        "https://gui-staging.dandiarchive.org",
+        None,
+        "https://api-staging.dandiarchive.org/api"
+    ),
     "dandi-api-local-docker-tests": dandi_instance(
         None, None, f"http://{instancehost}:8000/api"
     ),


### PR DESCRIPTION
There is now a staging API server set up at https://api-staging.dandiarchive.org, so it would be cool if dandi-cli could upload to it.