### PR TITLE
Increase retries & wait times for API errors

### DIFF
--- a/dandi/dandiapi.py
+++ b/dandi/dandiapi.py
@@ -130,7 +130,7 @@ class RESTFullAPIClient:
             doretry |= retry
 
         try:
-            result = try_multiple(5, doretry, 1.1)(
+            result = try_multiple(12, doretry, 1.25)(
                 f,
                 url,
                 params=params,


### PR DESCRIPTION
Closes #714.

Tenacity does not seem to support indefinite retrying for only one type of error.