### PR TITLE
Test against Python 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,8 +53,9 @@ jobs:
         # Fetch all commits so that versioneer will return something compatible
         # with semantic-version
         fetch-depth: 0
+
     - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,7 @@ jobs:
           - 3.7
           - 3.8
           - 3.9
+          - '3.10'  # Needs quotes so YAML doesn't think it's 3.1
         mode:
           - normal
         include:
@@ -43,7 +44,7 @@ jobs:
           # Temporarily disabled due to h5py/hdf5 dependency issue
           # See <https://github.com/dandi/dandi-cli/pull/315>
           - os: windows-2019
-            python: 3.9
+            python: 3.10
 
     steps:
     - name: Set up environment
@@ -58,11 +59,11 @@ jobs:
         python-version: ${{ matrix.python }}
 
     - name: Install hdf5 (Ubuntu)
-      if: matrix.python == '3.9' && startsWith(matrix.os, 'ubuntu')
+      if: matrix.python == '3.10' && startsWith(matrix.os, 'ubuntu')
       run: sudo apt-get update && sudo apt-get install -y libhdf5-dev
 
     - name: Install hdf5 (macOS)
-      if: matrix.python == '3.9' && startsWith(matrix.os, 'macos')
+      if: matrix.python == '3.10' && startsWith(matrix.os, 'macos')
       run: |
         brew install hdf5@1.8
         brew link hdf5@1.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Scientific/Engineering
 license = Apache 2.0
 description = Command line client for interaction with DANDI archive elements

--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,7 @@ filterwarnings =
     ignore:\s*load will be removed.*:PendingDeprecationWarning:ruamel.yaml
     ignore:Passing None into shape arguments.*:DeprecationWarning:h5py
     ignore:`Unit` has been deprecated:DeprecationWarning:humanize
+    ignore:The distutils package is deprecated:DeprecationWarning:joblib
 
 [coverage:run]
 parallel = True


### PR DESCRIPTION
Python 3.10 was released on Monday, so we need to support it.

Note that the issue with installing h5py on 3.9 is gone, as pynwb and hdmf have relaxed their version requirements to work with the latest version of h5py, which provides wheels for 3.9.  However, at time of writing, the latest h5py does not provide wheels for 3.10, so I just changed the h5py handling from 3.9 to 3.10.