### PR TITLE
upgrade dandischema requirement from 0.4.1 to 0.5.1 (~=)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     appdirs
     click
     click-didyoumean
-    dandischema ~= 0.4.1
+    dandischema ~= 0.5.1
     etelemetry >= 0.2.2
     fasteners
     fscacher


### PR DESCRIPTION
Want to see if we are all good with such an upgrade in the light of @dchiquito reporting error while downloading from the archive of 000027

<details>
<summary>detail from slack (not filed as an issue yet)</summary> 

```shell
Sadly I am having basic CLI problems. Running dandi download https://gui.dandiarchive.org/#/dandiset/000027 with dandi==0.34.0 is giving me this error:
Error: [{'type': 'array', 'items': [{'type': 'string'}, {'type': ['string', 'boolean']}], 'additionalItems': False}] is not of type 'object', 'boolean'

Failed validating 'type' in metaschema['properties']['definitions']['additionalProperties']['$dynamicRef']['allOf'][1]['properties']['properties']['additionalProperties']['$dynamicRef']['allOf'][1]['properties']['items']['$dynamicRef']['allOf'][0]:
    {'$defs': {'anchorString': {'pattern': '^[A-Za-z_][-A-Za-z0-9._]*$',
                                'type': 'string'},
               'uriReferenceString': {'format': 'uri-reference',
                                      'type': 'string'},
               'uriString': {'format': 'uri', 'type': 'string'}},
     '$dynamicAnchor': 'meta',
     '$id': 'https://json-schema.org/draft/2020-12/meta/core',
     '$schema': 'https://json-schema.org/draft/2020-12/schema',
     '$vocabulary': {'https://json-schema.org/draft/2020-12/vocab/core': True},
     'properties': {'$anchor': {'$ref': '#/$defs/anchorString'},
                    '$comment': {'type': 'string'},
                    '$defs': {'additionalProperties': {'$dynamicRef': '#meta'},
                              'type': 'object'},
                    '$dynamicAnchor': {'$ref': '#/$defs/anchorString'},
                    '$dynamicRef': {'$ref': '#/$defs/uriReferenceString'},
                    '$id': {'$comment': 'Non-empty fragments not allowed.',
                            '$ref': '#/$defs/uriReferenceString',
                            'pattern': '^[^#]*#?$'},
                    '$ref': {'$ref': '#/$defs/uriReferenceString'},
                    '$schema': {'$ref': '#/$defs/uriString'},
                    '$vocabulary': {'additionalProperties': {'type': 'boolean'},
                                    'propertyNames': {'$ref': '#/$defs/uriString'},
                                    'type': 'object'}},
     'title': 'Core vocabulary meta-schema',
     'type': ['object', 'boolean']}

On schema['definitions']['re_lookup']['properties']['re_lookup']['items']:
    [{'additionalItems': False,
      'items': [{'type': 'string'}, {'type': ['string', 'boolean']}],
      'type': 'array'}]
The schema version of 000027 is 0.6.0

Yarik  7 minutes ago
000027 is our elderly test dandiset... I wonder if dandischema release/upgrade triggered this somehow... in dandi-cli we have dandischema ~= 0.4.1 (will submit a PR to upgrade), but I failed to reproduce one way (without upgrade of dandischema) or another    (upgrade dandischema library to 0.5.1 which uses dandischema 0.6.2).

Daniel Chiquito  4 minutes ago
yep, my dandischema was on 0.4.3, I should have used a fresh venv

Daniel Chiquito  2 minutes ago
it worked with dandischema==0.5.1
```
</details>