### PR TITLE
Make `list_paths()` include dotfiles

### DIFF
--- a/dandi/utils.py
+++ b/dandi/utils.py
@@ -357,7 +357,18 @@ def find_files(
 
 
 def list_paths(dirpath: Union[str, Path], dirs: bool = False) -> List[Path]:
-    return sorted(map(Path, find_files(r".*", [dirpath], dirs=dirs)))
+    return sorted(
+        map(
+            Path,
+            find_files(
+                r".*",
+                [dirpath],
+                dirs=dirs,
+                exclude_dotfiles=False,
+                exclude_dotdirs=False,
+            ),
+        )
+    )
 
 
 _cp_supports_reflink: Optional[bool] = None


### PR DESCRIPTION
I realized while investigating https://github.com/dandi/dandi-archive/issues/1336 that `list_paths()` is ignoring dotfiles & dotdirs, which could theoretically lead to a test not behaving properly when such files are present in a Dandiset or Zarr.