### PR TITLE
Fix type in test docker-compose env var

### DIFF
--- a/dandi/tests/data/dandiarchive-docker/docker-compose.yml
+++ b/dandi/tests/data/dandiarchive-docker/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       DJANGO_DANDI_SCHEMA_VERSION:
       DJANGO_DANDI_WEB_APP_URL: http://localhost:8085
       DJANGO_DANDI_API_URL: http://localhost:8000
-      DANDI_JUPYTERHUB_URL: https://hub.dandiarchive.org
+      DJANGO_DANDI_JUPYTERHUB_URL: https://hub.dandiarchive.org
       DANDI_ALLOW_LOCALHOST_URLS: "1"
     ports:
       - "8000:8000"
@@ -85,7 +85,7 @@ services:
       DJANGO_DANDI_VALIDATION_JOB_INTERVAL: "5"
       DJANGO_DANDI_WEB_APP_URL: http://localhost:8085
       DJANGO_DANDI_API_URL: http://localhost:8000
-      DANDI_JUPYTERHUB_URL: https://hub.dandiarchive.org
+      DJANGO_DANDI_JUPYTERHUB_URL: https://hub.dandiarchive.org
       DANDI_ALLOW_LOCALHOST_URLS: "1"
 
   minio:


### PR DESCRIPTION
Bug fix to #959

Apologies, I forgot to include the `DJANGO_` prefix to the env var.