### PR TITLE
ENH: exit with non-0 when "bad_version" of dandi-cli is used

### DIFF
--- a/dandi/cli/command.py
+++ b/dandi/cli/command.py
@@ -128,7 +128,13 @@ def main(ctx, log_level, pdb=False):
     try:
         import etelemetry
 
-        etelemetry.check_available_version("dandi/dandi-cli", __version__, lgr=lgr)
+        try:
+            etelemetry.check_available_version(
+                "dandi/dandi-cli", __version__, lgr=lgr, raise_exception=True
+            )
+        except etelemetry.client.BadVersionError as exc:
+            # note: SystemExit is based of BaseException, so is not Exception
+            raise SystemExit(str(exc))
     except Exception as exc:
         lgr.warning(
             "Failed to check for a more recent version available with etelemetry: %s",

--- a/dandi/cli/command.py
+++ b/dandi/cli/command.py
@@ -132,9 +132,17 @@ def main(ctx, log_level, pdb=False):
             etelemetry.check_available_version(
                 "dandi/dandi-cli", __version__, lgr=lgr, raise_exception=True
             )
-        except etelemetry.client.BadVersionError as exc:
+        except etelemetry.client.BadVersionError:
             # note: SystemExit is based of BaseException, so is not Exception
-            raise SystemExit(str(exc))
+            raise SystemExit(
+                "DANDI CLI has detected that you are using a version that is known to "
+                "contain bugs, is incompatible with our current data archive, or has "
+                "other significant performance limitations. "
+                "To continue using DANDI CLI, please upgrade your dandi client to a newer "
+                "version (e.g., using pip install --upgrade dandi if you installed using pip). "
+                "If you have any issues, please contact the DANDI "
+                "helpdesk at https://github.com/dandi/helpdesk/issues/new/choose ."
+            )
     except Exception as exc:
         lgr.warning(
             "Failed to check for a more recent version available with etelemetry: %s",

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     click
     click-didyoumean
     dandischema ~= 0.2.10
-    etelemetry >= 0.2.0
+    etelemetry >= 0.2.2
     fasteners
     fscacher
     # Specifying != might be what causes pip 19.3.1 first to install hdmf 1.5.1


### PR DESCRIPTION
BadVersion was added in 0.2.2 thus boosting etelemetry version