### PR TITLE
Integrate NWBInspector with DANDI validation

### DIFF
--- a/dandi/files.py
+++ b/dandi/files.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections import deque
-from collections.abc import Iterable
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from contextlib import closing
 from dataclasses import dataclass, field, replace
@@ -511,8 +510,8 @@ class NWBAsset(LocalFileAsset):
         self,
         schema_version: Optional[str] = None,
         devel_debug: bool = False,
-    ) -> Iterable:
-        errors = []
+    ) -> List[str]:
+        errors: List[str] = []
         if schema_version is not None:
             errors.extend(
                 super().get_validation_errors(
@@ -540,7 +539,7 @@ class NWBAsset(LocalFileAsset):
                     e,
                     extra={"validating": True},
                 )
-                errors.append(f"Failed to inspect NWBFile: {e}!")
+                errors.append(f"Failed to inspect NWBFile: {e}")
         return errors
 
 

--- a/dandi/files.py
+++ b/dandi/files.py
@@ -930,6 +930,7 @@ class ZarrAsset(LocalDirectoryAsset[LocalZarrEntry]):
             for local_entry in self.iterfiles():
                 total_size += local_entry.size
                 to_upload.register(local_entry)
+
         yield {"status": "initiating upload", "size": total_size}
         lgr.debug("%s: Beginning upload", asset_path)
         bytes_uploaded = 0

--- a/dandi/files.py
+++ b/dandi/files.py
@@ -42,9 +42,9 @@ from dandischema.models import BareAsset, CommonModel
 from dandischema.models import Dandiset as DandisetMeta
 from dandischema.models import DigestType, get_schema_version
 from pydantic import ValidationError
+from nwbinspector import inspect_nwb, check_subject_exists, check_subject_id_exists
 import requests
 import zarr
-import nwbinspector
 
 from . import get_logger
 from .consts import (
@@ -77,10 +77,7 @@ lgr = get_logger()
 
 # TODO -- should come from schema.  This is just a simplistic example for now
 _required_dandiset_metadata_fields = ["identifier", "name", "description"]
-_required_nwb_metadata_fields = [
-    nwbinspector.check_subject_exists,
-    nwbinspector.check_subject_id_exists,
-]
+_required_nwb_checks = [check_subject_exists, check_subject_id_exists]
 
 
 @dataclass  # type: ignore[misc]  # <https://github.com/python/mypy/issues/5374>
@@ -524,9 +521,9 @@ class NWBAsset(LocalFileAsset):
                 errors.extend(
                     [
                         error.message
-                        for error in nwbinspector.inspect_nwb(
+                        for error in inspect_nwb(
                             nwbfile_path=self.filepath,
-                            checks=_required_nwb_metadata_fields,
+                            checks=_required_nwb_checks,
                         )
                     ]
                 )

--- a/dandi/pynwb_utils.py
+++ b/dandi/pynwb_utils.py
@@ -47,6 +47,7 @@ validate_cache = PersistentCache(
 
 def _sanitize_nwb_version(v, filename=None, log=None):
     """Helper to sanitize the value of nwb_version where possible
+
     Would log a warning if something detected to be fishy"""
     msg = f"File {filename}: " if filename else ""
     msg += f"nwb_version {v!r}"
@@ -82,11 +83,13 @@ def _sanitize_nwb_version(v, filename=None, log=None):
 
 def get_nwb_version(filepath, sanitize=False):
     """Return a version of the NWB standard used by a file
+
     Parameters
     ----------
     sanitize: bool, optional
       Either to sanitize version and return it non-raw where we detect version
       which does not follow semantic but we possibly can handle
+
     Returns
     -------
     str or None
@@ -111,6 +114,7 @@ def get_nwb_version(filepath, sanitize=False):
 
 def get_neurodata_types_to_modalities_map() -> Dict[str, str]:
     """Return a dict to map neurodata types known to pynwb to "modalities"
+
     It is an ugly hack, largely to check feasibility.
     It would base modality on the filename within pynwb providing that neural
     data type
@@ -236,11 +240,14 @@ def _get_pynwb_metadata(path: Union[str, Path]) -> Dict[str, Any]:
 
 def _get_image_series(nwb: pynwb.NWBFile) -> List[dict]:
     """Retrieves all ImageSeries related metadata from an open nwb file.
+
     Specifically it pulls out the ImageSeries uuid, name and all the
     externally linked files named under the argument 'external_file'.
+
     Parameters
     ----------
     nwb: pynwb.NWBFile
+
     Returns
     -------
     out: List[dict]
@@ -269,8 +276,10 @@ def _get_image_series(nwb: pynwb.NWBFile) -> List[dict]:
 
 def rename_nwb_external_files(metadata: List[dict], dandiset_path: str) -> None:
     """Renames the external_file attribute in an ImageSeries datatype in an open nwb file.
+
     It pulls information about the ImageSeries objects from metadata:
     metadata["external_file_objects"] populated during _get_pynwb_metadata() call.
+
     Parameters
     ----------
     metadata: List[dict]
@@ -313,8 +322,10 @@ def rename_nwb_external_files(metadata: List[dict], dandiset_path: str) -> None:
 @validate_cache.memoize_path
 def validate(path: Union[str, Path], devel_debug: bool = False) -> List[str]:
     """Run validation on a file and return errors
+
     In case of an exception being thrown, an error message added to the
     returned list of validation errors
+
     Parameters
     ----------
     path: str or Path
@@ -393,6 +404,7 @@ def ignore_benign_pynwb_warnings() -> None:
 
 def get_object_id(path: Union[str, Path]) -> Any:
     """Read, if present an object_id
+
     if not available -- would simply raise a corresponding exception
     """
     with h5py.File(path, "r") as f:
@@ -406,6 +418,7 @@ def make_nwb_file(
     filename: StrPath, *args: Any, cache_spec: bool = False, **kwargs: Any
 ) -> StrPath:
     """A little helper to produce an .nwb file in the path using NWBFile
+
     Note: it doesn't cache_spec by default
     """
     nwbfile = pynwb.NWBFile(*args, **kwargs)
@@ -416,8 +429,10 @@ def make_nwb_file(
 
 def copy_nwb_file(src: Union[str, Path], dest: Union[str, Path]) -> str:
     """ "Copy" .nwb file by opening and saving into a new path.
+
     New file (`dest`) then should have new `object_id` attribute, and thus be
     considered "different" although containing the same data
+
     Parameters
     ----------
     src: str
@@ -426,9 +441,11 @@ def copy_nwb_file(src: Union[str, Path], dest: Union[str, Path]) -> str:
       Destination file or directory. If points to an existing directory, file with
       the same name is created (exception if already exists).  If not an
       existing directory - target directory is created.
+
     Returns
     -------
     dest
+
     """
     if op.isdir(dest):
         dest = op.join(dest, op.basename(src))

--- a/dandi/tests/fixtures.py
+++ b/dandi/tests/fixtures.py
@@ -96,6 +96,22 @@ def simple2_nwb(
 
 
 @pytest.fixture(scope="session")
+def simple3_nwb(
+    simple1_nwb_metadata: Dict[str, Any], tmpdir_factory: pytest.TempdirFactory
+) -> str:
+    """With a subject, but no subject_id."""
+    return make_nwb_file(
+        str(tmpdir_factory.mktemp("simple2").join("simple2.nwb")),
+        subject=pynwb.file.Subject(
+            date_of_birth=datetime(2016, 12, 1, tzinfo=tzutc()),
+            sex="M",
+            species="mouse",
+        ),
+        **simple1_nwb_metadata,
+    )
+
+
+@pytest.fixture(scope="session")
 def organized_nwb_dir(
     simple2_nwb: str, tmp_path_factory: pytest.TempPathFactory
 ) -> Path:
@@ -141,7 +157,6 @@ if TYPE_CHECKING:
         from typing import Literal
     else:
         from typing_extensions import Literal
-
     Scope = Union[
         Literal["session"],
         Literal["package"],
@@ -199,7 +214,6 @@ def docker_compose_setup() -> Iterator[Dict[str, str]]:
     # Docker images don't work on Windows.
     if os.name != "posix":
         pytest.skip("Docker images require Unix host")
-
     persist = os.environ.get("DANDI_TESTS_PERSIST_DOCKER_COMPOSE")
 
     create = (
@@ -239,7 +253,6 @@ def docker_compose_setup() -> Iterator[Dict[str, str]]:
                 env=env,
                 check=True,
             )
-
         r = check_output(
             [
                 "docker-compose",

--- a/dandi/tests/fixtures.py
+++ b/dandi/tests/fixtures.py
@@ -157,6 +157,7 @@ if TYPE_CHECKING:
         from typing import Literal
     else:
         from typing_extensions import Literal
+
     Scope = Union[
         Literal["session"],
         Literal["package"],
@@ -214,6 +215,7 @@ def docker_compose_setup() -> Iterator[Dict[str, str]]:
     # Docker images don't work on Windows.
     if os.name != "posix":
         pytest.skip("Docker images require Unix host")
+
     persist = os.environ.get("DANDI_TESTS_PERSIST_DOCKER_COMPOSE")
 
     create = (
@@ -253,6 +255,7 @@ def docker_compose_setup() -> Iterator[Dict[str, str]]:
                 env=env,
                 check=True,
             )
+
         r = check_output(
             [
                 "docker-compose",

--- a/dandi/tests/test_files.py
+++ b/dandi/tests/test_files.py
@@ -143,18 +143,6 @@ def test_validate_bogus(tmp_path):
     assert any(e.startswith("Failed to inspect NWBFile") for e in errors)
 
 
-# def test_validate_missing_subject(tmp_path):
-#     path = tmp_path / "missing_subject.nwb"
-#     make_minimal_nwbfile
-#     # intended to produce use-case for https://github.com/dandi/dandi-cli/issues/93
-#     # but it would be tricky, so it is more of a smoke test that
-#     # we do not crash
-#     errors = list(dandi_file(path).get_validation_errors())
-#     # ATM we would get 2 errors -- since could not be open in two places,
-#     # but that would be too rigid to test. Let's just see that we have expected errors
-#     assert any(e.startswith("Failed to read metadata") for e in errors)
-
-
 def test_upload_zarr(new_dandiset, tmp_path):
     filepath = tmp_path / "example.zarr"
     zarr.save(filepath, np.arange(1000), np.arange(1000, 0, -1))

--- a/dandi/tests/test_files.py
+++ b/dandi/tests/test_files.py
@@ -2,7 +2,6 @@ from operator import attrgetter
 from pathlib import Path
 
 from dandischema.models import get_schema_version
-from nwbinspector.tools import make_minimal_nwbfile
 import numpy as np
 import zarr
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,7 @@ install_requires =
     pycryptodomex  # for EncryptedKeyring backend in keyrings.alt
     pydantic >= 1.9.0
     pynwb >= 1.0.3,!=1.1.0
+    nwbinspector >= 0.3.1
     pyout >=0.5, !=0.6.0
     python-dateutil
     requests ~= 2.20


### PR DESCRIPTION
Hello everyone!

This is a first attempt at integrating the [NWBInspector](https://github.com/neurodatawithoutborders/nwbinspector) in place of existing metadata validation applied to single NWBAsset instances. This approach will make including other types of metadata checking on NWBAssets much easier to extend; all you would have to do is add the specific check to the `list` of `_required_nwb_checks` at the [top of dandi/files](https://github.com/catalystneuro/dandi-cli/blob/4e0252dece8b2bb97cd2da0c6cf15a9cfca76374/dandi/files.py#L80).

No significant overall change to your CLI behavior is expected here, up to some changes we may have to make on our end to support PyNWB validation on older NWB schemas.

For 'next steps' after this PR that _would_ change behavior by adding extra metadata conditions, this would be very easy to do and could immediately include checking that Subject fields follow certain patterns, such as age/duration in ISO 8601, species being in Latin binomial form, etc...

I just wanted to check first off that this is the desired injection point for utilizing the generalized Inspector during explicit validation (see [PR #40](https://github.com/dandi/handbook/pull/40) for documentation changes suggesting users to run the **full** NWBInspector prior to DANDI validation, but this is purely optional).