### PR TITLE
Replace numpy.asscalar() with numpy.ndarray.item()

### DIFF
--- a/dandi/pynwb_utils.py
+++ b/dandi/pynwb_utils.py
@@ -10,7 +10,6 @@ import dandischema
 from fscacher import PersistentCache
 import h5py
 import hdmf
-import numpy as np
 import pynwb
 from pynwb import NWBHDF5IO
 import semantic_version
@@ -214,7 +213,7 @@ def _get_pynwb_metadata(path: Union[str, Path]) -> Dict[str, Any]:
             out.update(dandi_icephys.fields)
         # Go through devices and see if there any probes used to record this file
         probe_ids = [
-            np.asscalar(v.probe_id)  # .asscalar to avoid numpy types
+            v.probe_id.item()  # .item to avoid numpy types
             for v in getattr(nwb, "devices", {}).values()
             if hasattr(v, "probe_id")  # duck typing
         ]


### PR DESCRIPTION
[`asscalar()`](https://numpy.org/doc/1.21/reference/generated/numpy.asscalar.html) has been deprecated since numpy 1.16, with `numpy.ndarray.item()` recommended instead.  Moreover, it was [completely removed in numpy 1.23](https://numpy.org/doc/stable/release/1.23.0-notes.html#expired-deprecations), released June 22.  Note that none of our tests seem to cover the case where an NWB has any probe_ids.