### PR TITLE
Use full asset path as name of Zarr object

### DIFF
--- a/dandi/files.py
+++ b/dandi/files.py
@@ -798,7 +798,7 @@ class ZarrAsset(LocalDirectoryAsset[LocalZarrEntry]):
         lgr.debug("%s: Beginning upload", asset_path)
         bytes_uploaded = 0
         r = client.post(
-            "/zarr/", json={"name": self.filepath.name, "dandiset": dandiset.identifier}
+            "/zarr/", json={"name": asset_path, "dandiset": dandiset.identifier}
         )
         zarr_id = r["zarr_id"]
         with RESTFullAPIClient(


### PR DESCRIPTION
See https://github.com/dandi/dandi-archive/pull/897#issuecomment-1041703701