### PR TITLE
Add dedicated HTTP404Error exception class

### DIFF
--- a/dandi/exceptions.py
+++ b/dandi/exceptions.py
@@ -1,5 +1,6 @@
 from typing import List
 
+import requests
 from semantic_version import Version
 
 
@@ -74,4 +75,8 @@ class SchemaVersionError(Exception):
 
 
 class UnknownAssetError(ValueError):
+    pass
+
+
+class HTTP404Error(requests.HTTPError):
     pass


### PR DESCRIPTION
This cuts down on a lot of simple repetition by adding a dedicated `HTTP404Error` exception class subclassing `requests.HTTPError` that is used specifically for 404 errors.