### PR TITLE
Set "version" in docs/source/conf.py

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,6 +24,7 @@ author = "DANDI Team"
 import dandi
 
 # The full version, including alpha/beta/rc tags
+version = dandi.__version__
 release = dandi.__version__
 
 


### PR DESCRIPTION
This field seems to be required by the EPUB builder, and the lack of it is causing the build on "latest" to fail.

Closes #717 (again).