### PR TITLE
BF(TST): Allow for IteratorWithAggregation to get nothing if reraise_immediately

### DIFF
--- a/dandi/support/tests/test_iterators.py
+++ b/dandi/support/tests/test_iterators.py
@@ -59,7 +59,7 @@ def test_IteratorWithAggregation():
     assert got == [0, 1, 2]
     assert it.finished
 
-    # If there is an exception thrown, it would be raised only by the end
+    # If there is an exception thrown, it would be raised immediately
     it = IteratorWithAggregation(
         sleeping_range(5, 0.0001, thr=2), agg=sumup, reraise_immediately=True
     )
@@ -69,5 +69,5 @@ def test_IteratorWithAggregation():
             got.append(i)
             # sleep long enough to trigger exception before next iteration
             sleep(0.02 if not slow_machine else 0.1)
-    assert got == [0]
+    assert got in ([], [0])
     assert it.finished


### PR DESCRIPTION
with all the threading etc, I guess there is no way to guarantee it always
getting at least that single one before exception.  From one of the runs
in dandi-api:
https://github.com/dandi/dandi-cli/pull/706/checks?check_run_id=3030777195

	_________________________ test_IteratorWithAggregation _________________________
	dandi/support/tests/test_iterators.py:72: in test_IteratorWithAggregation
		assert got == [0]
	E   assert [] == [0]
	E     Right contains one more item: 0
	E     Full diff:
	E     - [0]
	E     ?  -
	E     + []