### PR TITLE
Remove Girder envvars from Docker Compose setup

### DIFF
--- a/dandi/tests/data/dandiarchive-docker/docker-compose.yml
+++ b/dandi/tests/data/dandiarchive-docker/docker-compose.yml
@@ -34,8 +34,6 @@ services:
       DJANGO_CELERY_BROKER_URL: amqp://rabbitmq:5672/
       DJANGO_CONFIGURATION: DevelopmentConfiguration
       DJANGO_DANDI_DANDISETS_BUCKET_NAME: dandi-dandisets
-      DJANGO_DANDI_GIRDER_API_URL:
-      DJANGO_DANDI_GIRDER_API_KEY:
       DJANGO_DATABASE_URL: postgres://postgres:postgres@postgres:5432/django
       DJANGO_MINIO_STORAGE_ACCESS_KEY: minioAccessKey
       DJANGO_MINIO_STORAGE_ENDPOINT: minio:9000
@@ -69,8 +67,6 @@ services:
       DJANGO_CELERY_BROKER_URL: amqp://rabbitmq:5672/
       DJANGO_CONFIGURATION: DevelopmentConfiguration
       DJANGO_DANDI_DANDISETS_BUCKET_NAME: dandi-dandisets
-      DJANGO_DANDI_GIRDER_API_URL:
-      DJANGO_DANDI_GIRDER_API_KEY:
       DJANGO_DATABASE_URL: postgres://postgres:postgres@postgres:5432/django
       DJANGO_MINIO_STORAGE_ACCESS_KEY: minioAccessKey
       DJANGO_MINIO_STORAGE_ENDPOINT: minio:9000

--- a/dandi/tests/fixtures.py
+++ b/dandi/tests/fixtures.py
@@ -177,13 +177,7 @@ def docker_compose_setup():
         != 0
     )
 
-    # TODO: Delete this after <https://github.com/dandi/dandi-api/pull/251> is
-    # merged:
-    env = dict(os.environ)
-    env["DJANGO_DANDI_GIRDER_API_URL"] = "http://localhost:8080/api/v1"
-    env["DJANGO_DANDI_GIRDER_API_KEY"] = "abc123"
-    env["DJANGO_DANDI_SCHEMA_VERSION"] = DANDI_SCHEMA_VERSION
-
+    env = {**os.environ, "DJANGO_DANDI_SCHEMA_VERSION": DANDI_SCHEMA_VERSION}
     try:
         if create:
             run(


### PR DESCRIPTION
The Girder environment variables have been removed from dandi-api, so we no longer need to set them here.