### PR TITLE
Organize & fine-tune dandi.dandiapi Sphinx docs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,14 +80,18 @@ jobs:
         pip install git+https://github.com/NeurodataWithoutBorders/pynwb
 
     - name: Run all tests
-      if: matrix.mode != 'dandi-api' && github.event_name != 'schedule'
+      if: matrix.mode != 'dandi-api'
       run: |
         python -m pytest -s -v --cov=dandi --cov-report=xml dandi
 
-    - name: Run all tests (including doctests)
+    - name: Smoke test example code in docs
       if: matrix.mode != 'dandi-api' && github.event_name == 'schedule'
       run: |
-        python -m pytest -s -v --cov=dandi --cov-report=xml --doctest-modules dandi
+        set -ex
+        cd docs/source/examples
+        for f in *.py
+        do python "$f"
+        done
 
     - name: Run Dandi API tests only
       if: matrix.mode == 'dandi-api'

--- a/dandi/dandiapi.py
+++ b/dandi/dandiapi.py
@@ -1,49 +1,3 @@
-"""
-This module provides functionality for interacting with a Dandi Archive server
-via the REST API.  Interaction begins with the creation of a `DandiAPIClient`
-instance, which can be used to retrieve `RemoteDandiset` objects (representing
-Dandisets on the server) and `BaseRemoteAsset` objects (representing assets
-without any data associating them with their Dandisets).  `RemoteDandiset`
-objects can, in turn, be used to retrieve `RemoteAsset` objects (representing
-assets associated with Dandisets).  Aside from `DandiAPIClient`, none of these
-classes should be instantiated directly by the user.
-
-All operations that merely fetch data from the server can be done without
-authenticating, but any operation that writes, uploads, modifies, or deletes
-data requires the user to authenticate the `DandiAPIClient` instance by
-supplying an API key either when creating the instance or by calling the
-`~DandiAPIClient.authenticate()` or `~DandiAPIClient.dandi_authenticate()`
-method.
-
-Example code for printing the metadata of all assets with "two-photon" in their
-``metadata.measurementTechnique[].name`` for the latest published version of
-every Dandiset:
-
->>> import json
->>> from pathlib import Path
->>> from dandi.dandiapi import DandiAPIClient
->>> with DandiAPIClient.for_dandi_instance("dandi") as client:
-...     for dandiset in client.get_dandisets():
-...         if dandiset.most_recent_published_version is None:
-...             continue
-...         latest_dandiset = dandiset.for_version(
-...             dandiset.most_recent_published_version
-...         )
-...         for asset in latest_dandiset.get_assets():
-...             metadata = asset.get_metadata()
-...             if any(
-...                 mtt is not None and "two-photon" in mtt.name
-...                 for mtt in (metadata.measurementTechnique or [])
-...             ):
-...                 print(json.dumps(metadata.json_dict(), indent=4))
-...                 # Uncomment to also download the asset:
-...                 # asset.download(Path(dandiset.identifier, asset.path))
-...
-{
-    ...
-}
-"""
-
 from abc import ABC, abstractmethod
 from collections import deque
 from dataclasses import dataclass, field, replace
@@ -418,9 +372,9 @@ class DandiAPIClient(RESTFullAPIClient):
         `DandiAPIClient`.  If the :envvar:`DANDI_API_KEY` environment variable
         is set, its value is used as the token.  Otherwise, the token is looked
         up in the user's keyring under the service
-        "``dandi-api-INSTANCE_NAME``" [#auth]_ and username "``key``".  If no
-        token is found there, the user is prompted for the token, and, if it
-        proves to be valid, it is stored in the user's keyring.
+        ":samp:`dandi-api-{INSTANCE_NAME}`" [#auth]_ and username "``key``".
+        If no token is found there, the user is prompted for the token, and, if
+        it proves to be valid, it is stored in the user's keyring.
 
         .. [#auth] E.g., "``dandi-api-dandi``" for the production server or
                    "``dandi-api-dandi-staging``" for the staging server
@@ -850,9 +804,9 @@ class RemoteDandiset:
     def for_version(self, version_id: Union[str, Version]) -> "RemoteDandiset":
         """
         Returns a copy of the `RemoteDandiset` with the `version` attribute set
-        to given `Version` object or the `Version` with the given version ID.
-        If a version ID given and the version does not exist, a `NotFoundError`
-        is raised.
+        to the given `Version` object or the `Version` with the given version
+        ID.  If a version ID given and the version does not exist, a
+        `NotFoundError` is raised.
         """
         if isinstance(version_id, str):
             version_id = self.get_version(version_id)

--- a/docs/source/examples/dandiapi-example.py
+++ b/docs/source/examples/dandiapi-example.py
@@ -1,0 +1,18 @@
+import json
+
+from dandi.dandiapi import DandiAPIClient
+
+with DandiAPIClient.for_dandi_instance("dandi") as client:
+    for dandiset in client.get_dandisets():
+        if dandiset.most_recent_published_version is None:
+            continue
+        latest_dandiset = dandiset.for_version(dandiset.most_recent_published_version)
+        for asset in latest_dandiset.get_assets():
+            metadata = asset.get_metadata()
+            if any(
+                mtt is not None and "two-photon" in mtt.name
+                for mtt in (metadata.measurementTechnique or [])
+            ):
+                print(json.dumps(metadata.json_dict(), indent=4))
+                # Can be used to also download the asset:
+                # asset.download(pathlib.Path(dandiset.identifier, asset.path))

--- a/docs/source/modref/dandiapi.rst
+++ b/docs/source/modref/dandiapi.rst
@@ -1,8 +1,75 @@
+.. module:: dandi.dandiapi
+
 ``dandi.dandiapi``
 ==================
 
-.. automodule:: dandi.dandiapi
+This module provides functionality for interacting with a Dandi Archive server
+via the REST API.  Interaction begins with the creation of a `DandiAPIClient`
+instance, which can be used to retrieve `RemoteDandiset` objects (representing
+Dandisets on the server) and `BaseRemoteAsset` objects (representing assets
+without any data associating them with their Dandisets).  `RemoteDandiset`
+objects can, in turn, be used to retrieve `RemoteAsset` objects (representing
+assets associated with Dandisets).  Aside from `DandiAPIClient`, none of these
+classes should be instantiated directly by the user.
 
-    .. TODO: Once <https://github.com/sphinx-doc/sphinx/issues/9709> is fixed,
-       set `:members:` to all classes other than APIBase (which is an
-       implementation detail)
+All operations that merely fetch data from the server can be done without
+authenticating, but any operation that writes, uploads, modifies, or deletes
+data requires the user to authenticate the `DandiAPIClient` instance by
+supplying an API key either when creating the instance or by calling the
+`~DandiAPIClient.authenticate()` or `~DandiAPIClient.dandi_authenticate()`
+method.
+
+Example code for printing the metadata of all assets with "two-photon" in their
+``metadata.measurementTechnique[].name`` for the latest published version of
+every Dandiset:
+
+.. literalinclude:: /examples/dandiapi-example.py
+    :language: python
+
+Client
+------
+
+.. autoclass:: RESTFullAPIClient
+
+.. autoclass:: DandiAPIClient
+    :show-inheritance:
+
+Dandisets
+---------
+
+.. autoclass:: RemoteDandiset()
+
+.. autoclass:: Version()
+    :inherited-members: BaseModel
+    :exclude-members: Config, JSON_EXCLUDE
+
+Assets
+------
+
+.. autoclass:: BaseRemoteAsset()
+    :inherited-members: BaseModel
+    :exclude-members: Config, JSON_EXCLUDE
+
+.. autoclass:: AssetType
+
+.. autoclass:: RemoteAsset()
+    :show-inheritance:
+    :exclude-members: JSON_EXCLUDE
+
+.. autoclass:: RemoteBlobAsset()
+    :show-inheritance:
+
+Zarr Assets
+^^^^^^^^^^^
+
+.. autoclass:: RemoteZarrAsset()
+    :show-inheritance:
+
+.. autoclass:: RemoteZarrEntry()
+    :show-inheritance:
+
+.. autoclass:: ZarrListing()
+
+.. autoclass:: ZarrEntryStat()
+
+.. Excluded from documentation: APIBase, RemoteDandisetData

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,6 @@ commands = sphinx-build -E -W -b html source build
 
 [pytest]
 addopts = --tb=short --durations=10
-doctest_optionflags = ELLIPSIS
 markers =
     integration
     redirector


### PR DESCRIPTION
This PR eliminates the use of `.. automodule:: dandi.dandiapi` to document `dandi/dandiapi.py` in favor of listing the classes explicitly with `autoclass::`.  This makes the following possible:

* Internal, implementation-defined classes (i.e., `APIBase` and `RemoteDandisetData`) can be excluded from the documentation
* The order in which the classes are listed can be controlled, and headers can be added to the listing
* Classes that are not meant for public construction can have their `__init__` signatures suppressed

The one downside (aside from now having to list classes manually) is that the `dandiapi.py` module docstring is now unused; this PR moves it to the reStructuredText document and stores the code example in an included external file so that the testing of the example via doctests can be replaced with a `python $filename` smoke test.