### PR TITLE
Show valid instance names when given a dandi:// URL with an unknown instance

### DIFF
--- a/dandi/dandiarchive.py
+++ b/dandi/dandiarchive.py
@@ -380,7 +380,7 @@ class _dandi_url_parser:
         # use
         (
             re.compile(
-                rf"dandi://(?P<instance_name>({'|'.join(known_instances)}))"
+                rf"dandi://(?P<instance_name>[-\w._]+)"
                 rf"/{dandiset_id_grp}"
                 rf"(@(?P<version>{VERSION_REGEX}))?"
                 rf"(/(?P<location>.*)?)?"
@@ -505,7 +505,13 @@ class _dandi_url_parser:
                     parsed_url.api_url = known_instance.api
                 continue  # in this run we ignore and match further
             elif "instance_name" in groups:
-                known_instance = get_instance(groups["instance_name"])
+                try:
+                    known_instance = get_instance(groups["instance_name"])
+                except KeyError:
+                    raise UnknownURLError(
+                        f"Unknown instance {groups['instance_name']!r}.  Valid instances: "
+                        + ", ".join(sorted(known_instances))
+                    )
                 assert known_instance.api  # must be defined
                 groups["server"] = known_instance.api
                 # could be overloaded later depending if location is provided

--- a/dandi/tests/test_dandiarchive.py
+++ b/dandi/tests/test_dandiarchive.py
@@ -12,7 +12,7 @@ from dandi.dandiarchive import (
     follow_redirect,
     parse_dandi_url,
 )
-from dandi.exceptions import NotFoundError
+from dandi.exceptions import NotFoundError, UnknownURLError
 from dandi.tests.skip import mark
 
 
@@ -232,6 +232,15 @@ from dandi.tests.skip import mark
 )
 def test_parse_api_url(url, parsed_url):
     assert parse_dandi_url(url) == parsed_url
+
+
+def test_parse_dandi_url_unknown_instance():
+    with pytest.raises(UnknownURLError) as excinfo:
+        parse_dandi_url("dandi://not-an-instance/000001")
+    assert str(excinfo.value) == (
+        "Unknown instance 'not-an-instance'.  Valid instances: dandi,"
+        " dandi-api-local-docker-tests, dandi-devel, dandi-staging"
+    )
 
 
 @mark.skipif_no_network


### PR DESCRIPTION
Closes #809.