### PR TITLE
Convert DANDI: resource identifiers to lowercase when prepending "https://identifiers.org/" and tighten regex

### DIFF
--- a/dandi/consts.py
+++ b/dandi/consts.py
@@ -70,7 +70,7 @@ DANDISET_ID_REGEX = r"[0-9]{6}"
 
 #: Regular expression for a valid Dandiset version identifier.  This regex is
 #: not anchored.
-VERSION_REGEX = r"(?:[.0-9]{5,}|draft)"
+VERSION_REGEX = r"(?:[0-9]+\.[0-9]+\.[0-9]+|draft)"
 
 dandiset_metadata_file = "dandiset.yaml"
 dandiset_identifier_regex = f"^{DANDISET_ID_REGEX}$"

--- a/dandi/consts.py
+++ b/dandi/consts.py
@@ -68,9 +68,13 @@ metadata_all_fields = metadata_nwb_fields + metadata_dandiset_fields
 #: anchored.
 DANDISET_ID_REGEX = r"[0-9]{6}"
 
+#: Regular expression for a valid published (i.e., non-draft) Dandiset version
+#: identifier.  This regex is not anchored.
+PUBLISHED_VERSION_REGEX = r"[0-9]+\.[0-9]+\.[0-9]+"
+
 #: Regular expression for a valid Dandiset version identifier.  This regex is
 #: not anchored.
-VERSION_REGEX = r"(?:[0-9]+\.[0-9]+\.[0-9]+|draft)"
+VERSION_REGEX = fr"(?:{PUBLISHED_VERSION_REGEX}|draft)"
 
 dandiset_metadata_file = "dandiset.yaml"
 dandiset_identifier_regex = f"^{DANDISET_ID_REGEX}$"

--- a/dandi/dandiarchive.py
+++ b/dandi/dandiarchive.py
@@ -363,9 +363,12 @@ class _dandi_url_parser:
         # TODO: Later should better conform to our API, so we could allow
         #       for not only "dandiarchive.org" URLs
         (
-            re.compile(r"DANDI:.*"),
+            re.compile(
+                fr"DANDI:{DANDISET_ID_REGEX}(?:/[0-9]+\.[0-9]+\.[0-9]+)?",
+                flags=re.I,
+            ),
             {"rewrite": lambda x: "https://identifiers.org/" + x.lower()},
-            "DANDI:<dandiset id>",
+            "DANDI:<dandiset id>[/<version id>]",
         ),
         (
             re.compile(r"https?://dandiarchive\.org/.*"),
@@ -373,9 +376,13 @@ class _dandi_url_parser:
             "https://dandiarchive.org/...",
         ),
         (
-            re.compile(r"https?://identifiers\.org/DANDI:.*"),
+            re.compile(
+                fr"https?://identifiers\.org/DANDI:{DANDISET_ID_REGEX}"
+                fr"(?:/[0-9]+\.[0-9]+\.[0-9]+)?",
+                flags=re.I,
+            ),
             {"handle_redirect": "pass"},
-            "https://identifiers.org/DANDI:<dandiset id>",
+            "https://identifiers.org/DANDI:<dandiset id>[/<version id>]",
         ),
         (
             re.compile(
@@ -474,10 +481,12 @@ class _dandi_url_parser:
         is omitted from a URL, the given Dandiset's most recent published
         version, if any, or else its draft version will be used.
 
-        - :samp:`https://identifiers.org/DANDI:{dandiset-id}` when it redirects
+        - :samp:`https://identifiers.org/DANDI:{dandiset-id}[/{version}]`
+          (case insensitive; ``version`` cannot be "draft") when it redirects
           to one of the other URL formats
 
-        - :samp:`DANDI:{dandiset-id}` — Abbreviation for the above
+        - :samp:`DANDI:{dandiset-id}[/{version}]` — (case insensitive;
+          ``version`` cannot be "draft") Abbreviation for the above
 
         - Any ``https://dandiarchive.org/`` or
           ``https://*dandiarchive-org.netflify.app/`` URL which redirects to

--- a/dandi/dandiarchive.py
+++ b/dandi/dandiarchive.py
@@ -35,7 +35,13 @@ from pydantic import AnyHttpUrl, BaseModel, parse_obj_as, validator
 import requests
 
 from . import get_logger
-from .consts import DANDISET_ID_REGEX, RETRY_STATUSES, VERSION_REGEX, known_instances
+from .consts import (
+    DANDISET_ID_REGEX,
+    PUBLISHED_VERSION_REGEX,
+    RETRY_STATUSES,
+    VERSION_REGEX,
+    known_instances,
+)
 from .dandiapi import BaseRemoteAsset, DandiAPIClient, RemoteDandiset
 from .exceptions import FailedToConnectError, NotFoundError, UnknownURLError
 from .utils import get_instance
@@ -364,7 +370,7 @@ class _dandi_url_parser:
         #       for not only "dandiarchive.org" URLs
         (
             re.compile(
-                fr"DANDI:{DANDISET_ID_REGEX}(?:/[0-9]+\.[0-9]+\.[0-9]+)?",
+                fr"DANDI:{DANDISET_ID_REGEX}(?:/{PUBLISHED_VERSION_REGEX})?",
                 flags=re.I,
             ),
             {"rewrite": lambda x: "https://identifiers.org/" + x.lower()},
@@ -378,7 +384,7 @@ class _dandi_url_parser:
         (
             re.compile(
                 fr"https?://identifiers\.org/DANDI:{DANDISET_ID_REGEX}"
-                fr"(?:/[0-9]+\.[0-9]+\.[0-9]+)?",
+                fr"(?:/{PUBLISHED_VERSION_REGEX})?",
                 flags=re.I,
             ),
             {"handle_redirect": "pass"},

--- a/dandi/dandiarchive.py
+++ b/dandi/dandiarchive.py
@@ -364,7 +364,7 @@ class _dandi_url_parser:
         #       for not only "dandiarchive.org" URLs
         (
             re.compile(r"DANDI:.*"),
-            {"rewrite": lambda x: "https://identifiers.org/" + x},
+            {"rewrite": lambda x: "https://identifiers.org/" + x.lower()},
             "DANDI:<dandiset id>",
         ),
         (

--- a/dandi/tests/test_dandiarchive.py
+++ b/dandi/tests/test_dandiarchive.py
@@ -109,6 +109,24 @@ from dandi.tests.skip import mark
             ),
             marks=mark.skipif_no_network,
         ),
+        pytest.param(
+            "DANDI:000027/0.210831.2033",
+            DandisetURL(
+                api_url=known_instances["dandi"].api,
+                dandiset_id="000027",
+                version_id="0.210831.2033",
+            ),
+            marks=mark.skipif_no_network,
+        ),
+        pytest.param(
+            "dandi:000027/0.210831.2033",
+            DandisetURL(
+                api_url=known_instances["dandi"].api,
+                dandiset_id="000027",
+                version_id="0.210831.2033",
+            ),
+            marks=mark.skipif_no_network,
+        ),
         (
             "http://localhost:8000/api/dandisets/000002/",
             DandisetURL(
@@ -274,6 +292,20 @@ from dandi.tests.skip import mark
 )
 def test_parse_api_url(url, parsed_url):
     assert parse_dandi_url(url) == parsed_url
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "DANDI:27",
+        "DANDI:000027/draft",
+        # Currently takes too long to run; cf. #830:
+        # "https://identifiers.org/DANDI:000027/draft",
+    ],
+)
+def test_parse_bad_api_url(url):
+    with pytest.raises(UnknownURLError):
+        parse_dandi_url(url)
 
 
 def test_parse_dandi_url_unknown_instance():


### PR DESCRIPTION
See https://github.com/dandi/helpdesk/issues/37#issuecomment-962037772