### PR TITLE
Black update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     -   id: check-yaml
     -   id: check-added-large-files
 -   repo: https://github.com/psf/black
-    rev: 21.5b2
+    rev: 22.3.0
     hooks:
     -   id: black
         exclude: ^(dandi/_version\.py|dandi/due\.py|versioneer\.py)$


### PR DESCRIPTION
Older black will hit an error if the system uses click 8.1.0 or newer.
See: https://github.com/psf/black/issues/2964#issuecomment-1080974737

@yarikoptic this is pertaining to the issue we discussed earlier this evening, and this commit solves it.