### PR TITLE
Improve CLI documentation

### DIFF
--- a/dandi/cli/cmd_organize.py
+++ b/dandi/cli/cmd_organize.py
@@ -9,9 +9,9 @@ from ..consts import file_operation_modes
 
 @click.command()
 @dandiset_path_option(
-    help="A top directory (local) of the dandiset to organize files under. "
-    "If not specified, dandiset current directory is under is assumed. "
-    "For 'simulate' mode target dandiset/directory must not exist.",
+    help="The root directory of the Dandiset to organize files under. "
+    "If not specified, the Dandiset under the current directory is assumed. "
+    "For 'simulate' mode, the target Dandiset/directory must not exist.",
     type=click.Path(dir_okay=True, file_okay=False),
 )
 @click.option(
@@ -25,8 +25,8 @@ from ..consts import file_operation_modes
     "-f",
     "--files-mode",
     help="If 'dry' - no action is performed, suggested renames are printed. "
-    "If 'simulate' - hierarchy of empty files at --local-top-path is created. "
-    "Note that previous layout should be removed prior this operation.  "
+    "If 'simulate' - hierarchy of empty files at --dandiset-path is created. "
+    "Note that previous layout should be removed prior to this operation.  "
     "If 'auto' - whichever of symlink, hardlink, copy is allowed by system. "
     "The other modes (copy, move, symlink, hardlink) define how data files "
     "should be made available.",
@@ -47,30 +47,32 @@ def organize(
     """(Re)organize files according to the metadata.
 
     The purpose of this command is to take advantage of metadata contained in
-    the .nwb files to provide datasets with consistently named files, so their
-    naming reflects data they contain.
+    .nwb files to provide datasets with consistently-named files whose names
+    reflect the data they contain.
 
-    .nwb files are organized into a hierarchy of subfolders one per each
-    "subject", e.g. sub-0001 if .nwb file had contained a Subject group with
-    subject_id=0001.  Each file in a subject-specific subfolder follows the
-    convention:
+    .nwb files are organized into a hierarchy of subfolders, one per "subject",
+    e.g., `sub-0001` if an .nwb file contained a Subject group with
+    `subject_id=0001`.  Each file in a subject-specific subfolder follows the
+    pattern:
 
         sub-<subject_id>[_key-<value>][_mod1+mod2+...].nwb
 
-    where following keys are considered if present in the data:
+    where the following keys are considered if present in the data:
 
-        ses -- session_id\n
-        tis -- tissue_sample_id\n
-        slice -- slice_id\n
-        cell -- cell_id\n
+    \b
+        ses -- session_id
+        tis -- tissue_sample_id
+        slice -- slice_id
+        cell -- cell_id
 
-    and `modX` are "modalities" as identified based on detected neural data types
-    (such as "ecephys", "icephys") per extensions found in nwb-schema definitions:
+    and `modX` are "modalities" as identified based on detected neural data
+    types (such as "ecephys", "icephys") per extensions found in nwb-schema
+    definitions:
     https://github.com/NeurodataWithoutBorders/nwb-schema/tree/dev/core
 
-    In addition an "obj" key with a value corresponding to crc32 checksum of
-    "object_id" is added if aforementioned keys and the list of modalities are
-    not sufficient to disambiguate different files.
+    In addition, an "obj" key with a value corresponding to the crc32 checksum
+    of "object_id" is added if the aforementioned keys and the list of
+    modalities are not sufficient to disambiguate different files.
 
     You can visit https://dandiarchive.org for a growing collection of
     (re)organized dandisets.
@@ -118,7 +120,7 @@ def organize(
         if op.exists(dandiset_path):
             # TODO: RF away
             raise RuntimeError(
-                "In simulate mode %r (--top-path) must not exist, we will create it."
+                "In simulate mode %r (--dandiset-path) must not exist, we will create it."
                 % dandiset_path
             )
 

--- a/dandi/cli/cmd_upload.py
+++ b/dandi/cli/cmd_upload.py
@@ -93,17 +93,18 @@ def upload(
     upload_dandiset_metadata=False,
     devel_debug=False,
 ):
-    """Upload dandiset (files) to DANDI archive.
+    """
+    Upload Dandiset files to DANDI Archive.
 
-    Target dandiset to upload to must already be registered in the archive and
-    locally "dandiset.yaml" should exist in `--dandiset-path`.
+    The target Dandiset to upload to must already be registered in the archive,
+    and a `dandiset.yaml` file must exist in the local `--dandiset-path`.
 
-    Local dandiset should pass validation.  For that it should be first organized
-    using 'dandiset organize' command.
+    Local Dandiset should pass validation.  For that, the assets should first
+    be organized using the `dandiset organize` command.
 
-    By default all files in the dandiset (not following directories starting with a period)
-    will be considered for the upload.  You can point to specific files you would like to
-    validate and have uploaded.
+    By default all .nwb files in the Dandiset (excluding directories starting
+    with a period) will be considered for the upload.  You can point to
+    specific files you would like to validate and have uploaded.
     """
     from ..upload import upload
 

--- a/dandi/cli/cmd_upload.py
+++ b/dandi/cli/cmd_upload.py
@@ -100,7 +100,7 @@ def upload(
     and a `dandiset.yaml` file must exist in the local `--dandiset-path`.
 
     Local Dandiset should pass validation.  For that, the assets should first
-    be organized using the `dandiset organize` command.
+    be organized using the `dandi organize` command.
 
     By default all .nwb files in the Dandiset (excluding directories starting
     with a period) will be considered for the upload.  You can point to

--- a/dandi/dandiarchive.py
+++ b/dandi/dandiarchive.py
@@ -1,7 +1,8 @@
 """
-This module provides functionality for parsing URLs for Dandisets & assets on
-Dandi Archive servers and for fetching the objects to which the URLs refer.
-See the docstring for `parse_dandi_url()` for a list of accepted URL formats.
+This module provides functionality for parsing URLs and other resource
+identifiers for Dandisets & assets on Dandi Archive servers and for fetching
+the objects to which the URLs refer.  See :ref:`resource_ids` for a list of
+accepted URL formats.
 
 Basic operation begins by calling `parse_dandi_url()` on a URL in order to
 acquire a `ParsedDandiURL` instance, which can then be used to obtain the
@@ -479,57 +480,8 @@ class _dandi_url_parser:
     @classmethod
     def parse(cls, url: str, *, map_instance: bool = True) -> ParsedDandiURL:
         """
-        Parse a Dandi Archive URL and return a `ParsedDandiURL` instance.
-
-        The accepted URL formats are as follows.  Text in [brackets] is
-        optional.  A ``server`` field is a base API, GUI, or redirector URL for
-        a registered Dandi Archive instance.  If an optional ``version`` field
-        is omitted from a URL, the given Dandiset's most recent published
-        version, if any, or else its draft version will be used.
-
-        - :samp:`https://identifiers.org/DANDI:{dandiset-id}[/{version}]`
-          (case insensitive; ``version`` cannot be "draft") when it redirects
-          to one of the other URL formats
-
-        - :samp:`DANDI:{dandiset-id}[/{version}]` — (case insensitive;
-          ``version`` cannot be "draft") Abbreviation for the above
-
-        - Any ``https://dandiarchive.org/`` or
-          ``https://*dandiarchive-org.netflify.app/`` URL which redirects to
-          one of the other URL formats
-
-        - :samp:`https://{server}[/api]/[#/]dandiset/{dandiset-id}[/{version}][/files[?location={path}]]`
-          — If ``path`` is not specified, the URL refers to a Dandiset and is
-          converted to a `DandisetURL`.  If ``path`` is specified and it ends
-          with a forward slash, the URL refers to an asset folder and is
-          converted to an `AssetFolderURL` instance; if it does not end with a
-          slash, it refers to a single asset and is converted to an
-          `AssetItemURL` instance.
-
-        - :samp:`https://{server}[/api]/dandisets/{dandiset-id}[/versions[/{version}]]`
-          — Refers to a Dandiset and is converted to a `DandisetURL`
-
-        - :samp:`https://{server}[/api]/assets/{asset-id}[/download]` — Refers
-          to a single asset by identifier and is converted to a
-          `BaseAssetIDURL`
-
-        - :samp:`https://{server}[/api]/dandisets/{dandiset-id}/versions/{version}/assets/{asset-id}[/download]`
-          — Refers to a single asset and is converted to an `AssetIDURL`
-
-        - :samp:`https://{server}[/api]/dandisets/{dandiset-id}/versions/{version}/assets/?path={path}`
-          — Refers to all assets in the given Dandiset whose paths begin with
-          the prefix ``path``; converted to an `AssetPathPrefixURL`
-
-        - :samp:`dandi://{instance-name}/{dandiset-id}[@{version}][/{path}]`,
-          where ``instance-name`` is the name of a registered Dandi Archive
-          instance.  If ``path`` is not specified, the URL refers to a Dandiset
-          and is converted to a `DandisetURL`.  If ``path`` is specified and it
-          ends with a forward slash, the URL refers to an asset folder and is
-          converted to an `AssetFolderURL` instance; if it does not end with a
-          slash, it refers to a single asset and is converted to an
-          `AssetItemURL` instance.
-
-        - Any other HTTPS URL that redirects to one of the above
+        Parse a Dandi Archive URL and return a `ParsedDandiURL` instance.  See
+        :ref:`resource_ids` for the supported URL formats.
 
         :raises UnknownURLError: if the URL is not one of the above
         """

--- a/docs/source/cmdline/dandi.rst
+++ b/docs/source/cmdline/dandi.rst
@@ -1,0 +1,25 @@
+:program:`dandi`
+================
+
+::
+
+    dandi [<global options>] <subcommand> [<arguments>]
+
+A command-line client for interacting with the `DANDI Archive
+<http://dandiarchive.org>`_.
+
+Global Options
+--------------
+
+.. option:: -l <level>, --log-level <level>
+
+    Set the `logging level`_ to the given value; default: ``INFO``.  The level
+    can be given as a case-insensitive level name or as a numeric value.
+
+    .. _logging level: https://docs.python.org/3/library/logging.html
+                       #logging-levels
+
+.. option:: --pdb
+
+    Handle errors by opening `pdb (the Python Debugger)
+    <https://docs.python.org/3/library/pdb.html>`_

--- a/docs/source/cmdline/delete.rst
+++ b/docs/source/cmdline/delete.rst
@@ -5,12 +5,34 @@
 
     dandi [<global options>] delete [<options>] [<paths> ...]
 
-Delete dandisets and assets from the server.
+Delete Dandisets and assets from the server.
 
-PATH could be a local path or a URL to an asset, directory, or an entire
-dandiset.
+Each argument must be either a file path pointing to an asset file or directory
+in a local Dandiset (in which case the corresponding assets are deleted on the
+remote server) or a resource identifier pointing to a remote asset, directory,
+or entire Dandiset.
 
 Options
 -------
 
+.. option:: -i, --instance <instance-name>
+
+    DANDI instance to delete assets & Dandisets from  [default: ``dandi``]
+
 .. option:: --skip-missing
+
+    By default, if an argument points to a remote resource that does not exist,
+    an error is raised.  If :option:`--skip-missing` is supplied, missing
+    resources are instead simply silently ignored.
+
+
+Development Options
+-------------------
+
+The following options are intended only for development & testing purposes.
+They are only available if the :envvar:`DANDI_DEVEL` environment variable is
+set to a nonempty value.
+
+.. option:: --devel-debug
+
+    Do not use pyout callbacks, do not swallow exceptions, do not parallelize.

--- a/docs/source/cmdline/delete.rst
+++ b/docs/source/cmdline/delete.rst
@@ -9,8 +9,8 @@ Delete Dandisets and assets from the server.
 
 Each argument must be either a file path pointing to an asset file or directory
 in a local Dandiset (in which case the corresponding assets are deleted on the
-remote server) or a resource identifier pointing to a remote asset, directory,
-or entire Dandiset.
+remote server) or a :ref:`resource identifier <resource_ids>` pointing to a
+remote asset, directory, or entire Dandiset.
 
 Options
 -------

--- a/docs/source/cmdline/digest.rst
+++ b/docs/source/cmdline/digest.rst
@@ -12,4 +12,4 @@ Options
 
 .. option:: -d, --digest [dandi-etag|md5|sha1|sha256|sha512]
 
-    Digest algorithm to use  [default: dandi-etag]
+    Digest algorithm to use  [default: ``dandi-etag``]

--- a/docs/source/cmdline/download.rst
+++ b/docs/source/cmdline/download.rst
@@ -7,6 +7,8 @@
 
 Download a Dandiset, asset, or folder of assets from DANDI.
 
+See :ref:`resource_ids` for allowed URL formats.
+
 Options
 -------
 

--- a/docs/source/cmdline/download.rst
+++ b/docs/source/cmdline/download.rst
@@ -3,34 +3,41 @@
 
 ::
 
-    dandi [<global options>] download [<options>] [<url> ...]
+    dandi [<global options>] download [<options>] <url>
+
+Download a Dandiset, asset, or folder of assets from DANDI.
 
 Options
 -------
 
-.. option:: -o, --output-dir <dir>
+.. option:: --download [dandiset.yaml,assets,all]
 
-    Directory where to download to (directory must exist).  Files will be
-    downloaded with paths relative to that directory.
+    Comma-separated list of elements to download  [default: ``all``]
 
 .. option:: -e, --existing [error|skip|overwrite|overwrite-different|refresh]
 
-    What to do if a file found existing locally. 'refresh': verify
-    that according to the size and mtime, it is the same file, if not -
-    download and overwrite.
+    How to handle paths that already exist locally  [default: ``error``]
+
+    For ``refresh``, if the local file's size and mtime are the same as on the
+    server, the asset is skipped; otherwise, it is redownloaded.
 
 .. option:: -f, --format [pyout|debug]
 
-    Choose the format/frontend for output.
+    Choose the format/frontend for output  [default: ``pyout``]
+
+.. option:: -i, --instance <instance-name>
+
+    DANDI instance to download from  [default: ``dandi``]
 
 .. option:: -J, --jobs <int>
 
-    Number of parallel download jobs.
+    Number of parallel download jobs  [default: 6]
 
-.. option:: --download [dandiset.yaml,assets,all]
+.. option:: -o, --output-dir <dir>
 
-    Comma-separated list of elements to download
+    Directory to download to (must exist).  Files will be downloaded with paths
+    relative to that directory.  [default: current working directory]
 
 .. option:: --sync
 
-    Delete local assets that do not exist on the server
+    Delete local assets that do not exist on the server after downloading

--- a/docs/source/cmdline/index.rst
+++ b/docs/source/cmdline/index.rst
@@ -5,4 +5,5 @@ Command-Line Interface
 .. toctree::
     :glob:
 
+    dandi
     *

--- a/docs/source/cmdline/ls.rst
+++ b/docs/source/cmdline/ls.rst
@@ -5,7 +5,10 @@
 
     dandi [<global options>] ls [<options>] [<path|url> ...]
 
-List .nwb files and dandisets metadata.
+List :file:`*.nwb` files' and Dandisets' metadata.
+
+The arguments may be either resource identifiers or paths to local
+files/directories.
 
 Patterns for known setups:
 
@@ -24,27 +27,50 @@ Patterns for known setups:
 Options
 -------
 
-.. option:: -F, --fields <fields>
-
-    Comma-separated list of fields to display.  An empty value to trigger a
-    list of available fields to be printed out
-
 .. option:: -f, --format [auto|pyout|json|json_pp|json_lines|yaml]
 
-    Choose the format/frontend for output. If 'auto' (default), 'pyout' will be
-    used in case of multiple files, and 'yaml' for a single file.
+    Choose the format/frontend for output.  If ``auto`` (the default),
+    ``pyout`` will be used in case of multiple files, ``yaml`` for a single
+    file.
 
-.. option:: -r, --recursive
+.. option:: -F, --fields <fields>
 
-    Recurse into content of dandisets/directories. Only .nwb files will be
-    considered.
+    Comma-separated list of fields to display.  Specifying ``-F ""`` causes a
+    list of available fields to be printed out.
 
 .. option:: -J, --jobs <int>
 
-    Number of parallel download jobs.
+    Number of parallel download jobs  [default: 6]
 
 .. option:: --metadata [api|all|assets]
+
+    Control when to include asset metadata for remote assets:
+
+    - ``api`` [default] — only include asset metadata if returned by the API
+      response (i.e., if a URL identifying an asset by ID was supplied)
+
+    - ``all`` — make an additional request to fetch asset metadata if not
+      returned by initial API response
+
+    - ``assets`` — same as ``all``
+
+.. option:: -r, --recursive
+
+    Recurse into Dandisets/directories.  Only :file:`*.nwb` files will be
+    considered.
 
 .. option:: --schema <version>
 
     Convert metadata to new schema version
+
+
+Development Options
+-------------------
+
+The following options are intended only for development & testing purposes.
+They are only available if the :envvar:`DANDI_DEVEL` environment variable is
+set to a nonempty value.
+
+.. option:: --use-fake-digest
+
+    Use dummy value for digests of local files instead of computing

--- a/docs/source/cmdline/ls.rst
+++ b/docs/source/cmdline/ls.rst
@@ -7,22 +7,8 @@
 
 List :file:`*.nwb` files' and Dandisets' metadata.
 
-The arguments may be either resource identifiers or paths to local
-files/directories.
-
-Patterns for known setups:
-
-- ``DANDI:<dandiset id>``
-- ``https://dandiarchive.org/...``
-- ``https://identifiers.org/DANDI:<dandiset id>``
-- ``https://<server>[/api]/[#/]dandiset/<dandiset id>[/<version>][/files[?location=<path>]]``
-- ``https://*dandiarchive-org.netflify.app/...``
-- ``https://<server>[/api]/dandisets/<dandiset id>[/versions[/<version>]]``
-- ``https://<server>[/api]/dandisets/<dandiset id>/versions/<version>/assets/<asset id>[/download]``
-- ``https://<server>[/api]/dandisets/<dandiset id>/versions/<version>/assets/?path=<path>``
-- ``dandi://<instance name>/<dandiset id>[@<version>][/<path>]``
-- ``https://<server>/...``
-
+The arguments may be either :ref:`resource identifiers <resource_ids>` or paths
+to local files/directories.
 
 Options
 -------

--- a/docs/source/cmdline/organize.rst
+++ b/docs/source/cmdline/organize.rst
@@ -1,3 +1,5 @@
+.. _dandi_organize:
+
 :program:`dandi organize`
 =========================
 
@@ -5,31 +7,32 @@
 
     dandi [<global options>] organize [<options>] [<path> ...]
 
-(Re)organize files according to the metadata.
+(Re)organize files according to their metadata.
 
-The purpose of this command is to take advantage of metadata contained in the
-.nwb files to provide datasets with consistently named files, so their naming
-reflects data they contain.
+The purpose of this command is to take advantage of metadata contained in
+:file:`*.nwb` files to provide datasets with consistently-named files whose
+names reflect the data they contain.
 
-.nwb files are organized into a hierarchy of subfolders one per each "subject",
-e.g. sub-0001 if .nwb file had contained a Subject group with subject_id=0001.
-Each file in a subject-specific subfolder follows the convention::
+:file:`*.nwb` files are organized into a hierarchy of subfolders, one per
+"subject", e.g. :file:`sub-0001` if an :file:`*.nwb` file contained a Subject
+group with ``subject_id=0001``.  Each file in a subject-specific subfolder
+follows the pattern::
 
     sub-<subject_id>[_key-<value>][_mod1+mod2+...].nwb
 
-where following keys are considered if present in the data::
+where the following keys are considered if present in the data:
 
-    ses -- session_id
-    tis -- tissue_sample_id
-    slice -- slice_id
-    cell -- cell_id
+- ``ses`` — ``session_id``
+- ``tis`` — ``tissue_sample_id``
+- ``slice`` — ``slice_id``
+- ``cell`` — ``cell_id``
 
 and ``modX`` are "modalities" as identified based on detected neural data types
-(such as "ecephys", "icephys") per extensions found in nwb-schema definitions:
-https://github.com/NeurodataWithoutBorders/nwb-schema/tree/dev/core
+(such as "ecephys", "icephys") per extensions found in `nwb-schema definitions
+<https://github.com/NeurodataWithoutBorders/nwb-schema/tree/dev/core>`_.
 
-In addition an "obj" key with a value corresponding to crc32 checksum of
-"object_id" is added if aforementioned keys and the list of modalities are
+In addition, an "obj" key with a value corresponding to the crc32 checksum of
+"object_id" is added if the aforementioned keys and the list of modalities are
 not sufficient to disambiguate different files.
 
 You can visit https://dandiarchive.org for a growing collection of
@@ -40,19 +43,36 @@ Options
 
 .. option:: -d, --dandiset-path <dir>
 
-    A top directory (local) of the dandiset to organize files under.  If not
-    specified, dandiset current directory is under is assumed.  For 'simulate'
-    mode target dandiset/directory must not exist.
-
-.. option:: --invalid [fail|warn]
-
-    What to do if files without sufficient metadata are encountered.
+    The root directory of the Dandiset to organize files under.  If not
+    specified, the Dandiset under the current directory is assumed.  For
+    'simulate' mode, the target Dandiset/directory must not exist.
 
 .. option:: -f, --files-mode [dry|simulate|copy|move|hardlink|symlink|auto]
 
-    If 'dry' - no action is performed, suggested renames are printed.  If
-    'simulate' - hierarchy of empty files at --local-top-path is created.  Note
-    that previous layout should be removed prior this operation.  If 'auto'
-    (default) - whichever of symlink, hardlink, copy is allowed by system.  The
-    other modes (copy, move, symlink, hardlink) define how data files should be
-    made available.
+    How to relocate the files.
+
+    - ``auto`` [default] — The first of ``symlink``, ``hardlink``, and ``copy``
+      that is supported by the local filesystem
+
+    - ``dry`` — No action is performed, suggested renames are printed
+
+    - ``simulate`` — A hierarchy of empty files at :option:`--dandiset-path` is
+      created.  Note that the previous layout should be removed prior to this
+      operation.
+
+.. option:: --invalid [fail|warn]
+
+    What to do if files without sufficient metadata are encountered  [default:
+    ``fail``]
+
+
+Development Options
+-------------------
+
+The following options are intended only for development & testing purposes.
+They are only available if the :envvar:`DANDI_DEVEL` environment variable is
+set to a nonempty value.
+
+.. option:: --devel-debug
+
+    Do not use pyout callbacks, do not swallow exceptions, do not parallelize.

--- a/docs/source/cmdline/shell-completion.rst
+++ b/docs/source/cmdline/shell-completion.rst
@@ -5,7 +5,7 @@
 
     dandi [<global options>] shell-completion [<options>]
 
-Emit shell script for enabling command completion.
+Emit a shell script for enabling command completion.
 
 The output of this command should be "sourced" by bash or zsh to enable command
 completion.
@@ -20,5 +20,5 @@ Options
 
 .. option:: -s, --shell [bash|zsh|fish|auto]
 
-    The shell for which to generate completion code; `auto` (default) attempts
-    autodetection
+    The shell for which to generate completion code; ``auto`` (default)
+    attempts autodetection

--- a/docs/source/cmdline/upload.rst
+++ b/docs/source/cmdline/upload.rst
@@ -5,27 +5,35 @@
 
     dandi [<global options>] upload [<options>] [<path> ...]
 
-Upload dandiset (files) to DANDI archive.
+Upload Dandiset files to DANDI Archive.
 
-Target dandiset to upload to must already be registered in the archive and
-locally :file:`dandiset.yaml` should exist in :option:`--dandiset-path`.
+The target Dandiset to upload to must already be registered in the archive, and
+a :file:`dandiset.yaml` file must exist in the local :option:`--dandiset-path`.
 
-Local dandiset should pass validation.  For that it should be first organized
-using ``dandi organize`` command.
+Local Dandisets should pass validation.  For that, the assets should first be
+organized using the :ref:`dandi_organize` command.
 
-By default all files in the dandiset (not following directories starting with a
-period) will be considered for the upload.  You can point to specific files you
-would like to validate and have uploaded.
+By default, all :file:`*.nwb` files in the Dandiset (excluding directories
+starting with a period) will be considered for the upload.  You can point to
+specific files you would like to validate and have uploaded.
 
 Options
 -------
 
 .. option:: -e, --existing [error|skip|force|overwrite|refresh]
 
-    What to do if a file found existing on the server. 'skip' would skip the
-    file, 'force' - force reupload, 'overwrite' - force upload if either size
-    or modification time differs; 'refresh' (default) - upload only if local
-    modification time is ahead of the remote.
+    How to handle files that already exist on the server:
+
+    - ``error`` — raise an error
+    - ``skip`` — skip the file
+    - ``force`` — force reupload
+    - ``overwrite`` — force upload if either size or modification time differs
+    - ``refresh`` [default] — upload only if local modification time is ahead
+      of the remote
+
+.. option:: -i, --instance <instance-name>
+
+    DANDI instance to upload to  [default: ``dandi``]
 
 .. option:: -J, --jobs N[:M]
 
@@ -34,9 +42,36 @@ Options
 
 .. option:: --sync
 
-    Delete assets on the server that do not exist locally
+    Delete assets on the server that do not exist locally after uploading
 
 .. option:: --validation [require|skip|ignore]
 
-    Data must pass validation before the upload.  Use of this option is highly
+    How to handle invalid assets:
+
+    - ``require`` [default] — Do not upload any invalid assets
+    - ``skip`` — Do not check assets for validity
+    - ``ignore`` — Emit an error message for invalid assets but upload them
+      anyway
+
+    Data should pass validation before uploading.  Use of this option is highly
     discouraged.
+
+
+Development Options
+-------------------
+
+The following options are intended only for development & testing purposes.
+They are only available if the :envvar:`DANDI_DEVEL` environment variable is
+set to a nonempty value.
+
+.. option:: --allow-any-path
+
+    Upload all file types, not just :file:`*.nwb`'s
+
+.. option:: --devel-debug
+
+    Do not use pyout callbacks, do not swallow exceptions, do not parallelize.
+
+.. option:: --upload-dandiset-metadata
+
+    Update Dandiset metadata based on the local :file:`dandiset.yaml` file

--- a/docs/source/cmdline/validate.rst
+++ b/docs/source/cmdline/validate.rst
@@ -7,4 +7,24 @@
 
 Validate files for NWB (and DANDI) compliance.
 
-Exits with non-0 exit code if any file is not compliant.
+Exits with non-zero exit code if any file is not compliant.
+
+
+Development Options
+-------------------
+
+The following options are intended only for development & testing purposes.
+They are only available if the :envvar:`DANDI_DEVEL` environment variable is
+set to a nonempty value.
+
+.. option:: --allow-any-path
+
+    Validate all file types, not just :file:`*.nwb`'s
+
+.. option:: --devel-debug
+
+    Do not use pyout callbacks, do not swallow exceptions, do not parallelize.
+
+.. option:: --schema <version>
+
+    Validate against new schema version

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,6 +11,7 @@ Archive <https://dandiarchive.org>`_.
 
    cmdline/index
    modref/index
+   ref/index
 
 
 Indices and tables

--- a/docs/source/ref/index.rst
+++ b/docs/source/ref/index.rst
@@ -1,0 +1,8 @@
+**********
+References
+**********
+
+.. toctree::
+    :glob:
+
+    *

--- a/docs/source/ref/urls.rst
+++ b/docs/source/ref/urls.rst
@@ -1,0 +1,72 @@
+.. currentmodule:: dandi.dandiarchive
+
+.. _resource_ids:
+
+Resource Identifiers
+====================
+
+``dandi`` commands and Python functions accept URLs and URL-like identifiers in
+the following formats for identifying Dandisets, assets, and asset collections.
+
+Text in [brackets] is optional.  A ``server`` field is a base API, GUI, or
+redirector URL for a registered DANDI Archive instance.  If an optional
+``version`` field is omitted from a URL, the given Dandiset's most recent
+published version will be used if it has one, and its draft version will be
+used otherwise.
+
+- :samp:`https://identifiers.org/DANDI:{dandiset-id}[/{version}]`
+  (case insensitive; ``version`` cannot be "draft") when it redirects
+  to one of the other URL formats
+
+- :samp:`DANDI:{dandiset-id}[/{version}]` — (case insensitive;
+  ``version`` cannot be "draft") Abbreviation for the above
+
+- Any ``https://dandiarchive.org/`` or
+  ``https://*dandiarchive-org.netflify.app/`` URL which redirects to
+  one of the other URL formats
+
+- :samp:`https://{server}[/api]/[#/]dandiset/{dandiset-id}[/{version}][/files]`
+  — Refers to a Dandiset.  `parse_dandi_url()` converts this format to a
+  `DandisetURL`.
+
+- :samp:`https://{server}[/api]/[#/]dandiset/{dandiset-id}[/{version}]/files?location={path}/`
+  (trailing slash) — Refers to an asset folder by path.  `parse_dandi_url()`
+  converts this format to an `AssetFolderURL`.
+
+- :samp:`https://{server}[/api]/[#/]dandiset/{dandiset-id}[/{version}]/files?location={path}`
+  (no trailing slash) — Refers to a single asset by path.  `parse_dandi_url()`
+  converts this format to an `AssetItemURL`.
+
+- :samp:`https://{server}[/api]/dandisets/{dandiset-id}[/versions[/{version}]]`
+  — Refers to a Dandiset.  `parse_dandi_url()` converts this format to a
+  `DandisetURL`.
+
+- :samp:`https://{server}[/api]/assets/{asset-id}[/download]` — Refers to a
+  single asset by identifier.  `parse_dandi_url()` converts this format to a
+  `BaseAssetIDURL`.
+
+- :samp:`https://{server}[/api]/dandisets/{dandiset-id}/versions/{version}/assets/{asset-id}[/download]`
+  — Refers to a single asset by identifier.  `parse_dandi_url()` converts this
+  format to an `AssetIDURL`.
+
+- :samp:`https://{server}[/api]/dandisets/{dandiset-id}/versions/{version}/assets/?path={path}`
+  — Refers to all assets in the given Dandiset whose paths begin with the
+  prefix ``path``.  `parse_dandi_url()` converts this format to an
+  `AssetPathPrefixURL`.
+
+- :samp:`dandi://{instance-name}/{dandiset-id}[@{version}]` (where
+  ``instance-name`` is the name of a registered Dandi Archive instance) —
+  Refers to a Dandiset.  `parse_dandi_url()` converts this format to a
+  `DandisetURL`.
+
+- :samp:`dandi://{instance-name}/{dandiset-id}[@{version}]/{path}/` (where
+  ``instance-name`` is the name of a registered Dandi Archive instance)
+  (trailing slash) — Refers to an asset folder by path.  `parse_dandi_url()`
+  converts this format to an `AssetFolderURL`.
+
+- :samp:`dandi://{instance-name}/{dandiset-id}[@{version}]/{path}` (where
+  ``instance-name`` is the name of a registered Dandi Archive instance) (no
+  trailing slash) — Refers to a single asset by path.  `parse_dandi_url()`
+  converts this format to an `AssetItemURL`.
+
+- Any other HTTPS URL that redirects to one of the above


### PR DESCRIPTION
This PR expands the docs for the individual subcommands, adds a page documenting the root `dandi` command, and adds a single reference page listing the resource identifier patterns for other pages to link to.