### PR TITLE
Enable type-checking

### DIFF
--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -1,0 +1,27 @@
+name: Type-check
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  typing:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade tox
+
+      - name: Run type checker
+        run: tox -e typing

--- a/dandi/cli/base.py
+++ b/dandi/cli/base.py
@@ -120,4 +120,6 @@ def map_to_click_exceptions(f):
     return wrapper
 
 
-map_to_click_exceptions._do_map = not bool(os.environ.get("DANDI_DEVEL", None))
+map_to_click_exceptions._do_map = not bool(  # type: ignore[attr-defined]
+    os.environ.get("DANDI_DEVEL", None)
+)

--- a/dandi/consts.py
+++ b/dandi/consts.py
@@ -1,6 +1,6 @@
-from collections import namedtuple
 from enum import Enum
 import os
+from typing import NamedTuple, Optional
 
 #: A list of metadata fields which dandi extracts from .nwb files.
 #: Additional fields (such as ``number_of_*``) might be added by
@@ -87,7 +87,12 @@ class EmbargoStatus(Enum):
 dandiset_metadata_file = "dandiset.yaml"
 dandiset_identifier_regex = f"^{DANDISET_ID_REGEX}$"
 
-DandiInstance = namedtuple("DandiInstance", ("gui", "redirector", "api"))
+
+class DandiInstance(NamedTuple):
+    gui: Optional[str]
+    redirector: Optional[str]
+    api: Optional[str]
+
 
 # So it could be easily mapped to external IP (e.g. from within VM)
 # to test against instance running outside of current environment

--- a/dandi/dandiapi.py
+++ b/dandi/dandiapi.py
@@ -1176,12 +1176,12 @@ class BaseRemoteAsset(APIBase):
         This is a low-level method that non-developers would normally only use
         when acquiring data using means outside of this library.
         """
-        return BaseRemoteAsset(
+        return BaseRemoteAsset(  # type: ignore[call-arg]
             client=client,
             identifier=metadata["identifier"],
             path=metadata["path"],
             size=metadata["contentSize"],
-            _metadata=metadata,  # type: ignore[call-arg]
+            _metadata=metadata,
         )
 
     @property
@@ -1434,12 +1434,12 @@ class RemoteAsset(ABC, BaseRemoteAsset):
                 raise ValueError("Asset data contains both `blob` and `zarr`'")
         else:
             raise ValueError("Asset data contains neither `blob` nor `zarr`")
-        return klass(
+        return klass(  # type: ignore[call-arg]
             client=dandiset.client,
             dandiset_id=dandiset.identifier,
             version_id=dandiset.version_id,
             **data,
-            _metadata=metadata,  # type: ignore[call-arg]
+            _metadata=metadata,
         )
 
     @property

--- a/dandi/dandiapi.py
+++ b/dandi/dandiapi.py
@@ -569,7 +569,10 @@ class APIBase(BaseModel):
         Convert to a JSONable `dict`, omitting the ``client`` attribute and
         using the same field names as in the API
         """
-        return json.loads(self.json(exclude=self.JSON_EXCLUDE, by_alias=True))
+        return cast(
+            Dict[str, Any],
+            json.loads(self.json(exclude=self.JSON_EXCLUDE, by_alias=True)),
+        )
 
     class Config:
         allow_population_by_field_name = True
@@ -640,7 +643,7 @@ class RemoteDandiset:
         client: DandiAPIClient,
         identifier: str,
         version: Union[str, Version, None] = None,
-        data: Optional[Dict[str, Any]] = None,
+        data: Union[Dict[str, Any], RemoteDandisetData, None] = None,
     ) -> None:
         #: The `DandiAPIClient` instance that returned this `RemoteDandiset`
         #: and which the latter will use for API requests
@@ -1076,9 +1079,12 @@ class RemoteDandiset:
         :param RemoteAsset replace_asset: If set, replace the given asset,
             which must have the same path as the new asset
         """
-        from .files import dandi_file
+        from .files import LocalAsset, dandi_file
 
-        return dandi_file(filepath).upload(
+        df = dandi_file(filepath)
+        if not isinstance(df, LocalAsset):
+            raise ValueError(f"{filepath}: not an asset file")
+        return df.upload(
             self, metadata=asset_metadata, jobs=jobs, replacing=replace_asset
         )
 
@@ -1114,9 +1120,12 @@ class RemoteDandiset:
             ``"done"`` and an ``"asset"`` key containing the resulting
             `RemoteAsset`.
         """
-        from .files import dandi_file
+        from .files import LocalAsset, dandi_file
 
-        return dandi_file(filepath).iter_upload(
+        df = dandi_file(filepath)
+        if not isinstance(df, LocalAsset):
+            raise ValueError(f"{filepath}: not an asset file")
+        return df.iter_upload(
             self, metadata=asset_metadata, jobs=jobs, replacing=replace_asset
         )
 
@@ -1147,7 +1156,7 @@ class BaseRemoteAsset(APIBase):
     #: instead of performing an API call
     _metadata: Optional[Dict[str, Any]] = PrivateAttr(default_factory=None)
 
-    def __init__(self, **data: Any) -> None:
+    def __init__(self, **data: Any) -> None:  # type: ignore[no-redef]
         super().__init__(**data)
         # Pydantic insists on not initializing any attributes that start with
         # underscores, so we have to do it ourselves.
@@ -1172,7 +1181,7 @@ class BaseRemoteAsset(APIBase):
             identifier=metadata["identifier"],
             path=metadata["path"],
             size=metadata["contentSize"],
-            _metadata=metadata,
+            _metadata=metadata,  # type: ignore[call-arg]
         )
 
     @property
@@ -1240,7 +1249,7 @@ class BaseRemoteAsset(APIBase):
             digest_type = digest_type.value
         metadata = self.get_raw_metadata()
         try:
-            return metadata["digest"][digest_type]
+            return cast(str, metadata["digest"][digest_type])
         except KeyError:
             raise NotFoundError(f"No {digest_type} digest found in metadata")
 
@@ -1277,6 +1286,7 @@ class BaseRemoteAsset(APIBase):
         If ``strip_query`` is true, any query parameters are removed from the
         final URL before returning it.
         """
+        url: str
         for url in self.get_raw_metadata().get("contentUrl", []):
             if re.search(regex, url):
                 break
@@ -1303,7 +1313,7 @@ class BaseRemoteAsset(APIBase):
 
     def get_download_file_iter(
         self, chunk_size: int = MAX_CHUNK_SIZE
-    ) -> Callable[..., Iterator[bytes]]:
+    ) -> Callable[[int], Iterator[bytes]]:
         """
         Returns a function that when called (optionally with an offset into the
         asset to start downloading at) returns a generator of chunks of the
@@ -1346,7 +1356,7 @@ class BaseRemoteAsset(APIBase):
         """
         downloader = self.get_download_file_iter(chunk_size=chunk_size)
         with open(filepath, "wb") as fp:
-            for chunk in downloader():
+            for chunk in downloader(0):
                 fp.write(chunk)
 
     @property
@@ -1413,6 +1423,7 @@ class RemoteAsset(ABC, BaseRemoteAsset):
         This is a low-level method that non-developers would normally only use
         when acquiring data using means outside of this library.
         """
+        klass: Type[RemoteAsset]
         if data.get("blob") is not None:
             klass = RemoteBlobAsset
             if data.pop("zarr", None) is not None:
@@ -1428,7 +1439,7 @@ class RemoteAsset(ABC, BaseRemoteAsset):
             dandiset_id=dandiset.identifier,
             version_id=dandiset.version_id,
             **data,
-            _metadata=metadata,
+            _metadata=metadata,  # type: ignore[call-arg]
         )
 
     @property
@@ -1589,12 +1600,12 @@ class ZarrListing(BaseModel):
     @property
     def dirnames(self) -> List[str]:
         """The basenames of the directory URLs in `directories`"""
-        return [PurePosixPath(unquote(url.path)).name for url in self.directories]
+        return [PurePosixPath(unquote(url.path or "")).name for url in self.directories]
 
     @property
     def filenames(self) -> List[str]:
         """The basenames of the file URLs in `files`"""
-        return [PurePosixPath(unquote(url.path)).name for url in self.files]
+        return [PurePosixPath(unquote(url.path or "")).name for url in self.files]
 
 
 @dataclass
@@ -1794,7 +1805,7 @@ class RemoteZarrEntry(BasePath):
 
     def get_download_file_iter(
         self, chunk_size: int = MAX_CHUNK_SIZE
-    ) -> Callable[..., Iterator[bytes]]:
+    ) -> Callable[[int], Iterator[bytes]]:
         """
         Returns a function that when called (optionally with an offset into the
         file to start downloading at) returns a generator of chunks of the file

--- a/dandi/metadata.py
+++ b/dandi/metadata.py
@@ -2,8 +2,9 @@ from datetime import datetime
 from functools import lru_cache
 import os
 import os.path as op
+from pathlib import Path
 import re
-from typing import Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Union
 from uuid import uuid4
 from xml.dom.minidom import parseString
 
@@ -389,7 +390,9 @@ species_map = [
     stop=tenacity.stop_after_attempt(3),
     wait=tenacity.wait_exponential(exp_base=1.25, multiplier=1.25),
 )
-def parse_purlobourl(url: str, lookup: Optional[Tuple[str, ...]] = None):
+def parse_purlobourl(
+    url: str, lookup: Optional[Tuple[str, ...]] = None
+) -> Optional[Dict[str, str]]:
     """Parse an Ontobee URL to return properties of a Class node
 
     :param url: Ontobee URL
@@ -527,14 +530,14 @@ extract_wasAttributedTo = extract_model_list(
 )
 
 
-def extract_session(metadata: dict) -> list:
+def extract_session(metadata: dict) -> Optional[List[models.Session]]:
     probe_ids = metadata.get("probe_ids", [])
     if isinstance(probe_ids, str):
         probe_ids = [probe_ids]
-    probes = []
-    for val in probe_ids:
-        probes.append(models.Equipment(identifier=f"probe:{val}", name="Ecephys Probe"))
-    probes = probes or None
+    probes = [
+        models.Equipment(identifier=f"probe:{val}", name="Ecephys Probe")
+        for val in probe_ids
+    ] or None
     session_id = None
     if metadata.get("session_id") is not None:
         session_id = str(metadata["session_id"])
@@ -789,7 +792,9 @@ def process_ndtypes(asset, nd_types):
 
 
 def nwb2asset(
-    nwb_path, digest: Optional[Digest] = None, schema_version=None
+    nwb_path: Union[str, Path],
+    digest: Optional[Digest] = None,
+    schema_version: Optional[str] = None,
 ) -> models.BareAsset:
     if schema_version is not None:
         current_version = models.get_schema_version()
@@ -806,7 +811,7 @@ def nwb2asset(
     metadata["encodingFormat"] = "application/x-nwb"
     metadata["dateModified"] = get_utcnow_datetime()
     metadata["blobDateModified"] = ensure_datetime(os.stat(nwb_path).st_mtime)
-    metadata["path"] = nwb_path
+    metadata["path"] = str(nwb_path)
     if metadata["blobDateModified"] > metadata["dateModified"]:
         lgr.warning(
             "mtime %s of %s is in the future", metadata["blobDateModified"], nwb_path
@@ -820,7 +825,9 @@ def nwb2asset(
     return asset
 
 
-def get_default_metadata(path, digest: Optional[Digest] = None) -> models.BareAsset:
+def get_default_metadata(
+    path: Union[str, Path], digest: Optional[Digest] = None
+) -> models.BareAsset:
     start_time = datetime.now().astimezone()
     if digest is not None:
         digest_model = digest.asdict()
@@ -837,7 +844,7 @@ def get_default_metadata(path, digest: Optional[Digest] = None) -> models.BareAs
         dateModified=dateModified,
         blobDateModified=blobDateModified,
         wasGeneratedBy=[get_generator(start_time, end_time)],
-        encodingFormat=get_mime_type(path),
+        encodingFormat=get_mime_type(str(path)),
     )
 
 

--- a/dandi/misctypes.py
+++ b/dandi/misctypes.py
@@ -55,7 +55,7 @@ DUMMY_DIGEST = Digest(algorithm=DigestType.dandi_etag, value=32 * "d" + "-1")
 P = TypeVar("P", bound="BasePath")
 
 
-@dataclass
+@dataclass  # type: ignore[misc]  # <https://github.com/python/mypy/issues/5374>
 class BasePath(ABC):
     """
     An abstract base class for path-like objects that can be traversed with the

--- a/dandi/tests/fixtures.py
+++ b/dandi/tests/fixtures.py
@@ -8,7 +8,7 @@ import shutil
 from subprocess import DEVNULL, check_output, run
 import tempfile
 from time import sleep
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
 from click.testing import CliRunner
@@ -255,7 +255,9 @@ class DandiAPI:
 
     @property
     def api_url(self) -> str:
-        return self.instance.api
+        url = self.instance.api
+        assert isinstance(url, str)
+        return url
 
 
 @pytest.fixture(scope="session")
@@ -284,7 +286,7 @@ class SampleDandiset:
     def client(self) -> DandiAPIClient:
         return self.api.client
 
-    def upload(self, paths=None, **kwargs) -> None:
+    def upload(self, paths: Optional[List[str]] = None, **kwargs: Any) -> None:
         with pytest.MonkeyPatch().context() as m:
             m.setenv("DANDI_API_KEY", self.api.api_key)
             upload(
@@ -364,3 +366,4 @@ def tmp_home(
     monkeypatch.delenv("XDG_STATE_HOME", raising=False)
     monkeypatch.setenv("USERPROFILE", str(home))
     monkeypatch.setenv("LOCALAPPDATA", str(home))
+    return home

--- a/dandi/tests/test_download.py
+++ b/dandi/tests/test_download.py
@@ -649,7 +649,7 @@ def test_progress_combiner(
     file_qty: int, inputs: List[Tuple[str, dict]], expected: List[dict]
 ) -> None:
     pc = ProgressCombiner(zarr_size=69105, file_qty=file_qty)
-    outputs = []
+    outputs: List[dict] = []
     for path, status in inputs:
         outputs.extend(pc.feed(path, status))
     assert outputs == expected

--- a/dandi/utils.py
+++ b/dandi/utils.py
@@ -328,7 +328,7 @@ def list_paths(dirpath: Union[str, Path], dirs: bool = False) -> List[Path]:
     return sorted(map(Path, find_files(r".*", [dirpath], dirs=dirs)))
 
 
-_cp_supports_reflink = None
+_cp_supports_reflink: Optional[bool] = None
 
 
 def copy_file(src, dst):
@@ -598,14 +598,16 @@ def get_module_version(module: Union[str, types.ModuleType]) -> Optional[str]:
     -------
     object
     """
+    modobj: Optional[types.ModuleType]
     if isinstance(module, str):
+        modobj = sys.modules.get(module)
         mod_name = module
-        module = sys.modules.get(module)
     else:
+        modobj = module
         mod_name = module.__name__.split(".", 1)[0]
 
-    if module is not None:
-        version = getattr(module, "__version__", None)
+    if modobj is not None:
+        version = getattr(modobj, "__version__", None)
     else:
         version = None
     if version is None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -126,3 +126,34 @@ parentdir_prefix =
 skip = dandi/_version.py,dandi/due.py,versioneer.py
 # Don't warn about "[l]ist" in the abbrev_prompt() docstring:
 ignore-regex = \[\w\]\w+
+
+[mypy]
+# TODO: Eventually uncomment these:
+#allow_untyped_defs = False
+#implicit_reexport = False
+allow_incomplete_defs = False
+ignore_missing_imports = True
+no_implicit_optional = True
+local_partial_types = True
+pretty = True
+show_error_codes = True
+show_traceback = True
+strict_equality = True
+warn_redundant_casts = True
+warn_return_any = True
+warn_unreachable = True
+plugins = pydantic.mypy
+exclude = _version\.py|due\.py
+
+[mypy-dandi._version]
+follow_imports = skip
+
+[mypy-dandi.due]
+follow_imports = skip
+
+[mypy-ruamel.yaml]
+implicit_reexport = True
+
+[pydantic-mypy]
+init_forbid_extra = True
+warn_untypes_fields = True

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,py3
+envlist = lint,typing,py3
 
 [testenv]
 setenv =
@@ -22,6 +22,15 @@ deps =
 commands =
     codespell dandi setup.py
     flake8 --config=setup.cfg {posargs} dandi setup.py
+
+[testenv:typing]
+deps =
+    mypy~=0.900
+    types-appdirs
+    types-python-dateutil
+    types-requests
+commands =
+    mypy dandi
 
 [testenv:docs]
 basepython = python3


### PR DESCRIPTION
This PR adds a tox testenv and CI action for type-checking the code with mypy.  Note that much of the code base still does not have type annotations, which mypy is fine with; the plan is to annotate everything piecemeal so as not to end up with a massive PR that would likely create merge conflicts with everything else.