### PR TITLE
ENH: list localhost:8085 as the web UI for dandi-api-local-docker-tests 

### DIFF
--- a/dandi/cli/tests/test_download.py
+++ b/dandi/cli/tests/test_download.py
@@ -3,9 +3,10 @@ from pathlib import Path
 
 import click
 from click.testing import CliRunner
+import pytest
 
 from ..command import download
-from ...consts import dandiset_metadata_file
+from ...consts import dandiset_metadata_file, known_instances
 
 
 def test_download_defaults(mocker):
@@ -105,6 +106,10 @@ def test_download_gui_instance_in_dandiset(mocker):
     )
 
 
+@pytest.mark.skipif(
+    bool(known_instances["dandi-api-local-docker-tests"].gui),
+    reason="this instance now has GUI URL",
+)
 def test_download_api_instance_in_dandiset(mocker):
     mock_download = mocker.patch("dandi.download.download")
     runner = CliRunner()

--- a/dandi/cli/tests/test_instances.py
+++ b/dandi/cli/tests/test_instances.py
@@ -19,7 +19,7 @@ def test_cmd_instances(monkeypatch):
         f"  redirector: {redirector_base}\n"
         "dandi-api-local-docker-tests:\n"
         f"  api: http://{instancehost}:8000/api\n"
-        "  gui: null\n"
+        f"  gui: http://{instancehost}:8085\n"
         "  redirector: null\n"
         "dandi-devel:\n"
         "  api: null\n"

--- a/dandi/consts.py
+++ b/dandi/consts.py
@@ -121,9 +121,6 @@ known_instances = {
         "https://api-staging.dandiarchive.org/api",
     ),
     "dandi-api-local-docker-tests": DandiInstance(
-        None, None, f"http://{instancehost}:8000/api"
-    ),
-    "dandi-archive-local-docker": DandiInstance(
         f"http://{instancehost}:8085", None, f"http://{instancehost}:8000/api"
     ),
 }

--- a/dandi/consts.py
+++ b/dandi/consts.py
@@ -123,6 +123,9 @@ known_instances = {
     "dandi-api-local-docker-tests": DandiInstance(
         None, None, f"http://{instancehost}:8000/api"
     ),
+    "dandi-archive-local-docker": DandiInstance(
+        f"http://{instancehost}:8085", None, f"http://{instancehost}:8000/api"
+    ),
 }
 # to map back url: name
 known_instances_rev = {vv: k for k, v in known_instances.items() for vv in v if vv}

--- a/dandi/tests/test_dandiarchive.py
+++ b/dandi/tests/test_dandiarchive.py
@@ -171,6 +171,14 @@ from .fixtures import DandiAPI, SampleDandiset
             ),
         ),
         (
+            "http://localhost:8085/dandiset/000002",
+            DandisetURL(
+                api_url="http://localhost:8000/api",
+                dandiset_id="000002",
+                version_id=None,
+            ),
+        ),
+        (
             "https://gui.dandiarchive.org/#/dandiset/000001/files"
             "?location=%2Fsub-anm369962",
             AssetItemURL(

--- a/docs/source/cmdline/instances.rst
+++ b/docs/source/cmdline/instances.rst
@@ -19,7 +19,7 @@ Example output:
       redirector: https://dandiarchive.org
     dandi-api-local-docker-tests:
       api: http://localhost:8000/api
-      gui: null
+      gui: http://localhost:8085
       redirector: null
     dandi-devel:
       api: null


### PR DESCRIPTION
Troubleshooting dandi-archive locally and needed to download a new
dandiset from it. But it was not working because of

	$> dandi -l DEBUG download -f debug http://localhost:8085/dandiset/000002
	2022-05-05 16:46:10,698 [   DEBUG] Starting new HTTPS connection (1): rig.mit.edu:443
	2022-05-05 16:46:10,961 [   DEBUG] https://rig.mit.edu:443 "GET /et/projects/dandi/dandi-cli HTTP/1.1" 200 579
	2022-05-05 16:46:10,962 [   DEBUG] Running a newer version (0.39.5+4.gcca19df4.dirty) of dandi/dandi-cli than available (0.39.5)
	2022-05-05 16:46:11,143 [   DEBUG] Creating converter from 7 to 5
	2022-05-05 16:46:11,143 [   DEBUG] Creating converter from 5 to 7
	2022-05-05 16:46:11,143 [   DEBUG] Creating converter from 7 to 5
	2022-05-05 16:46:11,143 [   DEBUG] Creating converter from 5 to 7
	2022-05-05 16:46:12,556 [   DEBUG] Parsing url http://localhost:8085/dandiset/000002
	2022-05-05 16:46:12,611 [   DEBUG] Parsed into DandisetURL(api_url=AnyHttpUrl('http://localhost:8085', scheme='http', host='localhost', host_type='int_domain', port='8085'), dandiset_id='000002', version_id=None)
	2022-05-05 16:46:12,613 [   DEBUG] Initializing mode with given value of None
	2022-05-05 16:46:12,614 [   DEBUG] Setting write mode to 'update'
	2022-05-05 16:46:12,614 [   DEBUG] Setting width to stream width: 213
	2022-05-05 16:46:12,617 [   DEBUG] GET http://localhost:8085/dandisets/000002/
	2022-05-05 16:46:12,622 [   DEBUG] Starting new HTTP connection (1): localhost:8085
	2022-05-05 16:46:12,637 [   DEBUG] http://localhost:8085 "GET /dandisets/000002/ HTTP/1.1" 404 156
	2022-05-05 16:46:12,638 [   DEBUG] Response: 404
	2022-05-05 16:46:12,638 [   ERROR] Error 404 while sending GET request to http://localhost:8085/dandisets/000002/: <!DOCTYPE html>
	<html lang="en">
	<head>
	<meta charset="utf-8">
	<title>Error</title>
	</head>
	<body>
	<pre>Cannot GET /dandisets/000002/</pre>
	</body>
	</html>

	2022-05-05 16:46:12,638 [   DEBUG] Caught exception No such Dandiset: '000002'
	2022-05-05 16:46:12,638 [    INFO] Logs saved in /home/yoh/.cache/dandi-cli/log/20220505204610Z-120654.log
	Error: No such Dandiset: '000002'

There might be a better fix, since in general we know that our archive is one
page app, and thus requesting such urls directly would lead to such 404s, so we
should act accordingly.  But meanwhile I have decided to just announce
availability of such an instance of an archive which is started locally from
dandi-archive repo.  That seems to resolve the issue and allows to download
(and hopefully to upload, which will be tried shortly).