### PR TITLE
Delete functions (get_asset_metadata, find_dandi_files) obsoleted by PR #853

### DIFF
--- a/dandi/metadata.py
+++ b/dandi/metadata.py
@@ -788,28 +788,6 @@ def process_ndtypes(asset, nd_types):
     return asset
 
 
-def get_asset_metadata(
-    filepath, relpath, digest: Optional[Digest] = None, allow_any_path=True
-) -> models.BareAsset:
-    metadata = None
-    if op.splitext(filepath)[1] == ".nwb":
-        try:
-            metadata = nwb2asset(filepath, digest=digest)
-        except Exception as e:
-            lgr.warning(
-                "Failed to extract NWB metadata from %s: %s: %s",
-                filepath,
-                type(e).__name__,
-                str(e),
-            )
-            if not allow_any_path:
-                raise
-    if metadata is None:
-        metadata = get_default_metadata(filepath, digest=digest)
-    metadata.path = str(relpath)
-    return metadata
-
-
 def nwb2asset(
     nwb_path, digest: Optional[Digest] = None, schema_version=None
 ) -> models.BareAsset:

--- a/dandi/utils.py
+++ b/dandi/utils.py
@@ -357,12 +357,6 @@ def move_file(src, dst):
     return shutil.move(src, dst)
 
 
-def find_dandi_files(paths):
-    """Adapter to find_files to find files of interest to dandi project"""
-    sep = re.escape(os.sep)
-    yield from find_files(rf"((^|{sep})dandiset\.yaml|\.nwb)\Z", paths)
-
-
 def find_parent_directory_containing(filename, path=None):
     """Find a directory, on the path to 'path' containing filename
 


### PR DESCRIPTION
* `get_asset_metadata()` in `metadata.py` has been replaced by the `get_metadata()` methods of the `LocalAsset` class hierarchy in `files.py`
* `find_dandi_files()` in `util.py` has been replaced by `find_dandi_files()` in `files.py`