### PR TITLE
Remove Parameters description from docstring used by click

### DIFF
--- a/dandi/cli/cmd_validate.py
+++ b/dandi/cli/cmd_validate.py
@@ -87,12 +87,6 @@ def validate(
     """Validate files for NWB and DANDI compliance.
 
     Exits with non-0 exit code if any file is not compliant.
-
-    Parameters
-    ----------
-
-    grouping : str, optional
-        A string which is either "", "error", or "path" — "error" not yet implemented.
     """
     from ..pynwb_utils import ignore_benign_pynwb_warnings
     from ..validate import validate as validate_


### PR DESCRIPTION
With that numpy style Parameters --help looks ugly and duplicates click produced help.

    ❯ dandi validate --help ecephys_tutorial.nwb
    Usage: dandi validate [OPTIONS] [PATHS]...

      Validate files for NWB and DANDI compliance.

      Exits with non-0 exit code if any file is not compliant.

      Parameters ----------

      grouping : str, optional     A string which is either "", "error", or "path"
      — "error" not yet implemented.

    Options:
      -g, --grouping [none|path]  How to group error/warning reporting.
      --help                      Show this message and exit.

I remember asking for this change but it was missed.