### PR TITLE
Improve UX of failed redirects while resolving resource identifiers

### DIFF
--- a/dandi/dandiarchive.py
+++ b/dandi/dandiarchive.py
@@ -658,8 +658,15 @@ class _dandi_url_parser:
         i = 0
         while True:
             r = requests.head(url, allow_redirects=True)
-            if r.status_code in (400, *RETRY_STATUSES) and i < 5:
-                sleep(0.1 * 10 ** i)
+            if r.status_code in RETRY_STATUSES and i < 4:
+                delay = 0.1 * 10 ** i
+                lgr.warning(
+                    "HEAD request to %s returned %d; sleeping for %f seconds and then retrying...",
+                    url,
+                    r.status_code,
+                    delay,
+                )
+                sleep(delay)
                 i += 1
                 continue
             elif r.status_code == 404:


### PR DESCRIPTION
This PR:

* Eliminates retries on 400 responses (A 400 indicates that the client messed up, so it's highly unlikely that doing the same request again will go any better)
* Logs a WARNING message whenever an HTTP request made while resolving a resource identifier needs to be retried
* Lowers the number of retries for resolving resource identifiers from 5 to 4, thereby bringing the maximum time down from 18 and a half minutes to just under two minutes.

Closes #828.