### PR TITLE
fix: pin to range

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     appdirs
     click
     click-didyoumean
-    dandischema ~= 0.2.3
+    dandischema >= 0.2.3,<0.3.0
     etelemetry >= 0.2.0
     fasteners
     fscacher


### PR DESCRIPTION
lower bound should move only as we finalize the lowest schema version supported. for now allow for ranges of schema