### PR TITLE
Replace the use of pyfakefs with a `tmp_home` fixture

### DIFF
--- a/dandi/keyring.py
+++ b/dandi/keyring.py
@@ -75,7 +75,7 @@ def keyring_lookup(service_name, username):
         if click.confirm(
             "Would you like to establish an encrypted keyring?", default=True
         ):
-            keyring_cfg = Path(keyringrc_file())
+            keyring_cfg = keyringrc_file()
             if keyring_cfg.exists():
                 lgr.info("%s exists; refusing to overwrite", keyring_cfg)
             else:
@@ -95,4 +95,4 @@ def keyring_lookup(service_name, username):
 
 
 def keyringrc_file():
-    return op.join(config_root(), "keyringrc.cfg")
+    return Path(config_root(), "keyringrc.cfg")

--- a/dandi/tests/fixtures.py
+++ b/dandi/tests/fixtures.py
@@ -312,3 +312,20 @@ def text_dandiset(local_dandi_api, monkeypatch, tmp_path_factory):
         "dandiset_id": dandiset_id,
         "reupload": upload_dandiset,
     }
+
+
+@pytest.fixture()
+def tmp_home(
+    monkeypatch: pytest.MonkeyPatch, tmp_path_factory: pytest.TempPathFactory
+) -> Path:
+    home = tmp_path_factory.mktemp("tmp_home")
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+    monkeypatch.delenv("XDG_CONFIG_DIRS", raising=False)
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.delenv("XDG_DATA_DIRS", raising=False)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+    monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+    monkeypatch.setenv("USERPROFILE", str(home))
+    monkeypatch.setenv("LOCALAPPDATA", str(home))

--- a/dandi/tests/test_keyring.py
+++ b/dandi/tests/test_keyring.py
@@ -1,4 +1,4 @@
-import os.path
+from pathlib import Path
 
 from keyring.backend import get_all_keyring
 from keyring.backends import fail, null
@@ -12,9 +12,7 @@ from ..keyring import keyring_lookup, keyringrc_file
 
 @pytest.fixture(scope="module", autouse=True)
 def ensure_keyring_backends():
-    # Ensure that keyring backends are initialized before running any tests, as
-    # EncryptedKeyring cannot be initialized (on macOS, at least) while
-    # pyfakefs is in effect.
+    # Ensure that keyring backends are initialized before running any tests
     get_all_keyring()
     # This function caches its results, so it's safe to call if the backends
     # have already been initialized.
@@ -35,38 +33,36 @@ def test_dandi_authenticate_no_env_var(local_dandi_api, monkeypatch, mocker):
     )
 
 
-def setup_keyringrc_no_password(fs):
-    fs.create_file(
-        keyringrc_file(),
-        contents="[backend]\ndefault-keyring = keyring.backends.null.Keyring\n",
-    )
+def setup_keyringrc_no_password():
+    rc = keyringrc_file()
+    rc.parent.mkdir(parents=True, exist_ok=True)
+    rc.write_text("[backend]\ndefault-keyring = keyring.backends.null.Keyring\n")
 
 
-def setup_keyringrc_password(fs):
-    fs.create_file(
-        keyringrc_file(),
-        contents="[backend]\ndefault-keyring = keyrings.alt.file.PlaintextKeyring\n",
-    )
+def setup_keyringrc_password():
+    rc = keyringrc_file()
+    rc.parent.mkdir(parents=True, exist_ok=True)
+    rc.write_text("[backend]\ndefault-keyring = keyrings.alt.file.PlaintextKeyring\n")
     keyfile.PlaintextKeyring().set_password(
         "testservice", "testusername", "testpassword"
     )
 
 
-def setup_keyringrc_fail(fs):
-    fs.create_file(
-        keyringrc_file(),
-        contents="[backend]\ndefault-keyring = keyring.backends.fail.Keyring\n",
-    )
+def setup_keyringrc_fail():
+    rc = keyringrc_file()
+    rc.parent.mkdir(parents=True, exist_ok=True)
+    rc.write_text("[backend]\ndefault-keyring = keyring.backends.fail.Keyring\n")
 
 
 @pytest.mark.parametrize(
     "rcconfig",
     [None, setup_keyringrc_no_password, setup_keyringrc_password, setup_keyringrc_fail],
 )
-def test_keyring_lookup_envvar_no_password(fs, monkeypatch, rcconfig):
+@pytest.mark.usefixtures("tmp_home")
+def test_keyring_lookup_envvar_no_password(monkeypatch, rcconfig):
     monkeypatch.setenv("PYTHON_KEYRING_BACKEND", "keyring.backends.null.Keyring")
     if rcconfig is not None:
-        rcconfig(fs)
+        rcconfig()
     kb, password = keyring_lookup("testservice", "testusername")
     assert isinstance(kb, null.Keyring)
     assert password is None
@@ -75,13 +71,14 @@ def test_keyring_lookup_envvar_no_password(fs, monkeypatch, rcconfig):
 @pytest.mark.parametrize(
     "rcconfig", [None, setup_keyringrc_no_password, setup_keyringrc_fail]
 )
-def test_keyring_lookup_envvar_password(fs, monkeypatch, rcconfig):
+@pytest.mark.usefixtures("tmp_home")
+def test_keyring_lookup_envvar_password(monkeypatch, rcconfig):
     monkeypatch.setenv("PYTHON_KEYRING_BACKEND", "keyrings.alt.file.PlaintextKeyring")
     keyfile.PlaintextKeyring().set_password(
         "testservice", "testusername", "testpassword"
     )
     if rcconfig is not None:
-        rcconfig(fs)
+        rcconfig()
     kb, password = keyring_lookup("testservice", "testusername")
     assert isinstance(kb, keyfile.PlaintextKeyring)
     assert password == "testpassword"
@@ -91,40 +88,43 @@ def test_keyring_lookup_envvar_password(fs, monkeypatch, rcconfig):
     "rcconfig",
     [None, setup_keyringrc_no_password, setup_keyringrc_password, setup_keyringrc_fail],
 )
-def test_keyring_lookup_envvar_fail(fs, monkeypatch, rcconfig):
+@pytest.mark.usefixtures("tmp_home")
+def test_keyring_lookup_envvar_fail(monkeypatch, rcconfig):
     monkeypatch.setenv("PYTHON_KEYRING_BACKEND", "keyring.backends.fail.Keyring")
     if rcconfig is not None:
-        rcconfig(fs)
+        rcconfig()
     with pytest.raises(KeyringError):
         keyring_lookup("testservice", "testusername")
 
 
-def test_keyring_lookup_rccfg_no_password(fs, monkeypatch):
+@pytest.mark.usefixtures("tmp_home")
+def test_keyring_lookup_rccfg_no_password(monkeypatch):
     monkeypatch.delenv("PYTHON_KEYRING_BACKEND", raising=False)
-    setup_keyringrc_no_password(fs)
+    setup_keyringrc_no_password()
     kb, password = keyring_lookup("testservice", "testusername")
     assert isinstance(kb, null.Keyring)
     assert password is None
 
 
-def test_keyring_lookup_rccfg_password(fs, monkeypatch):
+@pytest.mark.usefixtures("tmp_home")
+def test_keyring_lookup_rccfg_password(monkeypatch):
     monkeypatch.delenv("PYTHON_KEYRING_BACKEND", raising=False)
-    setup_keyringrc_password(fs)
+    setup_keyringrc_password()
     kb, password = keyring_lookup("testservice", "testusername")
     assert isinstance(kb, keyfile.PlaintextKeyring)
     assert password == "testpassword"
 
 
-def test_keyring_lookup_rccfg_fail(fs, monkeypatch):
+@pytest.mark.usefixtures("tmp_home")
+def test_keyring_lookup_rccfg_fail(monkeypatch):
     monkeypatch.delenv("PYTHON_KEYRING_BACKEND", raising=False)
-    setup_keyringrc_fail(fs)
+    setup_keyringrc_fail()
     with pytest.raises(KeyringError):
         keyring_lookup("testservice", "testusername")
 
 
-def test_keyring_lookup_default_no_password(fs, mocker, monkeypatch):
-    # Requesting the `fs` fixture (even if it's not directly used) should
-    # guarantee that a keyringrc.cfg file on the real filesystem isn't found.
+@pytest.mark.usefixtures("tmp_home")
+def test_keyring_lookup_default_no_password(mocker, monkeypatch):
     monkeypatch.delenv("PYTHON_KEYRING_BACKEND", raising=False)
     kb0 = null.Keyring()
     get_keyring = mocker.patch("dandi.keyring.get_keyring", return_value=kb0)
@@ -134,11 +134,8 @@ def test_keyring_lookup_default_no_password(fs, mocker, monkeypatch):
     get_keyring.assert_called_once_with()
 
 
-def test_keyring_lookup_default_password(fs, mocker, monkeypatch):
-    # Requesting the `fs` fixture (even if it's not directly used) should
-    # guarantee that a keyringrc.cfg file on the real filesystem isn't found
-    # and that the PlaintextKeyring file is only created on the fake
-    # filesystem.
+@pytest.mark.usefixtures("tmp_home")
+def test_keyring_lookup_default_password(mocker, monkeypatch):
     monkeypatch.delenv("PYTHON_KEYRING_BACKEND", raising=False)
     kb0 = keyfile.PlaintextKeyring()
     kb0.set_password("testservice", "testusername", "testpassword")
@@ -153,9 +150,8 @@ class EncryptedFailure(fail.Keyring, keyfile.EncryptedKeyring):
     pass
 
 
-def test_keyring_lookup_fail_default_encrypted(fs, mocker, monkeypatch):
-    # Requesting the `fs` fixture (even if it's not directly used) should
-    # guarantee that a keyringrc.cfg file on the real filesystem isn't found.
+@pytest.mark.usefixtures("tmp_home")
+def test_keyring_lookup_fail_default_encrypted(mocker, monkeypatch):
     monkeypatch.delenv("PYTHON_KEYRING_BACKEND", raising=False)
     get_keyring = mocker.patch(
         "dandi.keyring.get_keyring", return_value=EncryptedFailure()
@@ -165,17 +161,21 @@ def test_keyring_lookup_fail_default_encrypted(fs, mocker, monkeypatch):
     get_keyring.assert_called_once_with()
 
 
-def test_keyring_lookup_encrypted_fallback_exists_no_password(fs, mocker, monkeypatch):
+@pytest.mark.usefixtures("tmp_home")
+def test_keyring_lookup_encrypted_fallback_exists_no_password(mocker, monkeypatch):
     monkeypatch.delenv("PYTHON_KEYRING_BACKEND", raising=False)
     get_keyring = mocker.patch("dandi.keyring.get_keyring", return_value=fail.Keyring())
-    fs.create_file(keyfile.EncryptedKeyring().file_path)
+    kf = Path(keyfile.EncryptedKeyring().file_path)
+    kf.parent.mkdir(parents=True, exist_ok=True)
+    kf.touch()
     kb, password = keyring_lookup("testservice", "testusername")
     assert isinstance(kb, keyfile.EncryptedKeyring)
     assert password is None
     get_keyring.assert_called_once_with()
 
 
-def test_keyring_lookup_encrypted_fallback_exists_password(fs, mocker, monkeypatch):
+@pytest.mark.usefixtures("tmp_home")
+def test_keyring_lookup_encrypted_fallback_exists_password(mocker, monkeypatch):
     monkeypatch.delenv("PYTHON_KEYRING_BACKEND", raising=False)
     get_keyring = mocker.patch("dandi.keyring.get_keyring", return_value=fail.Keyring())
     kb0 = keyfile.EncryptedKeyring()
@@ -190,11 +190,8 @@ def test_keyring_lookup_encrypted_fallback_exists_password(fs, mocker, monkeypat
     get_keyring.assert_called_once_with()
 
 
-def test_keyring_lookup_encrypted_fallback_not_exists_no_create(
-    fs, mocker, monkeypatch
-):
-    # Requesting the `fs` fixture (even if it's not directly used) should
-    # guarantee that an encrypted keyring on the real filesystem isn't found.
+@pytest.mark.usefixtures("tmp_home")
+def test_keyring_lookup_encrypted_fallback_not_exists_no_create(mocker, monkeypatch):
     monkeypatch.delenv("PYTHON_KEYRING_BACKEND", raising=False)
     get_keyring = mocker.patch("dandi.keyring.get_keyring", return_value=fail.Keyring())
     confirm = mocker.patch("click.confirm", return_value=False)
@@ -206,11 +203,10 @@ def test_keyring_lookup_encrypted_fallback_not_exists_no_create(
     )
 
 
+@pytest.mark.usefixtures("tmp_home")
 def test_keyring_lookup_encrypted_fallback_not_exists_create_rcconf(
-    fs, mocker, monkeypatch
+    mocker, monkeypatch
 ):
-    # Requesting the `fs` fixture (even if it's not directly used) should
-    # guarantee that a fake filesystem is used.
     monkeypatch.delenv("PYTHON_KEYRING_BACKEND", raising=False)
     get_keyring = mocker.patch("dandi.keyring.get_keyring", return_value=fail.Keyring())
     confirm = mocker.patch("click.confirm", return_value=True)
@@ -221,20 +217,22 @@ def test_keyring_lookup_encrypted_fallback_not_exists_create_rcconf(
     confirm.assert_called_once_with(
         "Would you like to establish an encrypted keyring?", default=True
     )
-    assert os.path.exists(keyringrc_file())
-    with open(keyringrc_file()) as fp:
-        assert fp.read() == (
-            "[backend]\ndefault-keyring = keyrings.alt.file.EncryptedKeyring\n"
-        )
+    assert keyringrc_file().exists()
+    assert keyringrc_file().read_text() == (
+        "[backend]\ndefault-keyring = keyrings.alt.file.EncryptedKeyring\n"
+    )
 
 
+@pytest.mark.usefixtures("tmp_home")
 def test_keyring_lookup_encrypted_fallback_not_exists_create_rcconf_exists(
-    fs, mocker, monkeypatch
+    mocker, monkeypatch
 ):
     monkeypatch.delenv("PYTHON_KEYRING_BACKEND", raising=False)
     get_keyring = mocker.patch("dandi.keyring.get_keyring", return_value=fail.Keyring())
     confirm = mocker.patch("click.confirm", return_value=True)
-    fs.create_file(keyringrc_file(), contents="# placeholder\n")
+    rc = keyringrc_file()
+    rc.parent.mkdir(parents=True, exist_ok=True)
+    rc.write_text("# placeholder\n")
     kb, password = keyring_lookup("testservice", "testusername")
     assert isinstance(kb, keyfile.EncryptedKeyring)
     assert password is None
@@ -242,5 +240,4 @@ def test_keyring_lookup_encrypted_fallback_not_exists_create_rcconf_exists(
     confirm.assert_called_once_with(
         "Would you like to establish an encrypted keyring?", default=True
     )
-    with open(keyringrc_file()) as fp:
-        assert fp.read() == "# placeholder\n"
+    assert rc.read_text() == "# placeholder\n"

--- a/setup.cfg
+++ b/setup.cfg
@@ -78,7 +78,6 @@ style =
 test =
     anys ~= 0.2
     coverage
-    pyfakefs ~= 4.0
     pytest
     pytest-cov
     pytest-mock


### PR DESCRIPTION
This eliminates the dependency on the slow and occasionally-troublesome pyfakefs in favor of just monkeypatching `$HOME` to a temporary directory when testing out keyring support.