### PR TITLE
Make internal Zarr-checksumming tree types support empty Zarrs

### DIFF
--- a/dandi/cli/tests/test_digest.py
+++ b/dandi/cli/tests/test_digest.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 from click.testing import CliRunner
@@ -52,3 +53,12 @@ def test_digest_zarr():
         r = runner.invoke(digest, ["--digest", "zarr-checksum", "sample.zarr"])
         assert r.exit_code == 0
         assert r.output == "sample.zarr: 4313ab36412db2981c3ed391b38604d6-5--1516\n"
+
+
+def test_digest_empty_zarr(tmp_path: Path) -> None:
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        os.mkdir("empty.zarr")
+        r = runner.invoke(digest, ["--digest", "zarr-checksum", "empty.zarr"])
+        assert r.exit_code == 0
+        assert r.output == "empty.zarr: 481a2f77ab786a0f45aafd5db0971caa-0--0\n"

--- a/dandi/support/tests/test_digests.py
+++ b/dandi/support/tests/test_digests.py
@@ -9,7 +9,6 @@
 
 from pathlib import Path
 
-import pytest
 from pytest_mock import MockerFixture
 
 from .. import digests
@@ -79,9 +78,7 @@ def test_get_zarr_checksum(mocker: MockerFixture, tmp_path: Path) -> None:
     assert get_zarr_checksum(tmp_path) == "25627e0fc7c609d10100d020f7782a25-8--197"
     assert get_zarr_checksum(sub1) == "64af93ad7f8d471c00044d1ddbd4c0ba-4--97"
 
-    with pytest.raises(ValueError) as excinfo:
-        get_zarr_checksum(empty)
-    assert str(excinfo.value) == "Cannot compute a Zarr checksum for an empty directory"
+    assert get_zarr_checksum(empty) == "481a2f77ab786a0f45aafd5db0971caa-0--0"
 
     spy = mocker.spy(digests, "md5file_nocache")
     assert (


### PR DESCRIPTION
@yarikoptic Please release this so I can use it in backups2datalad.