### PR TITLE
Prepend to sys.path to fix versioneer in PEP517 mode

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ if sys.version_info < (3,):
 # This is needed for versioneer to be importable when building with PEP 517.
 # See <https://github.com/warner/python-versioneer/issues/193> and links
 # therein for more information.
-sys.path.append(os.path.dirname(__file__))
+sys.path.insert(0, os.path.dirname(__file__))
 
 try:
     import versioneer


### PR DESCRIPTION
Prepend the current directory to sys.path rather than appending it
in order to fix the build in PEP517 mode properly.  If the path
is appended and versioneer is installed on the system, the system
versioneer.py (i.e. the module used to install versioneer into projects)
is imported rather than the local file, and the build fails:

```pytb
Traceback (most recent call last):
  File "/usr/lib/python-exec/python3.10/gpep517", line 4, in <module>
    sys.exit(main())
  File "/usr/lib/python3.10/site-packages/gpep517/__main__.py", line 136, in main
    return func(args)
  File "/usr/lib/python3.10/site-packages/gpep517/__main__.py", line 44, in build_wheel
    wheel_name = backend.build_wheel(args.wheel_dir, args.config_json)
  File "/usr/lib/python3.10/site-packages/setuptools/build_meta.py", line 244, in build_wheel
    return self._build_with_temp_dir(['bdist_wheel'], '.whl',
  File "/usr/lib/python3.10/site-packages/setuptools/build_meta.py", line 229, in _build_with_temp_dir
    self.run_setup()
  File "/usr/lib/python3.10/site-packages/setuptools/build_meta.py", line 174, in run_setup
    exec(compile(code, __file__, 'exec'), locals())
  File "setup.py", line 32, in <module>
    "version": versioneer.get_version(),
AttributeError: module 'versioneer' has no attribute 'get_version'
```