### PR TITLE
Pin minio image version

### DIFF
--- a/dandi/tests/data/dandiarchive-docker/docker-compose.yml
+++ b/dandi/tests/data/dandiarchive-docker/docker-compose.yml
@@ -86,7 +86,7 @@ services:
       DANDI_ALLOW_LOCALHOST_URLS: "1"
 
   minio:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2022-01-28T02-28-16Z
     # When run with a TTY, minio prints credentials on startup
     tty: true
     command: ["server", "/data"]


### PR DESCRIPTION
Due to [this](https://github.com/minio/minio/issues/14235) bug in a recent minio release (filed by our very own @waxlamp), the cli integration tests in dandi-archive are failing, due to the containers not coming up correctly ([example](https://github.com/dandi/dandi-archive/runs/5057988507?check_suite_focus=true)). This change would pin the image version to the last known working version. This change can be reverted once the bug fix is released.