### PR TITLE
Show more documentation

### DIFF
--- a/dandi/consts.py
+++ b/dandi/consts.py
@@ -1,9 +1,9 @@
 from collections import namedtuple
 import os
 
-# A list of metadata fields which dandi extracts from .nwb files.
-# Additional fields (such as `number_of_*`) might be added by the
-# get_metadata`
+#: A list of metadata fields which dandi extracts from .nwb files.
+#: Additional fields (such as ``number_of_*``) might be added by
+#: `get_metadata()`
 metadata_nwb_file_fields = (
     "experiment_description",
     "experimenter",
@@ -109,12 +109,13 @@ file_operation_modes = [
     "auto",
 ]
 
-#
+
 # Download (upload?) specific constants
-#
-# Chunk size when iterating a download (and upload) body. Taken from girder-cli
-# TODO: should we make them smaller for download than for upload?
-# ATM used only in download
+
+#: Chunk size when iterating a download (and upload) body. Taken from girder-cli
+#: TODO: should we make them smaller for download than for upload?
+#: ATM used only in download
 MAX_CHUNK_SIZE = int(os.environ.get("DANDI_MAX_CHUNK_SIZE", 1024 * 1024 * 8))  # 64
 
+#: The identifier for draft Dandiset versions
 DRAFT = "draft"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,7 +33,12 @@ release = dandi.__version__
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.autosummary", "sphinx.ext.napoleon"]
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,7 +17,7 @@
 
 # -- Project information -----------------------------------------------------
 
-project = "DANDI Archive CLI and Python API library"
+project = "dandi"
 copyright = "2021, DANDI Team"
 author = "DANDI Team"
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,7 +33,7 @@ release = dandi.__version__
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.autosummary"]
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.autosummary", "sphinx.ext.napoleon"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -42,6 +42,14 @@ templates_path = ["_templates"]
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = []
+
+autodoc_default_options = {
+    "members": True,
+    "undoc-members": True,
+}
+
+napoleon_google_docstring = False
+napoleon_numpy_docstring = True
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,12 +1,8 @@
-.. DANDI Archive CLI and Python API library documentation master file, created by
-   sphinx-quickstart on Wed Jul 14 14:06:55 2021.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
-Welcome to dandi-cli documentation
+Welcome to the dandi documentation
 ==================================
 
-dandi-cli provides both command line interface (CLI) tools and a Python library (AKA Python API) to work with `DANDI
+The `dandi <https://github.com/dandi/dandi-cli>`_ library provides both a
+command line interface (CLI) and a Python API for interacting with `DANDI
 Archive <https://dandiarchive.org>`_.
 
 .. toctree::

--- a/docs/source/modref/consts.rst
+++ b/docs/source/modref/consts.rst
@@ -2,3 +2,9 @@
 ================
 
 .. automodule:: dandi.consts
+
+    .. NOTE: Due to <https://github.com/sphinx-doc/sphinx/issues/1063>, only
+       data values with doc comments are included by automodule::, even with
+       `undoc-members` set, and the available workarounds involve explicitly
+       listing every data value, leading to problems when the list is not kept
+       in sync.

--- a/docs/source/modref/dandiapi.rst
+++ b/docs/source/modref/dandiapi.rst
@@ -2,5 +2,7 @@ Mid-level user interfaces
 =========================
 
 .. automodule:: dandi.dandiapi
-    :members: RESTFullAPIClient, DandiAPIClient, APIBase, RemoteDandiset,
-        Version, RemoteAsset
+
+    .. TODO: Once <https://github.com/sphinx-doc/sphinx/issues/9709> is fixed,
+       set `:members:` to all classes other than APIBase (which is an
+       implementation detail)

--- a/docs/source/modref/dandiapi.rst
+++ b/docs/source/modref/dandiapi.rst
@@ -1,5 +1,5 @@
-Mid-level user interfaces
-=========================
+``dandi.dandiapi``
+==================
 
 .. automodule:: dandi.dandiapi
 

--- a/docs/source/modref/dandiapi.rst
+++ b/docs/source/modref/dandiapi.rst
@@ -1,17 +1,6 @@
-.. currentmodule:: dandi.dandiapi
-
 Mid-level user interfaces
 =========================
 
-.. autoclass:: RESTFullAPIClient
-    :members:
-.. autoclass:: DandiAPIClient
-    :members:
-.. autoclass:: APIBase
-    :members:
-.. autoclass:: RemoteDandiset
-    :members:
-.. autoclass:: Version
-    :members:
-.. autoclass:: RemoteAsset
-    :members:
+.. automodule:: dandi.dandiapi
+    :members: RESTFullAPIClient, DandiAPIClient, APIBase, RemoteDandiset,
+        Version, RemoteAsset

--- a/docs/source/modref/dandiarchive.rst
+++ b/docs/source/modref/dandiarchive.rst
@@ -1,7 +1,7 @@
 .. currentmodule:: dandi.dandiarchive
 
-High-level user interfaces
-==========================
+``dandi.dandiarchive``
+======================
 
 .. autofunction:: navigate_url
 .. autofunction:: parse_dandi_url

--- a/docs/source/modref/index.rst
+++ b/docs/source/modref/index.rst
@@ -41,8 +41,9 @@ Test infrastructure
    tests.fixtures
    tests.skip
 
-Command line interface infrastructure
-=====================================
+..
+    Command line interface infrastructure
+    =====================================
 
-.. autosummary::
-   :toctree: generated
+    .. autosummary::
+       :toctree: generated

--- a/docs/source/modref/index.rst
+++ b/docs/source/modref/index.rst
@@ -9,12 +9,6 @@
 Python API
 **********
 
-This module reference extends the manual with a comprehensive overview of the
-available functionality built into datalad.  Each module in the package is
-documented by a general summary of its purpose and the list of classes and
-functions it provides.
-
-
 High-level user interfaces
 ==========================
 


### PR DESCRIPTION
This PR modifies the dandi Read the Docs docs to show the docstring for `dandi.dandiapi`; list the contents of `dandi.utils`, `dandi.support.digests`, and some of `dandi.consts`; change the titles for the module docs to names of the modules; adjust some prose; show "[source]" links next to Python objects; and a couple other things.