### PR TITLE
BIDS metadata read-in pilot.

### DIFF
--- a/dandi/cli/cmd_ls.py
+++ b/dandi/cli/cmd_ls.py
@@ -368,6 +368,7 @@ def get_metadata_ls(
         if (
             not op.isdir(path)
             and "nwb_version" not in rec
+            and "bids_version" not in rec
             and (keys and "nwb_version" in keys)
         ):
             # Let's at least get that one

--- a/dandi/consts.py
+++ b/dandi/consts.py
@@ -30,6 +30,7 @@ metadata_nwb_subject_fields = (
 metadata_nwb_dandi_fields = ("cell_id", "slice_id", "tissue_sample_id", "probe_ids")
 
 metadata_nwb_computed_fields = (
+    "bids_version",
     "number_of_electrodes",
     "number_of_units",
     "nwb_version",
@@ -75,7 +76,7 @@ PUBLISHED_VERSION_REGEX = r"[0-9]+\.[0-9]+\.[0-9]+"
 
 #: Regular expression for a valid Dandiset version identifier.  This regex is
 #: not anchored.
-VERSION_REGEX = fr"(?:{PUBLISHED_VERSION_REGEX}|draft)"
+VERSION_REGEX = rf"(?:{PUBLISHED_VERSION_REGEX}|draft)"
 
 
 class EmbargoStatus(Enum):


### PR DESCRIPTION
Will return minimal BIDS metadata via DANDI commands:

```console
chymera@decohost ~/.data2/dandi $ dandi ls /home/chymera/.data2/dandi/000026/derivatives/EPIC/sub-I46/ses-MRI/anat/sub-I46_ses-MRI_flip-3_VFA.nii.gz
2022-04-18 06:05:44,701 [ WARNING] A newer version (0.39.1) of dandi/dandi-cli is available. You are using 0.38.0+43.g648cb22
2022-04-18 06:05:44,875 [    INFO] Note: NumExpr detected 12 cores but "NUMEXPR_MAX_THREADS" not set, so enforcing safe limit of 8.
2022-04-18 06:05:44,875 [    INFO] NumExpr defaulting to 8 threads.
- bids_version: 1.7.0+012+dandi001
  path: /home/chymera/.data2/dandi/000026/derivatives/EPIC/sub-I46/ses-MRI/anat/sub-I46_ses-MRI_flip-3_VFA.nii.gz
  session_id: MRI
  size: 0
  subject_id: I46
2022-04-18 06:05:45,999 [    INFO] Logs saved in /home/chymera/.cache/dandi-cli/log/20220418100544Z-27525.log
```

- [ ] update BIDS version reporting once support is merged
   - [ ] will also require including the used BIDS version in the validator output directory
- [ ] nicely crawl up to the `dataset_description.json` to populate additional fields 