### PR TITLE
Add a wrapper function for the calls to `find_files()` in tests

### DIFF
--- a/dandi/tests/test_dandiapi.py
+++ b/dandi/tests/test_dandiapi.py
@@ -2,7 +2,6 @@ import builtins
 from datetime import datetime, timezone
 import logging
 import os.path
-from pathlib import Path
 import random
 import re
 from shutil import rmtree
@@ -25,7 +24,7 @@ from ..dandiapi import DandiAPIClient, Version
 from ..download import download
 from ..exceptions import NotFoundError, SchemaVersionError
 from ..upload import upload
-from ..utils import find_files
+from ..utils import list_paths
 
 
 def test_upload(local_dandi_api, simple1_nwb, tmp_path):
@@ -87,14 +86,11 @@ def test_publish_and_manipulate(local_dandi_api, monkeypatch, tmp_path):
     download_dir = tmp_path / "download"
     download_dir.mkdir()
 
-    def downloaded_files():
-        return list(map(Path, find_files(r".*", paths=[download_dir])))
-
     dandiset_yaml = download_dir / dandiset_id / dandiset_metadata_file
     file_in_version = download_dir / dandiset_id / "subdir" / "file.txt"
 
     download(dv.version_api_url, download_dir)
-    assert downloaded_files() == [dandiset_yaml, file_in_version]
+    assert list_paths(download_dir) == [dandiset_yaml, file_in_version]
     assert file_in_version.read_text() == "This is test text.\n"
 
     (upload_dir / "subdir" / "file.txt").write_text("This is different text.\n")
@@ -107,7 +103,7 @@ def test_publish_and_manipulate(local_dandi_api, monkeypatch, tmp_path):
     )
     rmtree(download_dir / dandiset_id)
     download(dv.version_api_url, download_dir)
-    assert downloaded_files() == [dandiset_yaml, file_in_version]
+    assert list_paths(download_dir) == [dandiset_yaml, file_in_version]
     assert file_in_version.read_text() == "This is test text.\n"
 
     (upload_dir / "subdir" / "file2.txt").write_text("This is more text.\n")
@@ -121,7 +117,7 @@ def test_publish_and_manipulate(local_dandi_api, monkeypatch, tmp_path):
 
     rmtree(download_dir / dandiset_id)
     download(d.version_api_url, download_dir)
-    assert sorted(downloaded_files()) == [
+    assert list_paths(download_dir) == [
         dandiset_yaml,
         file_in_version,
         file_in_version.with_name("file2.txt"),
@@ -131,19 +127,22 @@ def test_publish_and_manipulate(local_dandi_api, monkeypatch, tmp_path):
 
     rmtree(download_dir / dandiset_id)
     download(dv.version_api_url, download_dir)
-    assert downloaded_files() == [dandiset_yaml, file_in_version]
+    assert list_paths(download_dir) == [dandiset_yaml, file_in_version]
     assert file_in_version.read_text() == "This is test text.\n"
 
     d.get_asset_by_path("subdir/file.txt").delete()
 
     rmtree(download_dir / dandiset_id)
     download(d.version_api_url, download_dir)
-    assert downloaded_files() == [dandiset_yaml, file_in_version.with_name("file2.txt")]
+    assert list_paths(download_dir) == [
+        dandiset_yaml,
+        file_in_version.with_name("file2.txt"),
+    ]
     assert file_in_version.with_name("file2.txt").read_text() == "This is more text.\n"
 
     rmtree(download_dir / dandiset_id)
     download(dv.version_api_url, download_dir)
-    assert downloaded_files() == [dandiset_yaml, file_in_version]
+    assert list_paths(download_dir) == [dandiset_yaml, file_in_version]
     assert file_in_version.read_text() == "This is test text.\n"
 
 

--- a/dandi/tests/test_delete.py
+++ b/dandi/tests/test_delete.py
@@ -7,7 +7,7 @@ from ..dandiapi import RESTFullAPIClient
 from ..delete import delete
 from ..download import download
 from ..exceptions import NotFoundError
-from ..utils import find_files
+from ..utils import list_paths
 
 
 @pytest.mark.parametrize(
@@ -70,8 +70,9 @@ def test_delete_paths(
     )
     delete_spy.assert_called()
     download(text_dandiset["dandiset"].version_api_url, tmp_path)
-    files = sorted(map(Path, find_files(r".*", paths=[tmp_path])))
-    assert files == [tmp_path / dandiset_id / f for f in ["dandiset.yaml"] + remainder]
+    assert list_paths(tmp_path) == [
+        tmp_path / dandiset_id / f for f in ["dandiset.yaml"] + remainder
+    ]
 
 
 @pytest.mark.parametrize("confirm", [True, False])
@@ -276,8 +277,7 @@ def test_delete_nonexistent_asset_skip_missing(
     )
     delete_spy.assert_called()
     download(text_dandiset["dandiset"].version_api_url, tmp_path)
-    files = sorted(map(Path, find_files(r".*", paths=[tmp_path])))
-    assert files == [
+    assert list_paths(tmp_path) == [
         tmp_path / dandiset_id / "dandiset.yaml",
         tmp_path / dandiset_id / "subdir1" / "apple.txt",
         tmp_path / dandiset_id / "subdir2" / "banana.txt",
@@ -328,8 +328,7 @@ def test_delete_nonexistent_asset_folder_skip_missing(
     )
     delete_spy.assert_called()
     download(text_dandiset["dandiset"].version_api_url, tmp_path)
-    files = sorted(map(Path, find_files(r".*", paths=[tmp_path])))
-    assert files == [
+    assert list_paths(tmp_path) == [
         tmp_path / dandiset_id / "dandiset.yaml",
         tmp_path / dandiset_id / "file.txt",
         tmp_path / dandiset_id / "subdir2" / "banana.txt",

--- a/dandi/tests/test_download.py
+++ b/dandi/tests/test_download.py
@@ -1,7 +1,6 @@
 import json
 import os
 import os.path as op
-from pathlib import Path
 import re
 from shutil import rmtree
 
@@ -12,7 +11,7 @@ from .skip import mark
 from ..consts import DRAFT, dandiset_metadata_file
 from ..dandiarchive import DandisetURL
 from ..download import download, download_generator
-from ..utils import find_files
+from ..utils import list_paths
 
 
 # both urls point to 000027 (lean test dataset), and both draft and "released"
@@ -137,7 +136,7 @@ def test_download_folder(local_dandi_api, text_dandiset, tmp_path):
     download(
         f"dandi://{local_dandi_api['instance_id']}/{dandiset_id}/subdir2/", tmp_path
     )
-    assert sorted(map(Path, find_files(r".*", paths=[tmp_path], dirs=True))) == [
+    assert list_paths(tmp_path, dirs=True) == [
         tmp_path / "subdir2",
         tmp_path / "subdir2" / "banana.txt",
         tmp_path / "subdir2" / "coconut.txt",
@@ -152,27 +151,21 @@ def test_download_item(local_dandi_api, text_dandiset, tmp_path):
         f"dandi://{local_dandi_api['instance_id']}/{dandiset_id}/subdir2/coconut.txt",
         tmp_path,
     )
-    assert list(map(Path, find_files(r".*", paths=[tmp_path], dirs=True))) == [
-        tmp_path / "coconut.txt"
-    ]
+    assert list_paths(tmp_path, dirs=True) == [tmp_path / "coconut.txt"]
     assert (tmp_path / "coconut.txt").read_text() == "Coconut\n"
 
 
 def test_download_asset_id(text_dandiset, tmp_path):
     asset = text_dandiset["dandiset"].get_asset_by_path("subdir2/coconut.txt")
     download(asset.download_url, tmp_path)
-    assert list(map(Path, find_files(r".*", paths=[tmp_path], dirs=True))) == [
-        tmp_path / "coconut.txt"
-    ]
+    assert list_paths(tmp_path, dirs=True) == [tmp_path / "coconut.txt"]
     assert (tmp_path / "coconut.txt").read_text() == "Coconut\n"
 
 
 def test_download_asset_id_only(text_dandiset, tmp_path):
     asset = text_dandiset["dandiset"].get_asset_by_path("subdir2/coconut.txt")
     download(asset.base_download_url, tmp_path)
-    assert list(map(Path, find_files(r".*", paths=[tmp_path], dirs=True))) == [
-        tmp_path / "coconut.txt"
-    ]
+    assert list_paths(tmp_path, dirs=True) == [tmp_path / "coconut.txt"]
     assert (tmp_path / "coconut.txt").read_text() == "Coconut\n"
 
 
@@ -266,7 +259,7 @@ def test_download_metadata404(text_dandiset, tmp_path):
             "message": f"No such asset: {asset}",
         }
     ]
-    assert sorted(map(Path, find_files(r".*", paths=[tmp_path], dirs=True))) == [
+    assert list_paths(tmp_path, dirs=True) == [
         tmp_path / dandiset_metadata_file,
         tmp_path / "file.txt",
         tmp_path / "subdir2",

--- a/dandi/tests/test_upload.py
+++ b/dandi/tests/test_upload.py
@@ -10,7 +10,7 @@ from ..download import download
 from ..exceptions import NotFoundError
 from ..pynwb_utils import make_nwb_file
 from ..upload import upload
-from ..utils import find_files
+from ..utils import list_paths
 
 
 def test_new_upload_download(local_dandi_api, monkeypatch, organized_nwb_dir, tmp_path):
@@ -138,12 +138,11 @@ def test_upload_download_small_file(contents, local_dandi_api, monkeypatch, tmp_
     download_dir = tmp_path / "download"
     download_dir.mkdir()
     download(d.version_api_url, download_dir)
-    files = sorted(map(Path, find_files(r".*", paths=[download_dir])))
-    assert files == [
+    assert list_paths(download_dir) == [
         download_dir / dandiset_id / dandiset_metadata_file,
         download_dir / dandiset_id / "file.txt",
     ]
-    assert files[1].read_bytes() == contents
+    assert (download_dir / dandiset_id / "file.txt").read_bytes() == contents
 
 
 @pytest.mark.parametrize("confirm", [True, False])

--- a/dandi/utils.py
+++ b/dandi/utils.py
@@ -19,7 +19,7 @@ import shutil
 import subprocess
 import sys
 import types
-from typing import Optional, Union
+from typing import List, Optional, Union
 
 import dateutil.parser
 import requests
@@ -322,6 +322,10 @@ def find_files(
                     )
                 else:
                     yield path
+
+
+def list_paths(dirpath: Union[str, Path], dirs: bool = False) -> List[Path]:
+    return sorted(map(Path, find_files(r".*", [dirpath], dirs=dirs)))
 
 
 _cp_supports_reflink = None


### PR DESCRIPTION
So that I don't have to keep writing `sorted(map(Path, find_files(r".*", [dirpath])))`