### PR TITLE
Restore the rabbitmq version

### DIFF
--- a/dandi/tests/data/dandiarchive-docker/docker-compose.yml
+++ b/dandi/tests/data/dandiarchive-docker/docker-compose.yml
@@ -110,6 +110,6 @@ services:
       retries: 5
 
   rabbitmq:
-    image: rabbitmq:3.8-management
+    image: rabbitmq:management
     ports:
       - "5672:5672"


### PR DESCRIPTION
The RabbitMQ docker image used in the test docker-compose configuration
had a bug, which necessitated pinning to an earlier version.
The bug has been fixed, so we can go back to using the official image.