### PR TITLE
Set Sphinx `default_role` to "py:obj"

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -55,6 +55,7 @@ autodoc_default_options = {
 
 napoleon_google_docstring = False
 napoleon_numpy_docstring = True
+default_role = "py:obj"
 
 
 # -- Options for HTML output -------------------------------------------------


### PR DESCRIPTION
This causes function, class, etc. names between single backticks to be converted into hyperlinks to the corresponding doc entries.  See how the module docstring for `dandi.dandiapi` is rendered for an example.