### PR TITLE
Don't try to cancel failed Zarr uploads twice

### DIFF
--- a/dandi/files/zarr.py
+++ b/dandi/files/zarr.py
@@ -450,6 +450,7 @@ class ZarrAsset(LocalDirectoryAsset[LocalZarrEntry]):
                                 f.cancel()
                             executor.shutdown()
                             client.delete(f"/zarr/{zarr_id}/upload/")
+                            ZARR_UPLOADS_IN_PROGRESS.discard(upload_data)
                             raise
                         else:
                             bytes_uploaded += size


### PR DESCRIPTION
Fixed a bug seen in https://github.com/dandi/dandi-cli/issues/1028#issuecomment-1282761146.