### PR TITLE
RF: attempt nwb metadata extraction only on .nwb, if fails -- warning

### DIFF
--- a/dandi/metadata.py
+++ b/dandi/metadata.py
@@ -711,8 +711,8 @@ def get_asset_metadata(
                 type(e).__name__,
                 str(e),
             )
-        if not allow_any_path:
-            raise
+            if not allow_any_path:
+                raise
     if metadata is None:
         metadata = get_default_metadata(
             filepath, digest=digest, digest_type=digest_type

--- a/dandi/metadata.py
+++ b/dandi/metadata.py
@@ -700,21 +700,23 @@ def process_ndtypes(asset, nd_types):
 def get_asset_metadata(
     filepath, relpath, digest=None, digest_type=None, allow_any_path=True
 ) -> models.BareAsset:
-    try:
-        metadata = nwb2asset(filepath, digest=digest, digest_type=digest_type)
-    except Exception as e:
-        lgr.info(
-            "Failed to extract NWB metadata from %s: %s: %s",
-            filepath,
-            type(e).__name__,
-            str(e),
-        )
-        if allow_any_path:
-            metadata = get_default_metadata(
-                filepath, digest=digest, digest_type=digest_type
+    metadata = None
+    if op.splitext(filepath)[1] == ".nwb":
+        try:
+            metadata = nwb2asset(filepath, digest=digest, digest_type=digest_type)
+        except Exception as e:
+            lgr.warning(
+                "Failed to extract NWB metadata from %s: %s: %s",
+                filepath,
+                type(e).__name__,
+                str(e),
             )
-        else:
+        if not allow_any_path:
             raise
+    if metadata is None:
+        metadata = get_default_metadata(
+            filepath, digest=digest, digest_type=digest_type
+        )
     metadata.path = str(relpath)
     return metadata
 


### PR DESCRIPTION
I think time to assume that all NWB files would have .nwb extension I think.

This PR is maintaining prior behavior of re-raising the exception if allow_any_path is
False.  Otherwise -- and regardless if allow_any_path is True or not (thus
would not re-raise for non .nwb files even if not allow_any_path) - provide default
metadata record.

For upload it should be fine AFAIK even with the change  of behavior since we first
use allow_any_path to select .nwb files.

Closes #730