### PR TITLE
Give the resource classes `api_url` properties

### DIFF
--- a/dandi/dandiapi.py
+++ b/dandi/dandiapi.py
@@ -702,19 +702,35 @@ class RemoteDandiset:
     @property
     def api_path(self) -> str:
         """
-        The API path (relative to the base endpoint for a Dandi Archive API) at
-        which requests for interacting with the Dandiset itself are made
+        The path (relative to the base endpoint for a Dandi Archive API) at
+        which API requests for interacting with the Dandiset itself are made
         """
         return f"/dandisets/{self.identifier}/"
 
     @property
+    def api_url(self) -> str:
+        """
+        The URL at which API requests for interacting with the Dandiset itself
+        are made
+        """
+        return self.client.get_url(self.api_path)
+
+    @property
     def version_api_path(self) -> str:
         """
-        The API path (relative to the base endpoint for a Dandi Archive API) at
-        which requests for interacting with the version in question of the
+        The path (relative to the base endpoint for a Dandi Archive API) at
+        which API requests for interacting with the version in question of the
         Dandiset are made
         """
         return f"/dandisets/{self.identifier}/versions/{self.version_id}/"
+
+    @property
+    def version_api_url(self) -> str:
+        """
+        The URL at which API requests for interacting with the version in
+        question of the Dandiset are made
+        """
+        return self.client.get_url(self.version_api_path)
 
     @classmethod
     def from_data(
@@ -1237,10 +1253,18 @@ class BaseRemoteAsset(APIBase):
     @property
     def api_path(self) -> str:
         """
-        The API path (relative to the base endpoint for a Dandi Archive API) at
-        which requests for interacting with the asset itself are made
+        The path (relative to the base endpoint for a Dandi Archive API) at
+        which API requests for interacting with the asset itself are made
         """
         return f"/assets/{self.identifier}/"
+
+    @property
+    def api_url(self) -> str:
+        """
+        The URL at which API requests for interacting with the asset itself are
+        made
+        """
+        return self.client.get_url(self.api_path)
 
     @property
     def base_download_url(self) -> str:
@@ -1417,10 +1441,18 @@ class RemoteAsset(BaseRemoteAsset):
     @property
     def api_path(self) -> str:
         """
-        The API path (relative to the base endpoint for a Dandi Archive API) at
-        which requests for interacting with the asset itself are made
+        The path (relative to the base endpoint for a Dandi Archive API) at
+        which API requests for interacting with the asset itself are made
         """
         return f"/dandisets/{self.dandiset_id}/versions/{self.version_id}/assets/{self.identifier}/"
+
+    @property
+    def api_url(self) -> str:
+        """
+        The URL at which API requests for interacting with the asset itself are
+        made
+        """
+        return self.client.get_url(self.api_path)
 
     @property
     def download_url(self) -> str:

--- a/dandi/dandiarchive.py
+++ b/dandi/dandiarchive.py
@@ -360,7 +360,7 @@ class _dandi_url_parser:
         (
             re.compile(
                 rf"{server_grp}(?P<asset_type>dandiset)s/{dandiset_id_grp}"
-                rf"(/(versions(/(?P<version>{VERSION_REGEX}))?)?)?"
+                rf"(/(versions(/(?P<version>{VERSION_REGEX}))?/?)?)?"
             ),
             {},
             "https://<server>[/api]/dandisets/<dandiset id>[/versions[/<version>]]",

--- a/dandi/tests/test_dandiapi.py
+++ b/dandi/tests/test_dandiapi.py
@@ -81,10 +81,8 @@ def test_publish_and_manipulate(local_dandi_api, monkeypatch, tmp_path):
     v = d.publish().version
     version_id = v.identifier
     assert str(v) == version_id
-    assert (
-        str(d.for_version(v))
-        == f"DANDI-API-LOCAL-DOCKER-TESTS:{dandiset_id}/{version_id}"
-    )
+    dv = d.for_version(v)
+    assert str(dv) == f"DANDI-API-LOCAL-DOCKER-TESTS:{dandiset_id}/{version_id}"
 
     download_dir = tmp_path / "download"
     download_dir.mkdir()
@@ -95,10 +93,7 @@ def test_publish_and_manipulate(local_dandi_api, monkeypatch, tmp_path):
     dandiset_yaml = download_dir / dandiset_id / dandiset_metadata_file
     file_in_version = download_dir / dandiset_id / "subdir" / "file.txt"
 
-    download(
-        f"{local_dandi_api['instance'].api}/dandisets/{dandiset_id}/versions/{version_id}",
-        download_dir,
-    )
+    download(dv.version_api_url, download_dir)
     assert downloaded_files() == [dandiset_yaml, file_in_version]
     assert file_in_version.read_text() == "This is test text.\n"
 
@@ -111,10 +106,7 @@ def test_publish_and_manipulate(local_dandi_api, monkeypatch, tmp_path):
         validation="skip",
     )
     rmtree(download_dir / dandiset_id)
-    download(
-        f"{local_dandi_api['instance'].api}/dandisets/{dandiset_id}/versions/{version_id}",
-        download_dir,
-    )
+    download(dv.version_api_url, download_dir)
     assert downloaded_files() == [dandiset_yaml, file_in_version]
     assert file_in_version.read_text() == "This is test text.\n"
 
@@ -128,10 +120,7 @@ def test_publish_and_manipulate(local_dandi_api, monkeypatch, tmp_path):
     )
 
     rmtree(download_dir / dandiset_id)
-    download(
-        f"{local_dandi_api['instance'].api}/dandisets/{dandiset_id}/versions/draft",
-        download_dir,
-    )
+    download(d.version_api_url, download_dir)
     assert sorted(downloaded_files()) == [
         dandiset_yaml,
         file_in_version,
@@ -141,28 +130,19 @@ def test_publish_and_manipulate(local_dandi_api, monkeypatch, tmp_path):
     assert file_in_version.with_name("file2.txt").read_text() == "This is more text.\n"
 
     rmtree(download_dir / dandiset_id)
-    download(
-        f"{local_dandi_api['instance'].api}/dandisets/{dandiset_id}/versions/{version_id}",
-        download_dir,
-    )
+    download(dv.version_api_url, download_dir)
     assert downloaded_files() == [dandiset_yaml, file_in_version]
     assert file_in_version.read_text() == "This is test text.\n"
 
     d.get_asset_by_path("subdir/file.txt").delete()
 
     rmtree(download_dir / dandiset_id)
-    download(
-        f"{local_dandi_api['instance'].api}/dandisets/{dandiset_id}/versions/draft",
-        download_dir,
-    )
+    download(d.version_api_url, download_dir)
     assert downloaded_files() == [dandiset_yaml, file_in_version.with_name("file2.txt")]
     assert file_in_version.with_name("file2.txt").read_text() == "This is more text.\n"
 
     rmtree(download_dir / dandiset_id)
-    download(
-        f"{local_dandi_api['instance'].api}/dandisets/{dandiset_id}/versions/{version_id}",
-        download_dir,
-    )
+    download(dv.version_api_url, download_dir)
     assert downloaded_files() == [dandiset_yaml, file_in_version]
     assert file_in_version.read_text() == "This is test text.\n"
 

--- a/dandi/tests/test_dandiarchive.py
+++ b/dandi/tests/test_dandiarchive.py
@@ -110,7 +110,31 @@ from dandi.tests.skip import mark
             marks=mark.skipif_no_network,
         ),
         (
+            "http://localhost:8000/api/dandisets/000002/",
+            DandisetURL(
+                api_url="http://localhost:8000/api",
+                dandiset_id="000002",
+                version_id=None,
+            ),
+        ),
+        (
+            "http://localhost:8000/api/dandisets/000002",
+            DandisetURL(
+                api_url="http://localhost:8000/api",
+                dandiset_id="000002",
+                version_id=None,
+            ),
+        ),
+        (
             "http://localhost:8000/api/dandisets/000002/versions/draft",
+            DandisetURL(
+                api_url="http://localhost:8000/api",
+                dandiset_id="000002",
+                version_id="draft",
+            ),
+        ),
+        (
+            "http://localhost:8000/api/dandisets/000002/versions/draft/",
             DandisetURL(
                 api_url="http://localhost:8000/api",
                 dandiset_id="000002",
@@ -194,8 +218,26 @@ from dandi.tests.skip import mark
             ),
         ),
         (
+            "https://api.dandiarchive.org/api/dandisets/000003/versions/draft"
+            "/assets/0a748f90-d497-4a9c-822e-9c63811db412/download",
+            AssetIDURL(
+                api_url="https://api.dandiarchive.org/api",
+                dandiset_id="000003",
+                version_id="draft",
+                asset_id="0a748f90-d497-4a9c-822e-9c63811db412",
+            ),
+        ),
+        (
             "https://api.dandiarchive.org/api"
             "/assets/0a748f90-d497-4a9c-822e-9c63811db412/download/",
+            BaseAssetIDURL(
+                api_url="https://api.dandiarchive.org/api",
+                asset_id="0a748f90-d497-4a9c-822e-9c63811db412",
+            ),
+        ),
+        (
+            "https://api.dandiarchive.org/api"
+            "/assets/0a748f90-d497-4a9c-822e-9c63811db412/download",
             BaseAssetIDURL(
                 api_url="https://api.dandiarchive.org/api",
                 asset_id="0a748f90-d497-4a9c-822e-9c63811db412",

--- a/dandi/tests/test_delete.py
+++ b/dandi/tests/test_delete.py
@@ -69,10 +69,7 @@ def test_delete_paths(
         force=True,
     )
     delete_spy.assert_called()
-    download(
-        f"{local_dandi_api['instance'].api}/dandisets/{dandiset_id}/versions/draft",
-        tmp_path,
-    )
+    download(text_dandiset["dandiset"].version_api_url, tmp_path)
     files = sorted(map(Path, find_files(r".*", paths=[tmp_path])))
     assert files == [tmp_path / dandiset_id / f for f in ["dandiset.yaml"] + remainder]
 
@@ -278,10 +275,7 @@ def test_delete_nonexistent_asset_skip_missing(
         skip_missing=True,
     )
     delete_spy.assert_called()
-    download(
-        f"{local_dandi_api['instance'].api}/dandisets/{dandiset_id}/versions/draft",
-        tmp_path,
-    )
+    download(text_dandiset["dandiset"].version_api_url, tmp_path)
     files = sorted(map(Path, find_files(r".*", paths=[tmp_path])))
     assert files == [
         tmp_path / dandiset_id / "dandiset.yaml",
@@ -333,10 +327,7 @@ def test_delete_nonexistent_asset_folder_skip_missing(
         skip_missing=True,
     )
     delete_spy.assert_called()
-    download(
-        f"{local_dandi_api['instance'].api}/dandisets/{dandiset_id}/versions/draft",
-        tmp_path,
-    )
+    download(text_dandiset["dandiset"].version_api_url, tmp_path)
     files = sorted(map(Path, find_files(r".*", paths=[tmp_path])))
     assert files == [
         tmp_path / dandiset_id / "dandiset.yaml",


### PR DESCRIPTION
I was getting annoyed by having to type out API URLs the long way.

This PR also fixes the URL parsing to accept API URLs with trailing slashes and adds tests to ensure that all API URL formats are accepted with & without trailing slashes.