### PR TITLE
Update codecov action to v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,7 +114,7 @@ jobs:
           down -v
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml


### PR DESCRIPTION
Version 1 of codecov's GitHub action is [deprecated](https://github.com/codecov/codecov-action#%EF%B8%8F--deprecration-of-v1) and will start experiencing brownouts soon, and they advise updating to v2.