### PR TITLE
Install "test" extras when building docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,6 +6,7 @@ python:
         - requirements: docs/requirements.txt
         - method: pip
           path: .
+          extra_requirements: [test]
 sphinx:
     configuration: docs/source/conf.py
     fail_on_warning: true

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ commands =
 [testenv:docs]
 basepython = python3
 deps = -rdocs/requirements.txt
+extras = test
 changedir = docs
 commands = sphinx-build -E -W -b html source build
 


### PR DESCRIPTION
The docs try to document a couple test modules that import pytest, so that needs to be installed when building the docs.

Closes #717.