### PR TITLE
Log "error" statuses while uploading as ERROR log messages

### DIFF
--- a/dandi/upload.py
+++ b/dandi/upload.py
@@ -277,6 +277,7 @@ def upload(
         except Exception as exc:
             if devel_debug:
                 raise
+            lgr.exception("Error uploading %s:", relpath)
             # Custom formatting for some exceptions we know to extract
             # user-meaningful message
             message = str(exc)


### PR DESCRIPTION
This was the only spot I could find where a status of "error" was not accompanied by a corresponding logging call.

Closes #735.