### PR TITLE
Change docs to use "furo" theme

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-alabaster
+furo
 Sphinx

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -1,5 +1,0 @@
-@import './alabaster.css';  /* for Alabaster */
-
-div.footer {
-    text-align: center;
-}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -49,14 +49,4 @@ exclude_patterns = []
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "alabaster"
-html_theme_options = {
-    "page_width": "auto",
-    "body_max_width": "auto",
-}
-html_style = "custom.css"
-
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+html_theme = "furo"


### PR DESCRIPTION
I don't like Alabaster's lack of spacing between consecutive classes, so I thought I'd suggest switching to the latest hotness, [furo](https://github.com/pradyunsg/furo).