### PR TITLE
Smaller video files

### DIFF
--- a/dandi/tests/fixtures.py
+++ b/dandi/tests/fixtures.py
@@ -405,7 +405,7 @@ def video_files(tmp_path):
     for no in range(2):
         movie_file1 = video_path / f"test1_{no}.avi"
         movie_file2 = video_path / f"test2_{no}.avi"
-        (nf, nx, ny) = (5, 10, 20)
+        (nf, nx, ny) = (2, 2, 2)
         writer1 = cv2.VideoWriter(
             filename=str(movie_file1),
             apiPreference=None,


### PR DESCRIPTION
Reduced file size as per https://github.com/dandi/dandi-cli/issues/944#issuecomment-1088247834
They were already pretty small so this goes from 8KB to 6KB only.
Not entirely sure how 6KB are filled with 2 frames of 2x2 size, but I assume it's some encoding quirk.
`fps` changes seem to have no effect on size.


```python
chymera@decohost ~ $ cat lulu.py
def video_files(tmp_path):
    video_paths = []
    import cv2
    import numpy as np
    import os

    video_path = f"{tmp_path}/video_files"
    os.mkdir(video_path)
    for no in range(2):
        movie_file1 = f"{video_path}/test1_{no}.avi"
        movie_file2 = f"{video_path}/test2_{no}.avi"
        (nf, nx, ny) = (2, 2, 2)
        writer1 = cv2.VideoWriter(
            filename=str(movie_file1),
            apiPreference=None,
            fourcc=cv2.VideoWriter_fourcc(*"DIVX"),
            fps=25,
            frameSize=(ny, nx),
            params=None,
        )
        writer2 = cv2.VideoWriter(
            filename=str(movie_file2),
            apiPreference=None,
            fourcc=cv2.VideoWriter_fourcc(*"DIVX"),
            fps=25,
            frameSize=(ny, nx),
            params=None,
        )
        for k in range(nf):
            writer1.write(np.random.randint(0, 255, (nx, ny, 3)).astype("uint8"))
            writer2.write(np.random.randint(0, 255, (nx, ny, 3)).astype("uint8"))
        writer1.release()
        writer2.release()
        video_paths.append((movie_file1, movie_file2))
    return video_paths
chymera@decohost ~ $ python -c "import lulu; lulu.video_files('/tmp/')"
[ INFO:0@0.004] global /var/tmp/portage/media-libs/opencv-4.5.5-r1/work/opencv-4.5.5/modules/videoio/src/videoio_registry.cpp (223) VideoBackendRegistry VIDEOIO: Enabled backends(7, sorted by priority): FFMPEG(1000); GSTREAMER(990); INTEL_MFX(980); V4L2(970); CV_IMAGES(960); CV_MJPEG(950); UEYE(940)
chymera@decohost ~ $ ls -lah /tmp/video_files/*
-rw-r--r-- 1 chymera chymera 5.8K Apr  6 04:28 /tmp/video_files/test1_0.avi
-rw-r--r-- 1 chymera chymera 5.8K Apr  6 04:28 /tmp/video_files/test1_1.avi
-rw-r--r-- 1 chymera chymera 5.8K Apr  6 04:28 /tmp/video_files/test2_0.avi
-rw-r--r-- 1 chymera chymera 5.8K Apr  6 04:28 /tmp/video_files/test2_1.avi
chymera@decohost ~ $ colordiff lulu.py lala.py
12c12
<         (nf, nx, ny) = (2, 2, 2)
---
>         (nf, nx, ny) = (5, 10, 20)
chymera@decohost ~ $ rm -rf /tmp/video_files/
chymera@decohost ~ $ python -c "import lala; lala.video_files('/tmp/')"
[ INFO:0@0.004] global /var/tmp/portage/media-libs/opencv-4.5.5-r1/work/opencv-4.5.5/modules/videoio/src/videoio_registry.cpp (223) VideoBackendRegistry VIDEOIO: Enabled backends(7, sorted by priority): FFMPEG(1000); GSTREAMER(990); INTEL_MFX(980); V4L2(970); CV_IMAGES(960); CV_MJPEG(950); UEYE(940)
chymera@decohost ~ $ ls -lah /tmp/video_files/*
-rw-r--r-- 1 chymera chymera 7.7K Apr  6 04:29 /tmp/video_files/test1_0.avi
-rw-r--r-- 1 chymera chymera 7.8K Apr  6 04:29 /tmp/video_files/test1_1.avi
-rw-r--r-- 1 chymera chymera 7.8K Apr  6 04:29 /tmp/video_files/test2_0.avi
-rw-r--r-- 1 chymera chymera 7.8K Apr  6 04:29 /tmp/video_files/test2_1.avi