### PR TITLE
ENH: list localhost:8085  as the web UI for dandi-api-local-docker-tests

### DIFF
--- a/dandi/consts.py
+++ b/dandi/consts.py
@@ -121,7 +121,7 @@ known_instances = {
         "https://api-staging.dandiarchive.org/api",
     ),
     "dandi-api-local-docker-tests": DandiInstance(
-        None, None, f"http://{instancehost}:8000/api"
+        f"http://{instancehost}:8085", None, f"http://{instancehost}:8000/api"
     ),
 }
 # to map back url: name


### PR DESCRIPTION
It is not really for the tests but if local dandi-archive instance is
established following instructions. This follows @jwodder idea instead of
https://github.com/dandi/dandi-cli/pull/1003 with more explicit dedicated instance

Fixes #1003 