### PR TITLE
Fixed logic and commented a temporarily broken BIDS (lacking README) dataset

### DIFF
--- a/dandi/tests/fixtures.py
+++ b/dandi/tests/fixtures.py
@@ -42,7 +42,9 @@ lgr = get_logger()
 BIDS_TESTDATA_SELECTION = [
     "asl003",
     "eeg_cbm",
-    "hcp_example_bids",
+    # uncomment once upstream releases fixed spec:
+    # https://github.com/bids-standard/bids-specification/pull/1346#event-7696972438
+    # "hcp_example_bids",
     "micr_SEMzarr",
     "micr_SPIM",
     "pet003",

--- a/dandi/tests/test_validate.py
+++ b/dandi/tests/test_validate.py
@@ -15,7 +15,7 @@ def test_validate_bids(bids_examples, tmp_path, dataset):
     selected_dataset = os.path.join(bids_examples, dataset)
     validation_result = validate_bids(selected_dataset, report=True)
     for i in validation_result:
-        assert not hasattr(i, "severtiy")
+        assert i.severity is None
 
 
 def test_report_path(bids_examples, tmp_path):


### PR DESCRIPTION
Error [fixed upstream](https://github.com/bids-standard/bids-specification/pull/1346#event-7696972438) but it was the specification schema rather than the example data which was broken, so we won't have access to it until the new release; removing test dataset from whitelist until then.