### PR TITLE
Update minimum pydantic version to 1.9.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ install_requires =
     keyrings.alt
     packaging
     pycryptodomex  # for EncryptedKeyring backend in keyrings.alt
-    pydantic >= 1.8.1
+    pydantic >= 1.9.0
     pynwb >= 1.0.3,!=1.1.0
     pyout >=0.5, !=0.6.0
     python-dateutil


### PR DESCRIPTION
It turns out that the use of multiple inheritance with a `PrivateAttr` by the remote asset classes only works in pydantic 1.9.0+.