### PR TITLE
Specify DJANGO_DANDI_VALIDATION_JOB_INTERVAL

### DIFF
--- a/dandi/tests/data/dandiarchive-docker/docker-compose.yml
+++ b/dandi/tests/data/dandiarchive-docker/docker-compose.yml
@@ -78,6 +78,7 @@ services:
       DJANGO_STORAGE_BUCKET_NAME: django-storage
       DJANGO_MINIO_STORAGE_MEDIA_URL: http://localhost:9000/django-storage
       DJANGO_DANDI_SCHEMA_VERSION:
+      DJANGO_DANDI_VALIDATION_JOB_INTERVAL: "5"
       DANDI_ALLOW_LOCALHOST_URLS: "1"
 
   minio:

--- a/dandi/tests/data/dandiarchive-docker/docker-compose.yml
+++ b/dandi/tests/data/dandiarchive-docker/docker-compose.yml
@@ -54,7 +54,8 @@ services:
       "--app", "dandiapi.celery",
       "worker",
       "--loglevel", "INFO",
-      "--without-heartbeat"
+      "--without-heartbeat",
+      "-B"
     ]
     # Docker Compose does not set the TTY width, which causes Celery errors
     tty: false

--- a/dandi/tests/fixtures.py
+++ b/dandi/tests/fixtures.py
@@ -183,6 +183,7 @@ def docker_compose_setup():
     env["DJANGO_DANDI_GIRDER_API_URL"] = "http://localhost:8080/api/v1"
     env["DJANGO_DANDI_GIRDER_API_KEY"] = "abc123"
     env["DJANGO_DANDI_SCHEMA_VERSION"] = DANDI_SCHEMA_VERSION
+    env["DJANGO_DANDI_VALIDATION_JOB_INTERVAL"] = "5"
 
     try:
         if create:

--- a/dandi/tests/fixtures.py
+++ b/dandi/tests/fixtures.py
@@ -183,7 +183,6 @@ def docker_compose_setup():
     env["DJANGO_DANDI_GIRDER_API_URL"] = "http://localhost:8080/api/v1"
     env["DJANGO_DANDI_GIRDER_API_KEY"] = "abc123"
     env["DJANGO_DANDI_SCHEMA_VERSION"] = DANDI_SCHEMA_VERSION
-    env["DJANGO_DANDI_VALIDATION_JOB_INTERVAL"] = "5"
 
     try:
         if create:


### PR DESCRIPTION
https://github.com/dandi/dandi-api/pull/538 is adding a scheduled job
which checks for Versions that need validation and validates them. The
default wait interval is 60 seconds, but it is configurable through an
environment variable, `DJANGO_DANDI_VALIDATION_JOB_INTERVAL`. Set this
environment variable to `5` so that the validation job runs every 5
seconds, which should be quick enough for `wait_until_valid`.