### PR TITLE
Integration test config

### DIFF
--- a/dandi/tests/data/dandiarchive-docker/docker-compose.yml
+++ b/dandi/tests/data/dandiarchive-docker/docker-compose.yml
@@ -57,6 +57,7 @@ services:
       "--loglevel", "INFO",
       "--without-heartbeat",
       "-Q","celery,calculate_sha256,ingest_zarr_archive,manifest-worker",
+      "-c","1",
       "-B"
     ]
     # Docker Compose does not set the TTY width, which causes Celery errors

--- a/dandi/tests/data/dandiarchive-docker/docker-compose.yml
+++ b/dandi/tests/data/dandiarchive-docker/docker-compose.yml
@@ -87,7 +87,7 @@ services:
       DANDI_ALLOW_LOCALHOST_URLS: "1"
 
   minio:
-    image: minio/minio:RELEASE.2022-01-28T02-28-16Z
+    image: minio/minio:RELEASE.2022-04-12T06-55-35Z
     # When run with a TTY, minio prints credentials on startup
     tty: true
     command: ["server", "/data"]


### PR DESCRIPTION
These changes may possibly help resolve https://github.com/dandi/dandi-archive/issues/567.
* Limit celery concurrency to 1. Possibly having multiple workers running at the same time is causing a race condition.
* Upgrade the minio image version. The error might be happening when querying the minio container from the celery container, so possibly there is a minio bug that has been patched in the last 4 months.