### PR TITLE
Check for usage of latest NWB Inspector release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,9 +75,10 @@ jobs:
         python -m pip install --upgrade pip wheel
         pip install ".[test]"
 
-    - name: Install dev version of pynwb
+    - name: Install dev version of pynwb and nwbinspector
       if: matrix.mode == 'dev-deps'
       run: |
+        pip install git+https://github.com/NeurodataWithoutBorders/nwbinspector
         pip install git+https://github.com/NeurodataWithoutBorders/pynwb
 
     - name: Run all tests

--- a/dandi/tests/fixtures.py
+++ b/dandi/tests/fixtures.py
@@ -113,8 +113,8 @@ def simple2_nwb(
         subject=pynwb.file.Subject(
             subject_id="mouse001",
             date_of_birth=datetime(2016, 12, 1, tzinfo=tzutc()),
-            sex="M",
-            species="mouse",
+            sex="U",
+            species="Mus musculus",
         ),
         **simple1_nwb_metadata,
     )
@@ -128,9 +128,9 @@ def simple3_nwb(
     return make_nwb_file(
         str(tmpdir_factory.mktemp("simple2").join("simple2.nwb")),
         subject=pynwb.file.Subject(
-            date_of_birth=datetime(2016, 12, 1, tzinfo=tzutc()),
-            sex="M",
-            species="mouse",
+            age="P1D/",
+            sex="O",
+            species="Mus musculus",
         ),
         **simple1_nwb_metadata,
     )

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ install_requires =
     pycryptodomex  # for EncryptedKeyring backend in keyrings.alt
     pydantic >= 1.9.0
     pynwb >= 1.0.3,!=1.1.0
-    nwbinspector >= 0.3.8
+    nwbinspector >= 0.4.12
     pyout >=0.5, !=0.6.0
     python-dateutil
     requests ~= 2.20


### PR DESCRIPTION
Hey all, 

as a companion to the upcoming enforcement of more rigorous subject metadata requirements for DANDI upload (all taken care of by https://github.com/NeurodataWithoutBorders/nwbinspector/pull/247) it occurred to me that in order to both (i) prevent users from bypassing these requirements by downgrading their NWB Inspector version or (ii) prevent fewer future lower bound version bumps of the `nwbinspector` package on the DANDI requirements side; it would be best to simply check that the person is using the latest PyPI/conda-forge release of the package at time of validation.

I'm not really sure how to add a test for this though, let me know if you have ideas for that.