### PR TITLE
Stretch the doc to the screen width

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -1,0 +1,5 @@
+@import './alabaster.css';  /* for Alabaster */
+
+div.footer {
+    text-align: center;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -49,8 +49,13 @@ exclude_patterns = []
 # a list of builtin themes.
 #
 html_theme = "alabaster"
+html_theme_options = {
+    "page_width": "auto",
+    "body_max_width": "auto",
+}
+html_style = "custom.css"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-# html_static_path = ["_static"]
+html_static_path = ["_static"]


### PR DESCRIPTION
Default alabaster"s width is too narrow and causes too many word
and signature wraps.  I would leave it to the user to decide which
width they want.  someone with more CSS knowledge could make it a bit more dynamic
but default is really suboptimal IMHO

after preview is available, compare e.g. to https://dandi--718.org.readthedocs.build/en/718/modref/dandiarchive.html 