### PR TITLE
User notification if datasets are invalid.

### DIFF
--- a/dandi/tests/fixtures.py
+++ b/dandi/tests/fixtures.py
@@ -448,6 +448,15 @@ def bids_dandiset(new_dandiset: SampleDandiset, bids_examples: str) -> SampleDan
 
 
 @pytest.fixture()
+def bids_dandiset_invalid(new_dandiset: SampleDandiset, bids_examples: str) -> SampleDandiset:
+    copytree(
+        os.path.join(bids_examples, "invalid_pet001"),
+        str(new_dandiset.dspath) + "/",
+    )
+    return new_dandiset
+
+
+@pytest.fixture()
 def video_files(tmp_path):
     video_paths = []
     import cv2

--- a/dandi/tests/test_upload.py
+++ b/dandi/tests/test_upload.py
@@ -185,6 +185,7 @@ def test_upload_bids_invalid(
     mocker: MockerFixture, bids_dandiset_invalid: SampleDandiset
 ) -> None:
     iter_upload_spy = mocker.spy(LocalFileAsset, "iter_upload")
+    # Does it fail when it should fail?
     with pytest.raises(RuntimeError):
         bids_dandiset_invalid.upload(existing="forced")
     iter_upload_spy.assert_not_called()

--- a/dandi/tests/test_upload.py
+++ b/dandi/tests/test_upload.py
@@ -185,8 +185,8 @@ def test_upload_bids_invalid(
     mocker: MockerFixture, bids_dandiset_invalid: SampleDandiset
 ) -> None:
     iter_upload_spy = mocker.spy(LocalFileAsset, "iter_upload")
-    bids_dandiset_invalid.upload(existing="forced")
-    # Check whether upload failed
+    with pytest.raises(RuntimeError):
+        bids_dandiset_invalid.upload(existing="forced")
     iter_upload_spy.assert_not_called()
 
 

--- a/dandi/tests/test_upload.py
+++ b/dandi/tests/test_upload.py
@@ -181,9 +181,20 @@ def test_upload_sync_folder(
         text_dandiset.dandiset.get_asset_by_path("subdir2/banana.txt")
 
 
-def test_upload_bids(mocker: MockerFixture, bids_dandiset: SampleDandiset) -> None:
+def test_upload_bids_invalid(
+    mocker: MockerFixture, bids_dandiset_invalid: SampleDandiset
+) -> None:
     iter_upload_spy = mocker.spy(LocalFileAsset, "iter_upload")
-    bids_dandiset.upload(existing="forced")
+    bids_dandiset_invalid.upload(existing="forced")
+    # Check whether upload failed
+    iter_upload_spy.assert_not_called()
+
+
+def test_upload_bids_validation_ignore(
+    mocker: MockerFixture, bids_dandiset: SampleDandiset
+) -> None:
+    iter_upload_spy = mocker.spy(LocalFileAsset, "iter_upload")
+    bids_dandiset.upload(existing="forced", validation="ignore")
     # Check whether upload was run
     iter_upload_spy.assert_called()
     # Check existence of assets:
@@ -196,11 +207,9 @@ def test_upload_bids(mocker: MockerFixture, bids_dandiset: SampleDandiset) -> No
     dandiset.get_asset_by_path("sub-Sub1/anat/sub-Sub1_T1w.nii.gz")
 
 
-def test_upload_bids_validation_ignore(
-    mocker: MockerFixture, bids_dandiset: SampleDandiset
-) -> None:
+def test_upload_bids(mocker: MockerFixture, bids_dandiset: SampleDandiset) -> None:
     iter_upload_spy = mocker.spy(LocalFileAsset, "iter_upload")
-    bids_dandiset.upload(existing="forced", validation="ignore")
+    bids_dandiset.upload(existing="forced")
     # Check whether upload was run
     iter_upload_spy.assert_called()
     # Check existence of assets:

--- a/dandi/tests/test_upload.py
+++ b/dandi/tests/test_upload.py
@@ -192,8 +192,10 @@ def test_upload_bids_invalid(
     # Does validation ignoring work?
     bids_dandiset_invalid.upload(existing="forced", validation="ignore")
     iter_upload_spy.assert_called_once()
-    # Are files uploaded?
-    bids_dandiset_invalid.get_asset_by_path("dataset_description.json")
+    # Check existence of assets:
+    dandiset = bids_dandiset_invalid.dandiset
+    # Check file existence:
+    dandiset.get_asset_by_path("dataset_description.json")
 
 
 def test_upload_bids_validation_ignore(

--- a/dandi/tests/test_upload.py
+++ b/dandi/tests/test_upload.py
@@ -193,7 +193,7 @@ def test_upload_bids_invalid(
     bids_dandiset_invalid.upload(existing="forced", validation="ignore")
     iter_upload_spy.assert_called_once()
     # Are files uploaded?
-    dandiset.get_asset_by_path("dataset_description.json")
+    bids_dandiset_invalid.get_asset_by_path("dataset_description.json")
 
 
 def test_upload_bids_validation_ignore(

--- a/dandi/tests/test_upload.py
+++ b/dandi/tests/test_upload.py
@@ -188,6 +188,11 @@ def test_upload_bids_invalid(
     with pytest.raises(RuntimeError):
         bids_dandiset_invalid.upload(existing="forced")
     iter_upload_spy.assert_not_called()
+    # Does validation ignoring work?
+    bids_dandiset_invalid.upload(existing="forced", validation="ignore")
+    iter_upload_spy.assert_called_once()
+    # Are files uploaded?
+    dandiset.get_asset_by_path("dataset_description.json")
 
 
 def test_upload_bids_validation_ignore(

--- a/dandi/tests/test_upload.py
+++ b/dandi/tests/test_upload.py
@@ -191,10 +191,9 @@ def test_upload_bids_invalid(
     iter_upload_spy.assert_not_called()
     # Does validation ignoring work?
     bids_dandiset_invalid.upload(existing="forced", validation="ignore")
-    iter_upload_spy.assert_called_once()
+    iter_upload_spy.assert_called()
     # Check existence of assets:
     dandiset = bids_dandiset_invalid.dandiset
-    # Check file existence:
     dandiset.get_asset_by_path("dataset_description.json")
 
 

--- a/dandi/upload.py
+++ b/dandi/upload.py
@@ -453,6 +453,19 @@ def _bids_discover_and_validate(
             )
             if valid:
                 validated_datasets.append(bd)
+        invalid_datasets = []
+        for i in bids_datasets_to_validate:
+            if i not in validated_datasets:
+                invalid_datasets.append(str(i))
+        if invalid_datasets:
+            raise RuntimeError(
+                f"Found {pluralize(len(invalid_datasets), 'BIDS dataset')}, which did not "
+                "pass validation:\n * "
+                + "\n * ".join(invalid_datasets)
+                + "\nTo resolve "
+                "this, perform the required changes or set the validation parameter to "
+                '"skip" or "ignore".'
+            )
         return validated_datasets
     else:
         return bids_datasets

--- a/dandi/upload.py
+++ b/dandi/upload.py
@@ -443,8 +443,8 @@ def _bids_discover_and_validate(
         else:
             bids_datasets_to_validate = bids_datasets
         bids_datasets_to_validate.sort()
-        valid_datasets: List[str] = []
-        invalid_datasets = []
+        valid_datasets: List[Path] = []
+        invalid_datasets: List[Path] = []
         for bd in bids_datasets_to_validate:
             validator_result = validate_bids(bd)
             valid = is_valid(

--- a/dandi/upload.py
+++ b/dandi/upload.py
@@ -452,12 +452,12 @@ def _bids_discover_and_validate(
                 allow_missing_files=validation == "ignore",
                 allow_invalid_filenames=validation == "ignore",
             )
-            (valid_datasets if valid else invalid_datasets).append(str(bd))
+            (valid_datasets if valid else invalid_datasets).append(bd)
         if invalid_datasets:
             raise RuntimeError(
                 f"Found {pluralize(len(invalid_datasets), 'BIDS dataset')}, which did not "
                 "pass validation:\n * "
-                + "\n * ".join(invalid_datasets)
+                + "\n * ".join([str(i) for i in invalid_datasets])
                 + "\nTo resolve "
                 "this, perform the required changes or set the validation parameter to "
                 '"skip" or "ignore".'

--- a/dandi/upload.py
+++ b/dandi/upload.py
@@ -443,7 +443,8 @@ def _bids_discover_and_validate(
         else:
             bids_datasets_to_validate = bids_datasets
         bids_datasets_to_validate.sort()
-        validated_datasets = []
+        valid_datasets = []
+        invalid_datasets = []
         for bd in bids_datasets_to_validate:
             validator_result = validate_bids(bd)
             valid = is_valid(
@@ -451,12 +452,7 @@ def _bids_discover_and_validate(
                 allow_missing_files=validation == "ignore",
                 allow_invalid_filenames=validation == "ignore",
             )
-            if valid:
-                validated_datasets.append(bd)
-        invalid_datasets = []
-        for i in bids_datasets_to_validate:
-            if i not in validated_datasets:
-                invalid_datasets.append(str(i))
+            (valid_datasets if valid else invalid_datasets).append(str(bd))
         if invalid_datasets:
             raise RuntimeError(
                 f"Found {pluralize(len(invalid_datasets), 'BIDS dataset')}, which did not "
@@ -466,6 +462,6 @@ def _bids_discover_and_validate(
                 "this, perform the required changes or set the validation parameter to "
                 '"skip" or "ignore".'
             )
-        return validated_datasets
+        return valid_datasets
     else:
         return bids_datasets

--- a/dandi/upload.py
+++ b/dandi/upload.py
@@ -443,7 +443,7 @@ def _bids_discover_and_validate(
         else:
             bids_datasets_to_validate = bids_datasets
         bids_datasets_to_validate.sort()
-        valid_datasets = []
+        valid_datasets: List[str] = []
         invalid_datasets = []
         for bd in bids_datasets_to_validate:
             validator_result = validate_bids(bd)


### PR DESCRIPTION
Addressing: https://github.com/dandi/dandi-cli/issues/1055#issuecomment-1189149375

Example:
```console
chymera@decohost ~/src/bids-examples $ dandi upload -i dandi-staging eeg_cbm/
2022-07-19 14:17:00,460 [    INFO] Note: NumExpr detected 12 cores but "NUMEXPR_MAX_THREADS" not set, so enforcing safe limit of 8.
2022-07-19 14:17:00,460 [    INFO] NumExpr defaulting to 8 threads.
2022-07-19 14:17:01,688 [ WARNING] BIDSVersion 1.0.2 is less than the minimal working 1.7.0+012+dandi001. Falling back to 1.7.0+012+dandi001. To force the usage of earlier versions specify them explicitly when calling the validator.
2022-07-19 14:17:02,435 [   ERROR] The `.*?/CHANGES$` regex pattern file required by BIDS was not found.
2022-07-19 14:17:02,435 [    INFO] Logs saved in /home/chymera/.cache/dandi-cli/log/20220719181659Z-26640.log
Error: Found 1 BIDS dataset, which did not pass validation:
 * /home/chymera/src/bids-examples/eeg_cbm
To resolve this, perform the required changes or set the validation parameter to "skip" or "ignore".
```