### PR TITLE
Correctly set User-Agent for client requests

### DIFF
--- a/dandi/dandiapi.py
+++ b/dandi/dandiapi.py
@@ -57,9 +57,9 @@ class RESTFullAPIClient:
         self.api_url = api_url
         if session is None:
             session = requests.Session()
+        session.headers["User-Agent"] = USER_AGENT
         if headers is not None:
             session.headers.update(headers)
-        session.headers.setdefault("User-Agent", USER_AGENT)
         self.session = session
 
     def __enter__(self):


### PR DESCRIPTION
`requests.Session` objects start out with a `User-Agent` header already set, and so trying to set the header with `setdefault()` (which was chosen in order to not override a header set by the user on creating the Session object or set in `headers`) does nothing.