### PR TITLE
Exclude special dotfiles from Zarrs

### DIFF
--- a/dandi/cli/tests/test_digest.py
+++ b/dandi/cli/tests/test_digest.py
@@ -77,6 +77,9 @@ def test_digest_zarr_with_excluded_dotfiles():
         os.mkdir("sample.zarr/.dandi")
         Path("sample.zarr", ".dandi", "somefile.txt").touch()
         Path("sample.zarr", ".gitattributes").touch()
+        Path("sample.zarr", "arr_0", ".gitmodules").touch()
+        Path("sample.zarr", "arr_1", ".datalad").mkdir()
+        Path("sample.zarr", "arr_1", ".datalad", "config").touch()
         r = runner.invoke(digest, ["--digest", "zarr-checksum", "sample.zarr"])
         assert r.exit_code == 0
         assert r.output == "sample.zarr: 4313ab36412db2981c3ed391b38604d6-5--1516\n"

--- a/dandi/cli/tests/test_digest.py
+++ b/dandi/cli/tests/test_digest.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+import subprocess
 
 from click.testing import CliRunner
 import numpy as np
@@ -62,3 +63,20 @@ def test_digest_empty_zarr(tmp_path: Path) -> None:
         r = runner.invoke(digest, ["--digest", "zarr-checksum", "empty.zarr"])
         assert r.exit_code == 0
         assert r.output == "empty.zarr: 481a2f77ab786a0f45aafd5db0971caa-0--0\n"
+
+
+def test_digest_zarr_with_excluded_dotfiles():
+    # This test assumes that the Zarr serialization format never changes
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        dt = np.dtype("<i8")
+        zarr.save(
+            "sample.zarr", np.arange(1000, dtype=dt), np.arange(1000, 0, -1, dtype=dt)
+        )
+        subprocess.run(["git", "init"], cwd="sample.zarr", check=True)
+        os.mkdir("sample.zarr/.dandi")
+        Path("sample.zarr", ".dandi", "somefile.txt").touch()
+        Path("sample.zarr", ".gitattributes").touch()
+        r = runner.invoke(digest, ["--digest", "zarr-checksum", "sample.zarr"])
+        assert r.exit_code == 0
+        assert r.output == "sample.zarr: 4313ab36412db2981c3ed391b38604d6-5--1516\n"

--- a/dandi/download.py
+++ b/dandi/download.py
@@ -880,7 +880,7 @@ def _download_zarr(
         d = dirs.popleft()
         is_empty = True
         for p in list(d.iterdir()):
-            if d == zarr_basepath and exclude_from_zarr(p):
+            if exclude_from_zarr(p):
                 is_empty = False
             elif (
                 p.is_file()

--- a/dandi/download.py
+++ b/dandi/download.py
@@ -57,6 +57,7 @@ from .support.typing import Literal
 from .utils import (
     abbrev_prompt,
     ensure_datetime,
+    exclude_from_zarr,
     flattened,
     is_same_time,
     on_windows,
@@ -879,7 +880,9 @@ def _download_zarr(
         d = dirs.popleft()
         is_empty = True
         for p in list(d.iterdir()):
-            if (
+            if d == zarr_basepath and exclude_from_zarr(p):
+                is_empty = False
+            elif (
                 p.is_file()
                 and p.relative_to(zarr_basepath).as_posix() not in remote_paths
             ):

--- a/dandi/files/_private.py
+++ b/dandi/files/_private.py
@@ -20,6 +20,7 @@ from .bids import (
     ZarrBIDSAsset,
 )
 from .zarr import ZarrAsset
+from ..utils import exclude_from_zarr
 
 
 class DandiFileType(Enum):
@@ -34,7 +35,7 @@ class DandiFileType(Enum):
     @staticmethod
     def classify(path: Path) -> DandiFileType:
         if path.is_dir():
-            if not any(path.iterdir()):
+            if not any(p for p in path.iterdir() if not exclude_from_zarr(p)):
                 raise UnknownAssetError("Empty directories cannot be assets")
             if path.suffix in ZARR_EXTENSIONS:
                 return DandiFileType.ZARR

--- a/dandi/files/zarr.py
+++ b/dandi/files/zarr.py
@@ -80,7 +80,7 @@ class LocalZarrEntry(BasePath):
 
     def iterdir(self) -> Iterator[LocalZarrEntry]:
         for p in self.filepath.iterdir():
-            if self.is_root() and exclude_from_zarr(p):
+            if exclude_from_zarr(p):
                 continue
             if p.is_dir() and not any(p.iterdir()):
                 # Ignore empty directories

--- a/dandi/files/zarr.py
+++ b/dandi/files/zarr.py
@@ -33,7 +33,7 @@ from dandi.dandiapi import (
 from dandi.metadata import get_default_metadata
 from dandi.misctypes import BasePath, Digest
 from dandi.support.digests import get_digest, get_zarr_checksum, md5file_nocache
-from dandi.utils import chunked, pluralize
+from dandi.utils import chunked, exclude_from_zarr, pluralize
 
 from .bases import LocalDirectoryAsset
 from ..validate_types import Scope, Severity, ValidationOrigin, ValidationResult
@@ -80,6 +80,8 @@ class LocalZarrEntry(BasePath):
 
     def iterdir(self) -> Iterator[LocalZarrEntry]:
         for p in self.filepath.iterdir():
+            if self.is_root() and exclude_from_zarr(p):
+                continue
             if p.is_dir() and not any(p.iterdir()):
                 # Ignore empty directories
                 continue

--- a/dandi/files/zarr.py
+++ b/dandi/files/zarr.py
@@ -220,11 +220,7 @@ class ZarrAsset(LocalDirectoryAsset[LocalZarrEntry]):
                     message="Zarr group is empty.",
                 )
             ]
-        try:
-            next(self.filepath.glob(f"*{os.sep}" + os.sep.join(["*"] * MAX_ZARR_DEPTH)))
-        except StopIteration:
-            pass
-        else:
+        if self._is_too_deep():
             msg = f"Zarr directory tree more than {MAX_ZARR_DEPTH} directories deep"
             if devel_debug:
                 raise ValueError(msg)
@@ -245,6 +241,12 @@ class ZarrAsset(LocalDirectoryAsset[LocalZarrEntry]):
         return super().get_validation_errors(
             schema_version=schema_version, devel_debug=devel_debug
         )
+
+    def _is_too_deep(self) -> bool:
+        for e in self.iterfiles():
+            if len(e.parts) >= MAX_ZARR_DEPTH + 1:
+                return True
+        return False
 
     def iter_upload(
         self,

--- a/dandi/support/digests.py
+++ b/dandi/support/digests.py
@@ -124,9 +124,7 @@ def get_zarr_checksum(path: Path, known: Optional[Dict[str, str]] = None) -> str
         return (f, dgst, os.path.getsize(f))
 
     zcc = ZCTree()
-    for p, digest, size in threaded_walk(
-        path, digest_file, exclude=lambda p: p.parent == path and exclude_from_zarr(p)
-    ):
+    for p, digest, size in threaded_walk(path, digest_file, exclude=exclude_from_zarr):
         zcc.add(p.relative_to(path), digest, size)
     return zcc.get_digest()
 

--- a/dandi/support/digests.py
+++ b/dandi/support/digests.py
@@ -23,7 +23,7 @@ from dandischema.digests.zarr import get_checksum
 from fscacher import PersistentCache
 
 from .threaded_walk import threaded_walk
-from ..utils import auto_repr
+from ..utils import auto_repr, exclude_from_zarr
 
 lgr = logging.getLogger("dandi.support.digests")
 
@@ -124,7 +124,9 @@ def get_zarr_checksum(path: Path, known: Optional[Dict[str, str]] = None) -> str
         return (f, dgst, os.path.getsize(f))
 
     zcc = ZCTree()
-    for p, digest, size in threaded_walk(path, digest_file):
+    for p, digest, size in threaded_walk(
+        path, digest_file, exclude=lambda p: p.parent == path and exclude_from_zarr(p)
+    ):
         zcc.add(p.relative_to(path), digest, size)
     return zcc.get_digest()
 

--- a/dandi/support/threaded_walk.py
+++ b/dandi/support/threaded_walk.py
@@ -28,6 +28,7 @@ def threaded_walk(
     dirpath: Union[str, Path],
     func: Optional[Callable[[Path], Any]] = None,
     threads: int = 60,
+    exclude: Optional[Callable[[Path], Any]] = None,
 ) -> Iterable[Any]:
     if not os.path.isdir(dirpath):
         return
@@ -54,7 +55,9 @@ def threaded_walk(
                     break
             try:
                 for p in path.iterdir():
-                    if p.is_dir():
+                    if exclude is not None and exclude(p):
+                        log.debug("Excluding %s from traversal", p)
+                    elif p.is_dir():
                         with lock:
                             tasks += 1
                             paths.append(p)

--- a/dandi/tests/test_download.py
+++ b/dandi/tests/test_download.py
@@ -356,6 +356,8 @@ def test_download_different_zarr_onto_excluded_dotfiles(
     (zarr_path / ".dandi" / "somefile.txt").touch()
     (zarr_path / ".datalad").mkdir()
     (zarr_path / ".gitattributes").touch()
+    (zarr_path / "arr_0").mkdir()
+    (zarr_path / "arr_0" / ".gitmodules").touch()
     download(
         zarr_dandiset.dandiset.version_api_url, tmp_path, existing="overwrite-different"
     )
@@ -367,6 +369,7 @@ def test_download_different_zarr_onto_excluded_dotfiles(
         zarr_path / ".gitattributes",
         zarr_path / ".zgroup",
         zarr_path / "arr_0",
+        zarr_path / "arr_0" / ".gitmodules",
         zarr_path / "arr_0" / ".zarray",
         zarr_path / "arr_0" / "0",
         zarr_path / "arr_1",

--- a/dandi/tests/test_download.py
+++ b/dandi/tests/test_download.py
@@ -359,7 +359,7 @@ def test_download_different_zarr_onto_excluded_dotfiles(
     download(
         zarr_dandiset.dandiset.version_api_url, tmp_path, existing="overwrite-different"
     )
-    assert list_paths(zarr_path, dirs=True) == [
+    assert list_paths(zarr_path, dirs=True, exclude_vcs=False) == [
         zarr_path / ".dandi",
         zarr_path / ".dandi" / "somefile.txt",
         zarr_path / ".datalad",

--- a/dandi/tests/test_download.py
+++ b/dandi/tests/test_download.py
@@ -344,6 +344,37 @@ def test_download_different_zarr(tmp_path: Path, zarr_dandiset: SampleDandiset) 
     )
 
 
+def test_download_different_zarr_onto_excluded_dotfiles(
+    tmp_path: Path, zarr_dandiset: SampleDandiset
+) -> None:
+    dd = tmp_path / zarr_dandiset.dandiset_id
+    dd.mkdir()
+    zarr_path = dd / "sample.zarr"
+    zarr.save(zarr_path, np.eye(5))
+    (zarr_path / ".git").touch()
+    (zarr_path / ".dandi").mkdir()
+    (zarr_path / ".dandi" / "somefile.txt").touch()
+    (zarr_path / ".datalad").mkdir()
+    (zarr_path / ".gitattributes").touch()
+    download(
+        zarr_dandiset.dandiset.version_api_url, tmp_path, existing="overwrite-different"
+    )
+    assert list_paths(zarr_path, dirs=True) == [
+        zarr_path / ".dandi",
+        zarr_path / ".dandi" / "somefile.txt",
+        zarr_path / ".datalad",
+        zarr_path / ".git",
+        zarr_path / ".gitattributes",
+        zarr_path / ".zgroup",
+        zarr_path / "arr_0",
+        zarr_path / "arr_0" / ".zarray",
+        zarr_path / "arr_0" / "0",
+        zarr_path / "arr_1",
+        zarr_path / "arr_1" / ".zarray",
+        zarr_path / "arr_1" / "0",
+    ]
+
+
 def test_download_different_zarr_delete_dir(
     new_dandiset: SampleDandiset, tmp_path: Path
 ) -> None:

--- a/dandi/tests/test_files.py
+++ b/dandi/tests/test_files.py
@@ -229,11 +229,16 @@ def test_find_dandi_files_with_bids(tmp_path: Path) -> None:
 def test_dandi_file_zarr_with_excluded_dotfiles(tmp_path: Path) -> None:
     zarr_path = tmp_path / "foo.zarr"
     mkpaths(
-        zarr_path, ".git/data", ".gitattributes", ".dandi/somefile.txt", ".datalad/"
+        zarr_path,
+        ".git/data",
+        ".gitattributes",
+        ".dandi/somefile.txt",
+        ".datalad/",
+        "arr_0/.gitmodules",
     )
     with pytest.raises(UnknownAssetError):
         dandi_file(zarr_path)
-    (zarr_path / "foo").touch()
+    (zarr_path / "arr_0" / "foo").touch()
     zf = dandi_file(zarr_path)
     assert isinstance(zf, ZarrAsset)
 
@@ -368,6 +373,9 @@ def test_upload_zarr_with_excluded_dotfiles(
     (filepath / ".dandi").mkdir()
     (filepath / ".dandi" / "somefile.txt").write_text("Hello world!\n")
     (filepath / ".gitattributes").write_text("* eol=lf\n")
+    (filepath / "arr_0" / ".gitmodules").write_text("# Empty\n")
+    (filepath / "arr_1" / ".datalad").mkdir()
+    (filepath / "arr_1" / ".datalad" / "config").write_text("# Empty\n")
     zf = dandi_file(filepath)
     assert isinstance(zf, ZarrAsset)
     asset = zf.upload(new_dandiset.dandiset, {})
@@ -407,6 +415,6 @@ def test_validate_deep_zarr(tmp_path: Path) -> None:
 def test_validate_zarr_deep_via_excluded_dotfiles(tmp_path: Path) -> None:
     zarr_path = tmp_path / "foo.zarr"
     zarr.save(zarr_path, np.arange(1000), np.arange(1000, 0, -1))
-    mkpaths(zarr_path, ".git/a/b/c/d/e/f/g.txt")
+    mkpaths(zarr_path, ".git/a/b/c/d/e/f/g.txt", "a/b/c/.git/d/e/f/g.txt")
     zf = dandi_file(zarr_path)
     assert zf.get_validation_errors() == []

--- a/dandi/tests/test_files.py
+++ b/dandi/tests/test_files.py
@@ -392,3 +392,21 @@ def test_upload_zarr_with_excluded_dotfiles(
         "arr_1/.zarray",
         "arr_1/0",
     ]
+
+
+def test_validate_deep_zarr(tmp_path: Path) -> None:
+    zarr_path = tmp_path / "foo.zarr"
+    zarr.save(zarr_path, np.arange(1000), np.arange(1000, 0, -1))
+    mkpaths(zarr_path, "a/b/c/d/e/f/g.txt")
+    zf = dandi_file(zarr_path)
+    assert zf.get_validation_errors() == []
+    mkpaths(zarr_path, "a/b/c/d/e/f/g/h.txt")
+    assert [e.id for e in zf.get_validation_errors()] == ["zarr.tree_depth_exceeded"]
+
+
+def test_validate_zarr_deep_via_excluded_dotfiles(tmp_path: Path) -> None:
+    zarr_path = tmp_path / "foo.zarr"
+    zarr.save(zarr_path, np.arange(1000), np.arange(1000, 0, -1))
+    mkpaths(zarr_path, ".git/a/b/c/d/e/f/g.txt")
+    zf = dandi_file(zarr_path)
+    assert zf.get_validation_errors() == []

--- a/dandi/utils.py
+++ b/dandi/utils.py
@@ -796,6 +796,6 @@ def is_page2_url(page1: str, page2: str) -> bool:
 def exclude_from_zarr(path: Path) -> bool:
     """
     Returns `True` if the ``path`` is a file or directory that should be
-    excluded from consideration when located at the root of a Zarr
+    excluded from consideration when located in a Zarr
     """
     return path.name in (".dandi", ".datalad", ".git", ".gitattributes", ".gitmodules")

--- a/dandi/utils.py
+++ b/dandi/utils.py
@@ -788,3 +788,11 @@ def is_page2_url(page1: str, page2: str) -> bool:
     bits2 = urlparse(page2)
     params2 = parse_qs(bits2.query)
     return (bits1[:3], params1, bits1.fragment) == (bits2[:3], params2, bits2.fragment)
+
+
+def exclude_from_zarr(path: Path) -> bool:
+    """
+    Returns `True` if the ``path`` is a file or directory that should be
+    excluded from consideration when located at the root of a Zarr
+    """
+    return path.name in (".dandi", ".datalad", ".git", ".gitattributes", ".gitmodules")

--- a/dandi/utils.py
+++ b/dandi/utils.py
@@ -356,7 +356,9 @@ def find_files(
                     yield p
 
 
-def list_paths(dirpath: Union[str, Path], dirs: bool = False) -> List[Path]:
+def list_paths(
+    dirpath: Union[str, Path], dirs: bool = False, exclude_vcs: bool = True
+) -> List[Path]:
     return sorted(
         map(
             Path,
@@ -366,6 +368,7 @@ def list_paths(dirpath: Union[str, Path], dirs: bool = False) -> List[Path]:
                 dirs=dirs,
                 exclude_dotfiles=False,
                 exclude_dotdirs=False,
+                exclude_vcs=exclude_vcs,
             ),
         )
     )


### PR DESCRIPTION
Closes #1146.

To do:

- [x] Exclude dotfiles when uploading a Zarr
- [x] Exclude dotfiles when downloading a Zarr
- [x] Exclude dotfiles when determining whether a Zarr is empty
- [x] Exclude dotfiles when determining whether a Zarr has exceeded the maximum depth
- [x] Investigate expanding the exclusion to special dotfiles at all levels, rather than just at the root