### PR TITLE
Don't repeat API requests when finding subdir files to delete before Zarr upload

### DIFF
--- a/dandi/files.py
+++ b/dandi/files.py
@@ -866,11 +866,15 @@ class ZarrAsset(LocalDirectoryAsset[LocalZarrEntry]):
                         asset_path,
                         p,
                     )
-                    for ee in e.iterfiles():
-                        try:
-                            to_delete.append(old_zarr_entries.pop(str(ee)))
-                        except KeyError:
-                            pass
+                    eprefix = str(e) + "/"
+                    sub_e = [
+                        (k, v)
+                        for k, v in old_zarr_entries.items()
+                        if k.startswith(eprefix)
+                    ]
+                    for k, v in sub_e:
+                        old_zarr_entries.pop(k)
+                        to_delete.append(v)
                     to_upload.append(item)
                 elif pdigest != e.get_digest().value:
                     lgr.debug(


### PR DESCRIPTION
Before starting to upload a Zarr, the client compares the on-disk tree to the contents of the remote Zarr object being updated (if any).  Among other checks, if it finds a remote directory at the same path as a local file, it deletes the directory, which consists of deleting all of the files under it recursively.  Currently, the files are retrieved by making numerous queries to the API, but this PR changes the code to instead go through the already-fetched collection of remote files.