### PR TITLE
Fix a failing test on Windows on conda-forge

### DIFF
--- a/dandi/cli/tests/test_shell_completion.py
+++ b/dandi/cli/tests/test_shell_completion.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 import subprocess
 
@@ -15,4 +16,10 @@ else:
 
 @pytest.mark.skipif(not bash_works, reason="Bash required")
 def test_shell_completion_sourceable():
-    subprocess.run(["bash", "-c", "source <(dandi shell-completion)"], check=True)
+    subprocess.run(
+        ["bash", "-c", "source <(dandi shell-completion)"],
+        check=True,
+        # When testing for conda-forge on Windows, SHELL doesn't seem to be
+        # set, so we need to set it ourselves:
+        env={**os.environ, "SHELL": shutil.which("bash")},
+    )


### PR DESCRIPTION
dandi's conda-forge build is failing on Windows in part because `SHELL` isn't set for some reason when passing the shell completion command to Bash.  This PR fixes that by always setting `SHELL` explicitly.