### PR TITLE
DX: enable "released" plugin for auto

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -10,6 +10,7 @@
             {
                   "afterRelease": "python -m build && twine upload dist/*"
             }
-        ]
+        ],
+        "released"
     ]
 }


### PR DESCRIPTION
I have created released label manually in the github repo

More info: https://intuit.github.io/auto/docs/generated/released

@jwodder -- any other plugins https://github.com/dandi/dandi-archive/blob/master/.autorc#L2 uses appeal to you?