### PR TITLE
Update for change in Zarr checksum format

### DIFF
--- a/dandi/cli/tests/test_digest.py
+++ b/dandi/cli/tests/test_digest.py
@@ -51,4 +51,4 @@ def test_digest_zarr():
         )
         r = runner.invoke(digest, ["--digest", "zarr-checksum", "sample.zarr"])
         assert r.exit_code == 0
-        assert r.output == "sample.zarr: ebe3432f7ff77791877fa9eac0452831\n"
+        assert r.output == "sample.zarr: 4313ab36412db2981c3ed391b38604d6-5--1516\n"

--- a/dandi/files.py
+++ b/dandi/files.py
@@ -635,9 +635,7 @@ class LocalZarrEntry(BasePath):
         it is a file, it will be MD5.
         """
         if self.is_dir():
-            return Digest.dandi_zarr(
-                get_zarr_checksum(self.filepath, basepath=self.zarr_basepath)
-            )
+            return Digest.dandi_zarr(get_zarr_checksum(self.filepath))
         else:
             return Digest(
                 algorithm=DigestType.md5, value=get_digest(self.filepath, "md5")
@@ -700,11 +698,11 @@ class ZarrAsset(LocalDirectoryAsset[LocalZarrEntry]):
                 if p.is_dir():
                     st = dirstat(p)
                     size += st.size
-                    dir_md5s[str(p)] = st.digest.value
+                    dir_md5s[str(p)] = (st.digest.value, st.size)
                     files.extend(st.files)
                 else:
                     size += p.size
-                    file_md5s[str(p)] = md5file_nocache(p.filepath)
+                    file_md5s[str(p)] = (md5file_nocache(p.filepath), p.size)
                     files.append(p)
             return ZarrStat(
                 size=size,

--- a/dandi/support/tests/test_digests.py
+++ b/dandi/support/tests/test_digests.py
@@ -76,8 +76,8 @@ def test_get_zarr_checksum(mocker: MockerFixture, tmp_path: Path) -> None:
     assert (
         get_zarr_checksum(tmp_path / "file1.txt") == "d0aa42f003e36c1ecaf9aa8f20b6f1ad"
     )
-    assert get_zarr_checksum(tmp_path) == "e432031edb56d48fa9d9b205689db55e"
-    assert get_zarr_checksum(sub1) == "4cc960e6c5a46e4dae426124ec2f65c6"
+    assert get_zarr_checksum(tmp_path) == "25627e0fc7c609d10100d020f7782a25-8--197"
+    assert get_zarr_checksum(sub1) == "64af93ad7f8d471c00044d1ddbd4c0ba-4--97"
 
     with pytest.raises(ValueError) as excinfo:
         get_zarr_checksum(empty)
@@ -101,6 +101,6 @@ def test_get_zarr_checksum(mocker: MockerFixture, tmp_path: Path) -> None:
                 # ^^ Not used in calculation!
             },
         )
-        == "f67518b9092633027105f9aa9de9259f"
+        == "f77f4c5b277575f781c19ba91422f0c5-8--197"
     )
     spy.assert_called_once_with(sub2 / "file7.txt")

--- a/dandi/support/tests/test_digests.py
+++ b/dandi/support/tests/test_digests.py
@@ -77,12 +77,10 @@ def test_get_zarr_checksum(mocker: MockerFixture, tmp_path: Path) -> None:
         get_zarr_checksum(tmp_path / "file1.txt") == "d0aa42f003e36c1ecaf9aa8f20b6f1ad"
     )
     assert get_zarr_checksum(tmp_path) == "e432031edb56d48fa9d9b205689db55e"
-    assert (
-        get_zarr_checksum(sub1, basepath=tmp_path) == "4cc960e6c5a46e4dae426124ec2f65c6"
-    )
+    assert get_zarr_checksum(sub1) == "4cc960e6c5a46e4dae426124ec2f65c6"
 
     with pytest.raises(ValueError) as excinfo:
-        get_zarr_checksum(empty, basepath=tmp_path)
+        get_zarr_checksum(empty)
     assert str(excinfo.value) == "Cannot compute a Zarr checksum for an empty directory"
 
     spy = mocker.spy(digests, "md5file_nocache")

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     appdirs
     click
     click-didyoumean
-    dandischema ~= 0.5.1
+    dandischema ~= 0.6.0
     etelemetry >= 0.2.2
     fasteners
     fscacher


### PR DESCRIPTION
To accompany https://github.com/dandi/dandischema/pull/120

Cannot be tested until after dandischema 0.6.0 is released (and then further edits will be needed to update some test cases that hardcode checksums).