### PR TITLE
Properly include "data packages" in project

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -59,8 +59,11 @@ install_requires =
     tenacity
     zarr ~= 2.10
 zip_safe = False
-packages = find:
+packages = find_namespace:
 include_package_data = True
+
+[options.packages.find]
+include = dandi*
 
 [options.extras_require]
 # I bet will come handy


### PR DESCRIPTION
There are several folders in `dandi/` that contain data files but no Python source code, and we want these to be included when dandi is installed.  Currently, these folders are automatically included by the combination of `graft dandi` in `MANIFEST.in` and `include_package_data = True` in `setup.cfg`, but because we set `packages` in `setup.cfg` to `find:` instead of `find_namespace:`, the folders themselves are not recognized by setuptools as packages.  [This combination of settings is deprecated](https://github.com/pypa/setuptools/issues/3340), and the setuptools developers recommend using `find_namespace:` instead of `find:` for such situations.