### PR TITLE
Support `/asset/<asset id>/download/` URLs

### DIFF
--- a/dandi/tests/test_dandiarchive.py
+++ b/dandi/tests/test_dandiarchive.py
@@ -7,6 +7,7 @@ from dandi.dandiarchive import (
     AssetIDURL,
     AssetItemURL,
     AssetPathPrefixURL,
+    BaseAssetIDURL,
     DandisetURL,
     follow_redirect,
     parse_dandi_url,
@@ -188,6 +189,14 @@ from dandi.tests.skip import mark
                 api_url="https://api.dandiarchive.org/api",
                 dandiset_id="000003",
                 version_id="draft",
+                asset_id="0a748f90-d497-4a9c-822e-9c63811db412",
+            ),
+        ),
+        (
+            "https://api.dandiarchive.org/api"
+            "/assets/0a748f90-d497-4a9c-822e-9c63811db412/download/",
+            BaseAssetIDURL(
+                api_url="https://api.dandiarchive.org/api",
                 asset_id="0a748f90-d497-4a9c-822e-9c63811db412",
             ),
         ),

--- a/dandi/tests/test_download.py
+++ b/dandi/tests/test_download.py
@@ -180,6 +180,18 @@ def test_download_asset_id(local_dandi_api, text_dandiset, tmp_path):
     assert (tmp_path / "coconut.txt").read_text() == "Coconut\n"
 
 
+def test_download_asset_id_only(local_dandi_api, text_dandiset, tmp_path):
+    asset = text_dandiset["dandiset"].get_asset_by_path("subdir2/coconut.txt")
+    download(
+        f"{local_dandi_api['instance'].api}/assets/{asset.identifier}/download/",
+        tmp_path,
+    )
+    assert list(map(Path, find_files(r".*", paths=[tmp_path], dirs=True))) == [
+        tmp_path / "coconut.txt"
+    ]
+    assert (tmp_path / "coconut.txt").read_text() == "Coconut\n"
+
+
 @pytest.mark.parametrize("confirm", [True, False])
 def test_download_sync(confirm, local_dandi_api, mocker, text_dandiset, tmp_path):
     text_dandiset["dandiset"].get_asset_by_path("file.txt").delete()


### PR DESCRIPTION
Closes #723.

Note that the dandi-api Docker images are currently not building for some reason, and the latest image lacks support for the `/asset/<asset id>/` endpoint.  Hence, the tests will fail under the Docker build is fixed.