### PR TITLE
Update Docker Compose spin-up code for loss of --username option

### DIFF
--- a/dandi/tests/fixtures.py
+++ b/dandi/tests/fixtures.py
@@ -203,10 +203,8 @@ def docker_compose_setup():
                     "./manage.py",
                     "createsuperuser",
                     "--no-input",
-                    "--username",
-                    "admin2",
                     "--email",
-                    "nil@nil.nil",
+                    "admin@nil.nil",
                 ],
                 cwd=str(LOCAL_DOCKER_DIR),
                 env=env,
@@ -221,13 +219,13 @@ def docker_compose_setup():
                 "django",
                 "./manage.py",
                 "drf_create_token",
-                "admin2",
+                "admin@nil.nil",
             ],
             cwd=str(LOCAL_DOCKER_DIR),
             env=env,
             universal_newlines=True,
         )
-        m = re.search(r"^Generated token (\w+) for user admin2$", r, flags=re.M)
+        m = re.search(r"^Generated token (\w+) for user admin@nil.nil$", r, flags=re.M)
         if not m:
             raise RuntimeError(
                 f"Could not extract Django auth token from drf_create_token output: {r!r}"


### PR DESCRIPTION
See https://github.com/dandi/dandischema/issues/82 for more information.

Until the next rebuild of the dandi-api image on the Docker Hub, this PR will make dandi-cli's tests fail, so don't merge until then.  Once it's merged, the dandi-cli integration tests for dandischema (for the master version of dandi-cli, not the released version) will start passing again.