### PR TITLE
Register all celery queues with dandiarchive env

### DIFF
--- a/dandi/tests/data/dandiarchive-docker/docker-compose.yml
+++ b/dandi/tests/data/dandiarchive-docker/docker-compose.yml
@@ -53,6 +53,7 @@ services:
       "worker",
       "--loglevel", "INFO",
       "--without-heartbeat",
+      "-Q","celery,calculate_sha256",
       "-B"
     ]
     # Docker Compose does not set the TTY width, which causes Celery errors


### PR DESCRIPTION
There are now multiple queues to consume from in dandi-api, so the test
environment celery worker needs to explicitly handle all of them.

Requires https://github.com/dandi/dandi-api/pull/551 to be approved first.