### PR TITLE
keeping logs cleaner in dedicated directory

### DIFF
--- a/dandi/bids_validator_xs.py
+++ b/dandi/bids_validator_xs.py
@@ -452,8 +452,8 @@ def validate_all(
 
 def write_report(
     validation_result,
-    report_path="{logdir}/bids-validator-report_{date}.log",
-    datetime_format="%Y%m%d-%H%M%S",
+    report_path="{logdir}/bids-validator-report_{datetime}-{pid}.log",
+    datetime_format="%Y%m%d%H%M%SZ",
 ):
     """Write a human-readable report based on the validation result.
 
@@ -465,10 +465,10 @@ def write_report(
         The "itemwise" value, if present, should be a list of dictionaries, with keys including
         "path", "regex", and "match".
     report_path : str, optional
-        A path under which the report is to be saved, `logdir` and `date` are available
-        as variables for string formatting, and will be expanded to the application log
-        directory and current datetime (as per the `datetime_format` parameter),
-        respectively.
+        A path under which the report is to be saved, `datetime`, `logdir`, and `pid`
+        are available as variables for string formatting, and will be expanded to the
+        current datetime (as per the `datetime_format` parameter), application log
+        directory, and process ID, respectively.
     datetime_format : str, optional
         A datetime format, optionally used for the report path.
 
@@ -481,7 +481,8 @@ def write_report(
 
     report_path = report_path.format(
         logdir=logdir,
-        date=datetime.datetime.now().strftime(datetime_format),
+        datetime=datetime.datetime.utcnow().strftime(datetime_format),
+        pid=os.getpid(),
     )
     report_path = os.path.abspath(os.path.expanduser(report_path))
     try:

--- a/dandi/bids_validator_xs.py
+++ b/dandi/bids_validator_xs.py
@@ -529,7 +529,7 @@ def write_report(
         else:
             f.write("All mandatory BIDS files were found.\n")
         f.close()
-    lgr.info(f"BIDS validation log written to {report_path}")
+    lgr.info("BIDS validation log written to %s", report_path)
 
 
 def _find_dataset_description(my_path):
@@ -617,17 +617,21 @@ def select_schema_dir(
                         lgr.warning(
                             "BIDSVersion is not specified in "
                             "`dataset_description.json`. "
-                            f"Falling back to {schema_min_version}."
+                            "Falling back to %s.",
+                            schema_min_version,
                         )
                         schema_version = schema_min_version
         if schema_min_version:
             if schema_version < schema_min_version:
                 lgr.warning(
-                    f"BIDSVersion {schema_version} is less than the minimal working "
-                    "{schema_min_version}. "
-                    "Falling back to {schema_min_version}. "
+                    "BIDSVersion %s is less than the minimal working "
+                    "%s. "
+                    "Falling back to %s. "
                     "To force the usage of earlier versions specify them explicitly "
-                    "when calling the validator."
+                    "when calling the validator.",
+                    schema_version,
+                    schema_min_version,
+                    schema_min_version,
                 )
                 schema_version = schema_min_version
     schema_dir = os.path.join(schema_reference_root, schema_version)

--- a/dandi/tests/test_bids_validator_xs.py
+++ b/dandi/tests/test_bids_validator_xs.py
@@ -331,13 +331,15 @@ def test_bids_datasets_selected_paths(bids_examples, tmp_path):
     result = validate_bids(selected_paths, schema_version=TEST_SCHEMA_PATH)
 
     # Does terminal debug output work?
-    result = validate_bids(selected_paths, schema_version=TEST_SCHEMA_PATH, debug=True)
+    result = validate_bids(selected_paths, debug=True)
 
-    # Does custom log path specification work?
+    # Does the default report path work?
+    result = validate_bids(selected_paths, report_path=True)
+
+    # Does custom report path specification work?
     result = validate_bids(
         selected_paths,
         schema_version=TEST_SCHEMA_PATH,
-        debug=True,
         report_path=os.path.join(tmp_path, "test_bids.log"),
     )
     # Have all files been validated?


### PR DESCRIPTION
Very minor fix, prevents default logs from unceremoniously cluttering `/var/tmp/`.