### PR TITLE
Retry more requests; wait longer for Dandiset validity

### DIFF
--- a/dandi/consts.py
+++ b/dandi/consts.py
@@ -119,3 +119,7 @@ MAX_CHUNK_SIZE = int(os.environ.get("DANDI_MAX_CHUNK_SIZE", 1024 * 1024 * 8))  #
 
 #: The identifier for draft Dandiset versions
 DRAFT = "draft"
+
+#: HTTP response status codes that should always be retried (until we run out
+#: of retries)
+RETRY_STATUSES = (500, 502, 503, 504)

--- a/dandi/dandiapi.py
+++ b/dandi/dandiapi.py
@@ -69,6 +69,7 @@ from . import get_logger
 from .consts import (
     DRAFT,
     MAX_CHUNK_SIZE,
+    RETRY_STATUSES,
     DandiInstance,
     known_instances,
     known_instances_rev,
@@ -151,7 +152,7 @@ class RESTFullAPIClient:
 
         :type json_resp: bool
         :param retry_statuses: a sequence of HTTP response status codes to
-            retry; 503 will be added to this set
+            retry in addition to `dandi.consts.RETRY_STATUSES`
         """
 
         url = self.get_url(path)
@@ -191,7 +192,7 @@ class RESTFullAPIClient:
                         headers=headers,
                         **kwargs,
                     )
-                    if result.status_code in [503, *retry_statuses]:
+                    if result.status_code in [*RETRY_STATUSES, *retry_statuses]:
                         result.raise_for_status()
         except Exception:
             lgr.exception("HTTP connection failed")

--- a/dandi/dandiarchive.py
+++ b/dandi/dandiarchive.py
@@ -9,7 +9,7 @@ from pydantic import AnyHttpUrl, BaseModel, parse_obj_as, validator
 import requests
 
 from . import get_logger
-from .consts import VERSION_REGEX, known_instances
+from .consts import RETRY_STATUSES, VERSION_REGEX, known_instances
 from .dandiapi import BaseRemoteAsset, DandiAPIClient, RemoteDandiset
 from .exceptions import FailedToConnectError, NotFoundError, UnknownURLError
 from .utils import get_instance
@@ -526,7 +526,7 @@ class _dandi_url_parser:
         i = 0
         while True:
             r = requests.head(url, allow_redirects=True)
-            if r.status_code in (400, 502, 503, 504) and i < 5:
+            if r.status_code in (400, *RETRY_STATUSES) and i < 5:
                 sleep(0.1 * 10 ** i)
                 i += 1
                 continue

--- a/dandi/download.py
+++ b/dandi/download.py
@@ -12,7 +12,7 @@ import humanize
 import requests
 
 from . import get_logger
-from .consts import dandiset_metadata_file
+from .consts import RETRY_STATUSES, dandiset_metadata_file
 from .dandiarchive import DandisetURL, MultiAssetURL, SingleAssetURL, parse_dandi_url
 from .dandiset import Dandiset
 from .support.digests import get_digest
@@ -566,7 +566,7 @@ def _download_file(
             if attempt >= 2 or exc.response.status_code not in (
                 400,  # Bad Request, but happened with gider:
                 # https://github.com/dandi/dandi-cli/issues/87
-                503,  # Service Unavailable
+                *RETRY_STATUSES,
             ):
                 lgr.debug("Download failed: %s", exc)
                 yield {"status": "error", "message": str(exc)}


### PR DESCRIPTION
As requested [here](https://github.com/dandi/dandi-cli/pull/797#issuecomment-940116319).

(Submitting as a separate PR because it really has nothing to do with what #797 is accomplishing.)