### PR TITLE
Add Read the Docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![codecov.io](https://codecov.io/github/dandi/dandi-cli/coverage.svg?branch=master)](https://codecov.io/github/dandi/dandi-cli?branch=master)
 [![GitHub release](https://img.shields.io/github/release/dandi/dandi-cli.svg)](https://GitHub.com/dandi/dandi-cli/releases/)
 [![PyPI version fury.io](https://badge.fury.io/py/dandi.svg)](https://pypi.python.org/pypi/dandi/)
+[![Documentation Status](https://readthedocs.org/projects/dandi/badge/?version=latest)](https://dandi.readthedocs.io/en/latest/?badge=latest)
 
 This project is under heavy development.  Beware of [hidden](I-wish-we-knew) and
 [disclosed](https://github.com/dandi/dandi-cli/issues) issues, or

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ long_description_content_type = text/markdown; charset=UTF-8
 platforms = OS Independent
 project_urls =
     Source Code = https://github.com/dandi/dandi-cli
+    Documentation = https://dandi.readthedocs.io
 
 [options]
 python_requires = >=3.7


### PR DESCRIPTION
I also added a "Documentation" project URL link, which will show up on the left side of [the PyPI page](https://pypi.org/project/dandi/).

Closes #826.