### PR TITLE
skip handling URLs in external files references as we do for local paths

### DIFF
--- a/dandi/organize.py
+++ b/dandi/organize.py
@@ -254,6 +254,8 @@ def organize_external_files(
                     ext_file_dict["external_files_renamed"],
                 )
             ):
+                if any([str(name_old).startswith(i) for i in ["http", "ftp"]]):
+                    continue
                 new_path = op.join(dandiset_path, op.dirname(e["dandi_path"]), name_new)
                 name_old_str = str(name_old)
                 os.makedirs(op.dirname(new_path), exist_ok=True)

--- a/dandi/organize.py
+++ b/dandi/organize.py
@@ -255,7 +255,7 @@ def organize_external_files(
                     ext_file_dict["external_files_renamed"],
                 )
             ):
-                if is_url(name_old):
+                if is_url(str(name_old)):
                     continue
                 new_path = op.join(dandiset_path, op.dirname(e["dandi_path"]), name_new)
                 name_old_str = str(name_old)

--- a/dandi/organize.py
+++ b/dandi/organize.py
@@ -31,6 +31,7 @@ from .utils import (
     ensure_datetime,
     find_files,
     flattened,
+    is_url,
     load_jsonl,
     move_file,
     yaml_load,
@@ -254,7 +255,7 @@ def organize_external_files(
                     ext_file_dict["external_files_renamed"],
                 )
             ):
-                if any([str(name_old).startswith(i) for i in ["http", "ftp"]]):
+                if is_url(name_old):
                     continue
                 new_path = op.join(dandiset_path, op.dirname(e["dandi_path"]), name_new)
                 name_old_str = str(name_old)

--- a/dandi/pynwb_utils.py
+++ b/dandi/pynwb_utils.py
@@ -315,7 +315,8 @@ def rename_nwb_external_files(metadata: List[dict], dandiset_path: str) -> None:
                         ext_file_dict["external_files_renamed"],
                     )
                 ):
-                    container.external_file[no] = str(name_new)
+                    if not any([str(name_old).startswith(i) for i in ["http", "ftp"]]):
+                        container.external_file[no] = str(name_new)
 
 
 @validate_cache.memoize_path

--- a/dandi/pynwb_utils.py
+++ b/dandi/pynwb_utils.py
@@ -23,7 +23,7 @@ from .consts import (
     metadata_nwb_file_fields,
     metadata_nwb_subject_fields,
 )
-from .utils import get_module_version
+from .utils import get_module_version, is_url
 
 lgr = get_logger()
 
@@ -315,7 +315,7 @@ def rename_nwb_external_files(metadata: List[dict], dandiset_path: str) -> None:
                         ext_file_dict["external_files_renamed"],
                     )
                 ):
-                    if not any([str(name_old).startswith(i) for i in ["http", "ftp"]]):
+                    if not is_url(str(name_old)):
                         container.external_file[no] = str(name_new)
 
 

--- a/dandi/utils.py
+++ b/dandi/utils.py
@@ -614,7 +614,7 @@ def is_url(s: str) -> bool:
 
     TODO: redo
     """
-    return s.lower().startswith(("http://", "https://", "dandi:"))
+    return s.lower().startswith(("http://", "https://", "dandi:", "ftp://"))
     # Slashes are not required after "dandi:" so as to support "DANDI:<id>"
 
 


### PR DESCRIPTION
if the external_files contain weblinks to media files, skip re-writing that attribute and do not do any copy/move operation. 