### PR TITLE
Use timed wait in publish test

### DIFF
--- a/dandi/dandiapi.py
+++ b/dandi/dandiapi.py
@@ -429,28 +429,33 @@ class RemoteDandiset(APIBase):
             json={"metadata": metadata, "name": metadata.get("name", "")},
         )
 
+    def wait_until_valid(self, min_time=20):
+        """
+        Wait for a Dandiset to be valid.  Validation is a background celery
+        task which runs asynchronously, so we need to wait for it to complete.
+        """
+        lgr.debug("Waiting for Dandiset %s to complete validation ...", self.identifier)
+        start = time()
+        while time() - start < min_time:
+            r = self.client.get(f"{self.version_api_path}info/")
+            if "status" not in r:
+                # Running against older version of dandi-api that doesn't
+                # validate
+                return
+            if r["status"] == "Valid":
+                return
+            sleep(0.5)
+        else:
+            raise ValueError(
+                f"Dandiset {self.identifier} is {r['status']}: {r['validation_error']}"
+            )
+
     def publish(self) -> "RemoteDandiset":
         """
         Publish this version of the Dandiset.  Returns a copy of the
         `RemoteDandiset` with the `version` attribute set to the new published
         `Version`.
         """
-        lgr.debug("Waiting for Dandiset %s to complete validation ...", self.identifier)
-        start = time()
-        # Wait 20s for celery tasks to finish
-        while time() - start < 20:
-            r = self.client.get(f"{self.version_api_path}info/")
-            if "status" not in r:
-                # Running against older version of dandi-api that doesn't
-                # validate
-                break
-            if r["status"] == "Valid":
-                break
-            sleep(0.5)
-        else:
-            raise ValueError(
-                f"Dandiset {self.identifier} is {r['status']}: {r['validation_error']}"
-            )
         return self.copy(
             update={
                 "version": Version.parse_obj(

--- a/dandi/dandiapi.py
+++ b/dandi/dandiapi.py
@@ -445,10 +445,9 @@ class RemoteDandiset(APIBase):
             if r["status"] == "Valid":
                 return
             sleep(0.5)
-        else:
-            raise ValueError(
-                f"Dandiset {self.identifier} is {r['status']}: {r['validation_error']}"
-            )
+        raise ValueError(
+            f"Dandiset {self.identifier} is {r['status']}: {r['validation_error']}"
+        )
 
     def publish(self) -> "RemoteDandiset":
         """

--- a/dandi/tests/test_dandiapi.py
+++ b/dandi/tests/test_dandiapi.py
@@ -64,6 +64,7 @@ def test_publish_and_manipulate(local_dandi_api, monkeypatch, tmp_path):
         validation="skip",
     )
 
+    d.wait_until_valid()
     version_id = d.publish().version.identifier
 
     download_dir = tmp_path / "download"


### PR DESCRIPTION
I think the flaky tests we have been seeing are being caused by multiple
sequential celery tasks. Creating a new dandiset and uploading an asset
both trigger the validation task, but the first one is guaranteed to
fail. I think the test was noticing that first failure and quitting
immediately, instead of waiting the extra time required for the second
task to validate correctly.

Should fix dandi/dandi-api#393