### PR TITLE
Stop using `setup_requires`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,12 +37,5 @@ except ImportError:
     print("WARNING: failed to import versioneer, falling back to no version for now")
     setup_kw = {}
 
-# Give setuptools a hint to complain if it's too old a version
-# 30.3.0 allows us to put most metadata in setup.cfg
-# Should match pyproject.toml
-SETUP_REQUIRES = ["setuptools >= 38.3.0"]
-# This enables setuptools to install wheel on-the-fly
-SETUP_REQUIRES += ["wheel"] if "bdist_wheel" in sys.argv else []
-
 if __name__ == "__main__":
-    setup(name="dandi", setup_requires=SETUP_REQUIRES, **setup_kw)
+    setup(name="dandi", **setup_kw)


### PR DESCRIPTION
As of the release of [setuptools v58.3.0](https://setuptools.pypa.io/en/latest/history.html#v58-3-0) minutes ago, the `setup_requires` argument to `setup()` is now officially deprecated.  It can and should be replaced by `build-system.requires` in `pyproject.toml`, which we've already done.

(I seem to vaguely recall a mention that this option was being kept in dandi-cli for buildability on Debian or something like that?  Is that still a concern?)