### PR TITLE
Ignore a deprecation warning from humanize

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -49,6 +49,7 @@ filterwarnings =
     ignore:\s*safe_load will be removed.*:PendingDeprecationWarning:hdmf
     ignore:\s*load will be removed.*:PendingDeprecationWarning:ruamel.yaml
     ignore:Passing None into shape arguments.*:DeprecationWarning:h5py
+    ignore:`Unit` has been deprecated:DeprecationWarning:humanize
 
 [coverage:run]
 parallel = True


### PR DESCRIPTION
The latest version of humanize emits a deprecation warning when you simply import it (See https://github.com/jmoiron/humanize/issues/242), which causes our tests to fail.  This PR makes pytest ignore the warning.