### PR TITLE
Remove unused tqdm dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,6 @@ install_requires =
     ruamel.yaml >=0.15, <1
     semantic-version
     tenacity
-    tqdm
     zarr ~= 2.10
 zip_safe = False
 packages = find:


### PR DESCRIPTION
The only place tqdm is currently "used" is in a commented-out line in `dandi/organize.py`.