### PR TITLE
BF(workaround): blacklist 23.9.0 of keyring since introduced regression

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
     importlib-metadata;  python_version < "3.8"
     interleave ~= 0.1
     joblib
-    keyring
+    keyring != 23.9.0
     keyrings.alt
     packaging
     pycryptodomex  # for EncryptedKeyring backend in keyrings.alt


### PR DESCRIPTION
Closes #1111

Ref upstream: https://github.com/jaraco/keyring/issues/593