### PR TITLE
Skip shell completion test entirely on Windows

### DIFF
--- a/dandi/cli/tests/test_shell_completion.py
+++ b/dandi/cli/tests/test_shell_completion.py
@@ -4,17 +4,15 @@ import subprocess
 
 import pytest
 
-# In GitHub Actions' Windows environments, Bash is nominally present in the
-# PATH, but it doesn't actually work when run, so we need to check for more
-# than just `which`-ability.
-if shutil.which("bash") is None:
-    bash_works = False
-else:
-    r = subprocess.run(["bash", "--version"], capture_output=True, text=True)
-    bash_works = r.returncode == 0 and "GNU" in r.stdout
+from ...utils import on_windows
 
 
-@pytest.mark.skipif(not bash_works, reason="Bash required")
+# Process substitution is apparently broken on certain older versions of Bash
+# on Windows, which includes the version used by conda-forge as of 2021-07-08,
+# so we need to skip this test entirely on Windows.
+@pytest.mark.skipif(
+    shutil.which("bash") is None or on_windows, reason="Bash on POSIX required"
+)
 def test_shell_completion_sourceable():
     subprocess.run(
         ["bash", "-c", "source <(dandi shell-completion)"],


### PR DESCRIPTION
It just doesn't work on conda-forge.