### PR TITLE
Use cached namespace validation

### DIFF
--- a/dandi/pynwb_utils.py
+++ b/dandi/pynwb_utils.py
@@ -341,21 +341,21 @@ def validate(
         else:  # Fallback if an older version
             with pynwb.NWBHDF5IO(path=path, mode="r", load_namespaces=True) as reader:
                 error_outputs = pynwb.validate(io=reader)
-                # TODO: return ValidationResult structs
-                for error_output in error_outputs:
-                    errors.append(
-                        ValidationResult(
-                            origin=ValidationOrigin(
-                                name="pynwb",
-                                version=pynwb.__version__,
-                            ),
-                            severity=Severity.WARNING,
-                            id=f"pywnb.{error_output}",
-                            scope=Scope.FILE,
-                            path=Path(path),
-                            message="Failed to validate.",
-                        )
-                    )
+        # TODO: return ValidationResult structs
+        for error_output in error_outputs:
+            errors.append(
+                ValidationResult(
+                    origin=ValidationOrigin(
+                        name="pynwb",
+                        version=pynwb.__version__,
+                    ),
+                    severity=Severity.WARNING,
+                    id=f"pywnb.{error_output}",
+                    scope=Scope.FILE,
+                    path=Path(path),
+                    message="Failed to validate.",
+                )
+            )
     except Exception as exc:
         if devel_debug:
             raise

--- a/dandi/pynwb_utils.py
+++ b/dandi/pynwb_utils.py
@@ -10,6 +10,7 @@ import dandischema
 from fscacher import PersistentCache
 import h5py
 import hdmf
+from packaging.version import Version
 import pynwb
 from pynwb import NWBHDF5IO
 import semantic_version

--- a/dandi/pynwb_utils.py
+++ b/dandi/pynwb_utils.py
@@ -335,23 +335,27 @@ def validate(
     path = str(path)  # Might come in as pathlib's PATH
     errors: List[ValidationResult] = []
     try:
-        with pynwb.NWBHDF5IO(path, "r", load_namespaces=True) as reader:
-            error_outputs = pynwb.validate(reader)
-            # TODO: return ValidationResult structs
-            for error_output in error_outputs:
-                errors.append(
-                    ValidationResult(
-                        origin=ValidationOrigin(
-                            name="pynwb",
-                            version=pynwb.__version__,
-                        ),
-                        severity=Severity.WARNING,
-                        id=f"pywnb.{error_output}",
-                        scope=Scope.FILE,
-                        path=Path(path),
-                        message="Failed to validate.",
+        if Version(pynwb.__version__) >= Version("2.2.0"):  # Use cached namespace feature
+            # argument get_cached_namespaces is True by default
+            error_outputs, _ = pynwb.validate(paths=[path])
+        else:  # Fallback if an older version
+            with pynwb.NWBHDF5IO(path=path, mode="r", load_namespaces=True) as reader:
+                error_outputs = pynwb.validate(io=reader)
+                # TODO: return ValidationResult structs
+                for error_output in error_outputs:
+                    errors.append(
+                        ValidationResult(
+                            origin=ValidationOrigin(
+                                name="pynwb",
+                                version=pynwb.__version__,
+                            ),
+                            severity=Severity.WARNING,
+                            id=f"pywnb.{error_output}",
+                            scope=Scope.FILE,
+                            path=Path(path),
+                            message="Failed to validate.",
+                        )
                     )
-                )
     except Exception as exc:
         if devel_debug:
             raise


### PR DESCRIPTION
Fixes https://github.com/dandi/dandi-cli/issues/917

Which came from https://github.com/dandi/helpdesk/discussions/43

Replaces https://github.com/dandi/dandi-cli/pull/1036

Newest version of PyNWB supports validation against cached namespaces (and indeed this is now the default).

I've updated the usage here in a minimal way to both support older PyNWB versions (my other thought was to bump the version in the `setup.cfg`, but IDK what your policy or view is on that) that do not offer this feature as well as the newest version that supports it as a simple adjustment to the way the `pynwb.validate` function is called.