### PR TITLE
Test against Python 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,7 @@ jobs:
           - 3.8
           - 3.9
           - '3.10'  # Needs quotes so YAML doesn't think it's 3.1
+          - '3.11'
         mode:
           - normal
         include:

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Scientific/Engineering
 license = Apache 2.0
 description = Command line client for interaction with DANDI archive elements

--- a/tox.ini
+++ b/tox.ini
@@ -63,6 +63,7 @@ filterwarnings =
     ignore:The distutils package is deprecated:DeprecationWarning:joblib
     ignore:.*Value with data type .* is being converted:hdmf.build.warnings.DtypeConversionWarning
     ignore:.*find_spec\(\) not found:ImportWarning
+    ignore:'cgi' is deprecated:DeprecationWarning:botocore
 
 [coverage:run]
 parallel = True


### PR DESCRIPTION
Python 3.11 was released on October 24, so it's time to start testing against it.

Note: I expect this PR to fail for the next few weeks until numpy makes a 3.11-compatible release.