### PR TITLE
Fix a failing test on Windows on conda-forge (again)

### DIFF
--- a/dandi/cli/cmd_shell_completion.py
+++ b/dandi/cli/cmd_shell_completion.py
@@ -36,6 +36,8 @@ def shell_completion(shell):
             raise click.UsageError(
                 "Could not determine running shell: SHELL environment variable not set"
             )
+        if shell.lower().endswith(".exe"):
+            shell = shell[:-4]
         if shell not in SHELLS:
             raise click.UsageError(f"Unsupported/unrecognized shell {shell!r}")
     if Version(click.__version__) < Version("8.0.0"):

--- a/dandi/cli/cmd_shell_completion.py
+++ b/dandi/cli/cmd_shell_completion.py
@@ -1,5 +1,5 @@
 import os
-from os.path import basename
+from os.path import basename, normcase, splitext
 
 import click
 from packaging.version import Version
@@ -36,8 +36,10 @@ def shell_completion(shell):
             raise click.UsageError(
                 "Could not determine running shell: SHELL environment variable not set"
             )
-        if shell.lower().endswith(".exe"):
-            shell = shell[:-4]
+        shell = normcase(shell)
+        stem, ext = splitext(shell)
+        if ext in (".com", ".exe", ".bat"):
+            shell = stem
         if shell not in SHELLS:
             raise click.UsageError(f"Unsupported/unrecognized shell {shell!r}")
     if Version(click.__version__) < Version("8.0.0"):


### PR DESCRIPTION
dandi's conda-forge build is failing on Windows in part because the bash executable is named `bash.EXE`.  This PR fixes that by stripping off any ".exe" suffix (case insensitive) from the SHELL value before using it.