### PR TITLE
Specify all queues in test celery worker

### DIFF
--- a/dandi/tests/data/dandiarchive-docker/docker-compose.yml
+++ b/dandi/tests/data/dandiarchive-docker/docker-compose.yml
@@ -56,7 +56,7 @@ services:
       "worker",
       "--loglevel", "INFO",
       "--without-heartbeat",
-      "-Q","celery,calculate_sha256",
+      "-Q","celery,calculate_sha256,ingest_zarr_archive,manifest-worker",
       "-B"
     ]
     # Docker Compose does not set the TTY width, which causes Celery errors


### PR DESCRIPTION
The celery worker in the docker-compose test configuration needs to
explicitly specify all queues that it monitors. Several queues have been
added recently so the worker definition needs to include those new
queues.

Fixes https://github.com/dandi/dandi-archive/issues/1011