### PR TITLE
Pin dandischema to compatible 0.minor version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     appdirs
     click
     click-didyoumean
-    dandischema
+    dandischema ~= 0.1.0
     etelemetry >= 0.2.0
     fasteners
     fscacher


### PR DESCRIPTION
since we are not at luxury to "redeploy" dandi-cli rapidly (installed by
users), I see no other way than this.