### PR TITLE
organize - sanitize ; as well within the entity value

### DIFF
--- a/dandi/organize.py
+++ b/dandi/organize.py
@@ -400,7 +400,7 @@ def _sanitize_value(value, field):
     Of particular importance is _ which we use, as in BIDS, to separate
     _key-value entries
     """
-    value = re.sub("[_*:%@]", "-", value)
+    value = re.sub("[_*:%@;]", "-", value)
     if field != "extension":
         value = value.replace(".", "-")
     return value

--- a/dandi/tests/test_organize.py
+++ b/dandi/tests/test_organize.py
@@ -27,6 +27,7 @@ def test_sanitize_value() -> None:
     # . is not sanitized in extension but elsewhere
     assert _sanitize_value("_.ext", "extension") == "-.ext"
     assert _sanitize_value("_.ext", "unrelated") == "--ext"
+    assert _sanitize_value("A;B", "unrelated") == "A-B"
 
 
 def test_populate_dataset_yml(tmp_path: Path) -> None:


### PR DESCRIPTION
User reported filenames with ; in them.  Although I do not think
it caused any trouble, seeing such character in the filename is
quite "surprising" to say the least, and since ; has meaning in
POSIX as separator between different commands I think best to be avoided.
Also it is not part of alphanumerics of BIDS.

But with that I wonder if we should add other punctuation to be
subject for sanitization -- e.g.  ,[](){}?  WDYT @dandi/dandi-cli ???