### PR TITLE
Pin rabbitmq version

### DIFF
--- a/dandi/tests/data/dandiarchive-docker/docker-compose.yml
+++ b/dandi/tests/data/dandiarchive-docker/docker-compose.yml
@@ -110,6 +110,6 @@ services:
       retries: 5
 
   rabbitmq:
-    image: rabbitmq:management
+    image: rabbitmq:3.8-management
     ports:
       - "5672:5672"


### PR DESCRIPTION
RabbitMQ just released version 3.9.0, and it's not playing nice with
Celery. To get tests passing again, pin to version 3.8.