### PR TITLE
Whitespace for string returns

### DIFF
--- a/dandi/bids_validator_xs.py
+++ b/dandi/bids_validator_xs.py
@@ -606,7 +606,7 @@ def select_schema_dir(
         if dataset_description:
             if dataset_description in dataset_descriptions:
                 raise ValueError(
-                    "You have selected files belonging to 2 different datasets."
+                    "You have selected files belonging to 2 different datasets. "
                     "Please run the validator once per dataset."
                 )
             else:
@@ -640,7 +640,7 @@ def select_schema_dir(
         return schema_dir
     else:
         raise ValueError(
-            f"The expected schema directory {schema_dir} does not exist on the system."
+            f"The expected schema directory {schema_dir} does not exist on the system. "
             "Please ensure the file exists or manually specify a schema version for "
             "which the schemacode files are available on your system."
         )

--- a/dandi/cli/cmd_validate.py
+++ b/dandi/cli/cmd_validate.py
@@ -15,8 +15,8 @@ from .base import devel_debug_option, devel_option, lgr, map_to_click_exceptions
     "--report-flag",
     "-r",
     is_flag=True,
-    help="Whether to write a report under a"
-    "unique path in the current directory. Only usable if `--report` is not already used.",
+    help="Whether to write a report under a unique path in the current directory. "
+    "Only usable if `--report` is not already used.",
 )
 @click.argument("paths", nargs=-1, type=click.Path(exists=True, dir_okay=True))
 @devel_debug_option()


### PR DESCRIPTION
trivial change, a couple of the return strings contained merged words like `aunique` due to string line breaking.