### PR TITLE
increase number of trials in docker_compose_setup to 25

### DIFF
--- a/dandi/tests/fixtures.py
+++ b/dandi/tests/fixtures.py
@@ -308,7 +308,7 @@ def docker_compose_setup() -> Iterator[Dict[str, str]]:
                 check=True,
             )
             API_URL = known_instances["dandi-api-local-docker-tests"].api
-            for _ in range(10):
+            for _ in range(25):
                 try:
                     requests.get(f"{API_URL}/dandisets/")
                 except requests.ConnectionError:


### PR DESCRIPTION
increasing number of trials to connect to dandisets in `docker_compose_setup`

@jwodder @yarikoptic - closing my tabs, restarting laptop, updating docker didn't help, still was timing out...