### PR TITLE
Run test workflow on pushes only on master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: Tests
 
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 6 * * *'


### PR DESCRIPTION
I think it is time to just switch to do testing on PR merges, and avoid testing on pushes to PR branches.