### PR TITLE
checking for duplicate video files in external_files

### DIFF
--- a/dandi/organize.py
+++ b/dandi/organize.py
@@ -886,7 +886,8 @@ def organize(
     if media_files_mode == "move":
         videos_list = []
         for meta in metadata:
-            videos_list.extend(meta["external_file_objects"].get("external_files", []))
+            for ext_ob in meta["external_file_objects"]:
+                videos_list.extend(ext_ob.get("external_files", []))
         if len(set(videos_list)) < len(videos_list):
             raise ValueError(
                 "multiple nwbfiles linked to one video file, "

--- a/dandi/organize.py
+++ b/dandi/organize.py
@@ -712,6 +712,13 @@ def detect_link_type(workdir):
             pass
 
 
+def _find_all_videos(metadata_list):
+    videos = []
+    for metadata in metadata_list:
+        videos.extend(metadata["external_file_objects"].get("external_files", []))
+    return videos
+
+
 def organize(
     paths,
     dandiset_path=None,
@@ -881,6 +888,17 @@ def organize(
         lgr.warning(
             "--media-files-mode not specified, setting to recommended mode: 'symlink' "
         )
+
+    # look for multiple nwbfiles linking to one video:
+    if media_files_mode == "move":
+        videos_list = []
+        for meta in metadata:
+            videos_list.extend(meta["external_file_objects"].get("external_files", []))
+        if len(set(videos_list)) < len(videos_list):
+            raise ValueError(
+                "multiple nwbfiles linked to one video file, "
+                "provide 'media_files_mode' as copy/symlink/hardlink"
+            )
 
     metadata = _create_external_file_names(metadata)
 

--- a/dandi/organize.py
+++ b/dandi/organize.py
@@ -712,13 +712,6 @@ def detect_link_type(workdir):
             pass
 
 
-def _find_all_videos(metadata_list):
-    videos = []
-    for metadata in metadata_list:
-        videos.extend(metadata["external_file_objects"].get("external_files", []))
-    return videos
-
-
 def organize(
     paths,
     dandiset_path=None,

--- a/dandi/tests/fixtures.py
+++ b/dandi/tests/fixtures.py
@@ -395,7 +395,7 @@ def zarr_dandiset(new_dandiset: SampleDandiset) -> SampleDandiset:
 
 
 @pytest.fixture()
-def video_nwbfiles(tmp_path):
+def video_files(tmp_path):
     video_paths = []
     import cv2
 
@@ -427,10 +427,14 @@ def video_nwbfiles(tmp_path):
         writer1.release()
         writer2.release()
         video_paths.append((movie_file1, movie_file2))
-    base_nwb_path = tmp_path / "nwbfiles"
-    base_nwb_path.mkdir(parents=True, exist_ok=True)
+        return video_paths
 
-    for no, vid_loc in enumerate(video_paths):
+
+def _create_nwb_files(video_list):
+    base_path = video_list[0][0].parent.parent
+    base_nwb_path = base_path / "nwbfiles"
+    base_nwb_path.mkdir(parents=True, exist_ok=True)
+    for no, vid_loc in enumerate(video_list):
         vid_1 = vid_loc[0]
         vid_2 = vid_loc[1]
         subject_id = f"mouse{no}"
@@ -467,6 +471,19 @@ def video_nwbfiles(tmp_path):
         with NWBHDF5IO(str(nwbfile_path), "w") as io:
             io.write(nwbfile)
     return base_nwb_path
+
+
+@pytest.fixture()
+def nwbfiles_video_unique(video_files):
+    """Create nwbfiles linked with unique set of videos."""
+    return _create_nwb_files(video_files)
+
+
+@pytest.fixture()
+def nwbfiles_video_common(video_files):
+    """Create nwbfiles sharing video files."""
+    video_list = [video_files[0], video_files[0]]
+    return _create_nwb_files(video_list)
 
 
 @pytest.fixture()

--- a/dandi/tests/fixtures.py
+++ b/dandi/tests/fixtures.py
@@ -427,7 +427,7 @@ def video_files(tmp_path):
         writer1.release()
         writer2.release()
         video_paths.append((movie_file1, movie_file2))
-        return video_paths
+    return video_paths
 
 
 def _create_nwb_files(video_list):

--- a/dandi/tests/test_organize.py
+++ b/dandi/tests/test_organize.py
@@ -261,8 +261,8 @@ def test_detect_link_type(
 
 @pytest.mark.parametrize("mode", ["copy", "move"])
 @pytest.mark.parametrize("video_mode", ["copy", "move", "symlink", "hardlink"])
-def test_video_organize(video_mode, mode, video_nwbfiles):
-    dandi_organize_path = video_nwbfiles.parent / "dandi_organized"
+def test_video_organize(video_mode, mode, nwbfiles_video_unique):
+    dandi_organize_path = nwbfiles_video_unique.parent / "dandi_organized"
     cmd = [
         "--files-mode",
         mode,
@@ -271,9 +271,9 @@ def test_video_organize(video_mode, mode, video_nwbfiles):
         video_mode,
         "-d",
         str(dandi_organize_path),
-        str(video_nwbfiles),
+        str(nwbfiles_video_unique),
     ]
-    video_files_list = list((video_nwbfiles.parent / "video_files").iterdir())
+    video_files_list = list((nwbfiles_video_unique.parent / "video_files").iterdir())
     video_files_organized = []
     r = CliRunner().invoke(organize, cmd)
     assert r.exit_code == 0
@@ -296,3 +296,25 @@ def test_video_organize(video_mode, mode, video_nwbfiles):
                     assert (vid_folder.parent / name).exists()
     # check all video files are organized:
     assert len(video_files_list) == len(video_files_organized)
+
+
+@pytest.mark.parametrize("video_mode", ["copy", "move"])
+def test_video_organize_common(video_mode, nwbfiles_video_common):
+    dandi_organize_path = nwbfiles_video_common.parent / "dandi_organized"
+    cmd = [
+        "--files-mode",
+        "move",
+        "--update-external-file-paths",
+        "--media-files-mode",
+        video_mode,
+        "-d",
+        str(dandi_organize_path),
+        str(nwbfiles_video_common),
+    ]
+    r = CliRunner().invoke(organize, cmd)
+    if video_mode == "move":
+        assert r.exit_code == 1
+        print(r.exception)
+    else:
+        assert r.exit_code == 0
+        print(r.stdout)


### PR DESCRIPTION
If there happen to be multiple nwb files linked to one video file via the `ImageSeries.external_files`, the `move` option of `video_mode` will fail. This PR enforces the user to change the option to one of `copy/symlink/hardlink' instead by raising an Exception. 
