### PR TITLE
Merging validation functions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,42 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  schedule:
+    - cron: "31 5 * * 5"
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ python ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+          queries: +security-and-quality
+          config-file: codeql.yml
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 0.48.0 (Mon Dec 19 2022)
+
+#### 🚀 Enhancement
+
+- Update client for change in Zarr entries API [#1175](https://github.com/dandi/dandi-cli/pull/1175) ([@jwodder](https://github.com/jwodder))
+
+#### Authors: 1
+
+- John T. Wodder II ([@jwodder](https://github.com/jwodder))
+
+---
+
 # 0.47.0 (Mon Dec 19 2022)
 
 #### 🚀 Enhancement

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,51 @@
+# 0.47.0 (Mon Dec 19 2022)
+
+#### 🚀 Enhancement
+
+- Add validation of filepaths for non-BIDS NWB assets [#1173](https://github.com/dandi/dandi-cli/pull/1173) ([@jwodder](https://github.com/jwodder))
+- Exclude special dotfiles from Zarrs [#1147](https://github.com/dandi/dandi-cli/pull/1147) ([@jwodder](https://github.com/jwodder))
+- Structured validation results [#1104](https://github.com/dandi/dandi-cli/pull/1104) ([@jwodder](https://github.com/jwodder) [@yarikoptic](https://github.com/yarikoptic) [@TheChymera](https://github.com/TheChymera))
+
+#### 🐛 Bug Fix
+
+- Allow user to specify mandatory (if not empty) fields in organize [#1171](https://github.com/dandi/dandi-cli/pull/1171) ([@yarikoptic](https://github.com/yarikoptic) [@jwodder](https://github.com/jwodder))
+- BF: convert str errors from checking nwb version into proper ValidationResult [#1174](https://github.com/dandi/dandi-cli/pull/1174) ([@yarikoptic](https://github.com/yarikoptic))
+- Tests for `ls` reinstated, underlying function fixed, support for ZARR-BIDS files added. [#1164](https://github.com/dandi/dandi-cli/pull/1164) ([@TheChymera](https://github.com/TheChymera) [@jwodder](https://github.com/jwodder))
+- Add CodeQL workflow for GitHub code scanning and fix few bugs it detected [#1165](https://github.com/dandi/dandi-cli/pull/1165) ([@lgtm-migrator](https://github.com/lgtm-migrator) [@jwodder](https://github.com/jwodder) [@lgtm-com[bot]](https://github.com/lgtm-com[bot]))
+- Corrected reporting function logic to complete group message variable [#1166](https://github.com/dandi/dandi-cli/pull/1166) ([@TheChymera](https://github.com/TheChymera))
+- Renamed failing test, added prospective use case for NWBI warning. [#1162](https://github.com/dandi/dandi-cli/pull/1162) ([@TheChymera](https://github.com/TheChymera))
+- Use cached namespace validation [#1149](https://github.com/dandi/dandi-cli/pull/1149) ([@CodyCBakerPhD](https://github.com/CodyCBakerPhD))
+
+#### 🏠 Internal
+
+- Make `list_paths()` include dotfiles [#1142](https://github.com/dandi/dandi-cli/pull/1142) ([@jwodder](https://github.com/jwodder))
+
+#### 📝 Documentation
+
+- dandi-cli readme edit [#1170](https://github.com/dandi/dandi-cli/pull/1170) ([@melster1010](https://github.com/melster1010))
+- Remove Parameters description from docstring used by click [#1150](https://github.com/dandi/dandi-cli/pull/1150) ([@yarikoptic](https://github.com/yarikoptic))
+
+#### 🧪 Tests
+
+- No longer mark `test_rename_type_mismatch` as xfailing [#1161](https://github.com/dandi/dandi-cli/pull/1161) ([@jwodder](https://github.com/jwodder))
+- Fix typing error under mypy 0.990 [#1156](https://github.com/dandi/dandi-cli/pull/1156) ([@jwodder](https://github.com/jwodder))
+- Update `test_validate_nwb_path_grouping` test [#1157](https://github.com/dandi/dandi-cli/pull/1157) ([@jwodder](https://github.com/jwodder))
+- Fixed logic and commented a temporarily broken BIDS (lacking README) dataset [#1148](https://github.com/dandi/dandi-cli/pull/1148) ([@TheChymera](https://github.com/TheChymera))
+- Installing hdf5 for Python 3.10 is no longer needed [#1145](https://github.com/dandi/dandi-cli/pull/1145) ([@jwodder](https://github.com/jwodder))
+- Fix a typing issue involving the outdated `tmpdir_factory` [#1144](https://github.com/dandi/dandi-cli/pull/1144) ([@jwodder](https://github.com/jwodder))
+
+#### Authors: 7
+
+- [@lgtm-com[bot]](https://github.com/lgtm-com[bot])
+- Cody Baker ([@CodyCBakerPhD](https://github.com/CodyCBakerPhD))
+- Horea Christian ([@TheChymera](https://github.com/TheChymera))
+- John T. Wodder II ([@jwodder](https://github.com/jwodder))
+- LGTM Migrator ([@lgtm-migrator](https://github.com/lgtm-migrator))
+- Mary Elise Dedicke ([@melster1010](https://github.com/melster1010))
+- Yaroslav Halchenko ([@yarikoptic](https://github.com/yarikoptic))
+
+---
+
 # 0.46.6 (Fri Oct 21 2022)
 
 #### 🐛 Bug Fix

--- a/README.md
+++ b/README.md
@@ -6,15 +6,24 @@
 [![PyPI version fury.io](https://badge.fury.io/py/dandi.svg)](https://pypi.python.org/pypi/dandi/)
 [![Documentation Status](https://readthedocs.org/projects/dandi/badge/?version=latest)](https://dandi.readthedocs.io/en/latest/?badge=latest)
 
-This project is under heavy development.  Beware of [hidden](I-wish-we-knew) and
-[disclosed](https://github.com/dandi/dandi-cli/issues) issues, or
+The [DANDI Python client](https://pypi.org/project/dandi/) allows you to:
+
+* Download `Dandisets` and individual subject folders or files
+* Validate data to locally conform to standards
+* Organize your data locally before upload
+* Upload `Dandisets`
+* Interact with the DANDI archive's web API from Python
+* Delete data in the DANDI archive
+* Perform other auxiliary operations with data or the DANDI archive
+
+**Note**: This project is under heavy development. See [the issues log](https://github.com/dandi/dandi-cli/issues) or
 [Work-in-Progress (WiP)](https://github.com/dandi/dandi-cli/pulls).
 
 ## Installation
 
-At the moment DANDI client releases are [available from PyPI](https://pypi.org/project/dandi)
-and [conda-forge](https://anaconda.org/conda-forge/dandi).  You could
-install them in your Python (native, virtualenv, or conda) environment via
+DANDI Client releases are [available from PyPI](https://pypi.org/project/dandi)
+and [conda-forge](https://anaconda.org/conda-forge/dandi).  Install them in your Python (native, virtualenv, or 
+conda) environment via
 
     pip install dandi
 
@@ -22,13 +31,11 @@ or
 
     conda install -c conda-forge dandi
 
-if you are in a conda environment.
 
-## dandi tool
+## CLI Tool
 
-This package provides a `dandi` command line utility with a basic interface
-which should assist you in preparing and uploading your data to and/or obtaining
-data from the http://dandiarchive.org:
+This package provides a command line utility with a basic interface
+to help you prepare and upload your data to, or obtain data from, the [DANDI archive](http://dandiarchive.org):
 
 ```bash
 $> dandi
@@ -45,51 +52,85 @@ Usage: dandi [OPTIONS] COMMAND [ARGS]...
 
 Options:
   --version
-  -l, --log-level [DEBUG|INFO|WARNING|ERROR|CRITICAL]
-                                  Log level name  [default: INFO]
+ -l, --log-level [DEBUG|INFO|WARNING|ERROR|CRITICAL]
+                                  Log level (case insensitive).  May be
+                                  specified as an integer.  [default: INFO]
   --pdb                           Fall into pdb if errors out
   --help                          Show this message and exit.
 
 Commands:
-  download  Download a file or entire folder from DANDI
-  ls        List .nwb files and dandisets metadata.
-  organize  (Re)organize files according to the metadata.
-  register  Register a new dandiset in the DANDI archive
-  upload    Upload dandiset (files) to DANDI archive.
-  validate  Validate files for NWB (and DANDI) compliance.
+  delete            Delete dandisets and assets from the server.
+  digest            Calculate file digests
+  download          Download a file or entire folder from DANDI.
+  instances         List known Dandi Archive instances that the CLI can...
+  ls                List .nwb files and dandisets metadata.
+  move              Move or rename assets in a local Dandiset and/or on...
+  organize          (Re)organize files according to the metadata.
+  service-scripts   Various utility operations
+  shell-completion  Emit shell script for enabling command completion.
+  upload            Upload Dandiset files to DANDI Archive.
+  validate          Validate files for NWB and DANDI compliance.
+  validate-bids     Validate BIDS paths.
 ```
 
-Each of the commands has a set of options to alter their behavior.  Please run
-`dandi COMMAND --help` to get more information, e.g.
+Each of the commands has a set of options to alter its behavior.  Run
+`dandi COMMAND --help` to get more information:
 
 ```
 $> dandi ls --help
-Usage: dandi ls [OPTIONS] [PATHS]...
+Usage: dandi ls [OPTIONS] PATH|URL
 
-  List .nwb files metadata
+  List .nwb files and dandisets metadata.
+
+  The arguments may be either resource identifiers or paths to local
+  files/directories.
+
+  Accepted resource identifier patterns:
+   - DANDI:<dandiset id>[/<version>]
+   - https://dandiarchive.org/...
+   - https://identifiers.org/DANDI:<dandiset id>[/<version id>] (<version id> cannot be 'draft')
+   - https://<server>[/api]/[#/]dandiset/<dandiset id>[/<version>][/files[?location=<path>]]
+   - https://*dandiarchive-org.netflify.app/...
+   - https://<server>[/api]/dandisets/<dandiset id>[/versions[/<version>]]
+   - https://<server>[/api]/assets/<asset id>[/download]
+   - https://<server>[/api]/dandisets/<dandiset id>/versions/<version>/assets/<asset id>[/download]
+   - https://<server>[/api]/dandisets/<dandiset id>/versions/<version>/assets/?path=<path>
+   - dandi://<instance name>/<dandiset id>[@<version>][/<path>]
+   - https://<server>/...
 
 Options:
   -F, --fields TEXT               Comma-separated list of fields to display.
                                   An empty value to trigger a list of
                                   available fields to be printed out
-  -f, --format [auto|pyout|json|json_pp|yaml]
+  -f, --format [auto|pyout|json|json_pp|json_lines|yaml]
                                   Choose the format/frontend for output. If
                                   'auto', 'pyout' will be used in case of
                                   multiple files, and 'yaml' for a single
                                   file.
+  -r, --recursive                 Recurse into content of
+                                  dandisets/directories. Only .nwb files will
+                                  be considered.
+  -J, --jobs INTEGER              Number of parallel download jobs.  [default:
+                                  6]
+  --metadata [api|all|assets]
+  --schema VERSION                Convert metadata to new schema version
   --help                          Show this message and exit.
 ```
 
-See [DANDI Handbook](https://www.dandiarchive.org/handbook/10_using_dandi/)
-for examples on how to use this client in various use cases.
 
-## Development/contributing
+## Third-party Components
 
-Please see [DEVELOPMENT.md](./DEVELOPMENT.md) file.
-
-## 3rd party components included
-
-### dandi/tests/skip.py
-
-From https://github.com/ReproNim/reproman, as of v0.2.1-40-gf4f026d
+**dandi/tests/skip.py** -- from https://github.com/ReproNim/reproman, as of v0.2.1-40-gf4f026d
 Copyright (c) 2016-2020  ReproMan Team
+
+## Resources
+
+* To learn how to interact with the DANDI archive and for examples on how to use the DANDI Client in various use cases,
+see [the handbook](https://www.dandiarchive.org/handbook/).
+
+* To get help:
+  - ask a question: https://github.com/dandi/helpdesk/discussions
+  - file a feature request or bug report: https://github.com/dandi/helpdesk/issues/new/choose
+  - contact the DANDI team: help@dandiarchive.org
+
+* To understand how to contribute to the dandi-cli repository, see the [DEVELOPMENT.md](./DEVELOPMENT.md) file.

--- a/codeql.yml
+++ b/codeql.yml
@@ -1,0 +1,4 @@
+paths-ignore:
+  - dandi/_version.py
+  - dandi/due.py
+  - versioneer.py

--- a/dandi/cli/cmd_ls.py
+++ b/dandi/cli/cmd_ls.py
@@ -5,6 +5,7 @@ import os.path as op
 import click
 
 from .base import devel_option, lgr, map_to_click_exceptions
+from ..consts import ZARR_EXTENSIONS, metadata_all_fields
 from ..dandiarchive import DandisetURL, _dandi_url_parser, parse_dandi_url
 from ..misctypes import Digest
 from ..utils import is_url
@@ -92,7 +93,6 @@ def ls(
         PYOUTFormatter,
         YAMLFormatter,
     )
-    from ..consts import metadata_all_fields
 
     # TODO: avoid
     from ..support.pyout import PYOUT_SHORT_NAMES_rev
@@ -358,7 +358,20 @@ def get_metadata_ls(
                             digest=Digest.dandi_etag(digest),
                         ).json_dict()
                 else:
-                    rec = get_metadata(path)
+                    if path.endswith(tuple(ZARR_EXTENSIONS)):
+                        if use_fake_digest:
+                            digest = "0" * 32 + "-0--0"
+                        else:
+                            lgr.info("Calculating digest for %s", path)
+                            digest = get_digest(path, digest="zarr-checksum")
+                        rec = get_metadata(path, Digest.dandi_zarr(digest))
+                    else:
+                        if use_fake_digest:
+                            digest = "0" * 32 + "-1"
+                        else:
+                            lgr.info("Calculating digest for %s", path)
+                            digest = get_digest(path, digest="dandi-etag")
+                        rec = get_metadata(path, Digest.dandi_etag(digest))
             except Exception as exc:
                 _add_exc_error(path, rec, errors, exc)
             if flatten:

--- a/dandi/cli/cmd_organize.py
+++ b/dandi/cli/cmd_organize.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import click
 
 from .base import dandiset_path_option, devel_debug_option, map_to_click_exceptions
-from ..consts import file_operation_modes
+from ..consts import dandi_layout_fields, file_operation_modes
 
 
 @click.command()
@@ -46,11 +48,22 @@ from ..consts import file_operation_modes
     default=None,
     help="How to relocate video files referenced by NWB files",
 )
+@click.option(
+    "--required-field",
+    "required_fields",
+    type=click.Choice(list(dandi_layout_fields)),
+    multiple=True,
+    help=(
+        "Force a given field to be included in the organized filename of any"
+        " file for which it is nonempty.  Can be specified multiple times."
+    ),
+)
 @click.argument("paths", nargs=-1, type=click.Path(exists=True))
 @devel_debug_option()
 @map_to_click_exceptions
 def organize(
     paths,
+    required_fields,
     dandiset_path=None,
     invalid="fail",
     files_mode="auto",
@@ -101,4 +114,5 @@ def organize(
         devel_debug=devel_debug,
         update_external_file_paths=update_external_file_paths,
         media_files_mode=media_files_mode,
+        required_fields=required_fields,
     )

--- a/dandi/cli/cmd_validate.py
+++ b/dandi/cli/cmd_validate.py
@@ -11,11 +11,7 @@ from ..validate_types import Severity
 
 @click.command()
 @click.option(
-    "--schema", help="Validate against new BIDS schema version.", metavar="VERSION"
-)
-@click.option(
-    "--report-path",
-    help="Write report under path, this option implies `--report/-r`.",
+    "--bids-schema", help="Validate against new BIDS schema version.", metavar="VERSION"
 )
 @click.option(
     "--report",
@@ -24,42 +20,9 @@ from ..validate_types import Severity
     help="Whether to write a report under a unique path in the DANDI log directory.",
 )
 @click.option(
-    "--grouping",
-    "-g",
-    help="How to group error/warning reporting.",
-    type=click.Choice(["none", "path"], case_sensitive=False),
-    default="none",
+    "--report-path",
+    help="Write report under path, this option implies `--report/-r`.",
 )
-@click.argument("paths", nargs=-1, type=click.Path(exists=True, dir_okay=True))
-@map_to_click_exceptions
-def validate_bids(
-    paths,
-    schema,
-    report,
-    report_path,
-    grouping="none",
-):
-    """Validate BIDS paths.
-
-    Notes
-    -----
-    Used from bash, eg:
-        dandi validate-bids /my/path
-    """
-
-    from ..validate import validate_bids as validate_bids_
-
-    validator_result = validate_bids_(  # Controller
-        *paths,
-        report=report,
-        report_path=report_path,
-        schema_version=schema,
-    )
-
-    _process_issues(validator_result, grouping)
-
-
-@click.command()
 @devel_option("--schema", help="Validate against new schema version", metavar="VERSION")
 @devel_option(
     "--allow-any-path",
@@ -79,6 +42,9 @@ def validate_bids(
 @map_to_click_exceptions
 def validate(
     paths,
+    bids_schema,
+    report,
+    report_path,
     schema=None,
     devel_debug=False,
     allow_any_path=False,
@@ -108,9 +74,16 @@ def validate(
     validator_result = validate_(
         *paths,
         schema_version=schema,
+        bids_schema_version=bids_schema,
         devel_debug=devel_debug,
         allow_any_path=allow_any_path,
     )
+    from collections import Counter
+
+    # for some reason we get the same error repeated over and over again, probably related
+    # to different behaviour of yield and return
+    print(Counter([i.id for i in validator_result]))
+    raise
 
     _process_issues(validator_result, grouping)
 

--- a/dandi/cli/cmd_validate.py
+++ b/dandi/cli/cmd_validate.py
@@ -199,14 +199,15 @@ def display_errors(
             f"{errors[0]}: detected in {pluralize(len(purviews), 'purviews')}"
         )
         if len(set(messages)) == 1:
-            error_message += f" — {messages[0]}."
+            group_message += f" — {messages[0]}."
             click.secho(group_message, fg=fg)
             for purview, severity in zip(purviews, severities):
                 error_message = f"  {purview}"
                 fg = _get_severity_color([severity])
                 click.secho(error_message, fg=fg)
         else:
-            error_message += "."
+            group_message += "."
+            click.secho(group_message, fg=fg)
             for purview, severity, message in zip(purviews, severities, messages):
                 error_message = f"  {purview} — {message}"
                 fg = _get_severity_color([severity])

--- a/dandi/cli/command.py
+++ b/dandi/cli/command.py
@@ -148,7 +148,7 @@ from .cmd_organize import organize  # noqa: E402
 from .cmd_service_scripts import service_scripts  # noqa: E402
 from .cmd_shell_completion import shell_completion  # noqa: E402
 from .cmd_upload import upload  # noqa: E402
-from .cmd_validate import validate, validate_bids  # noqa: E402
+from .cmd_validate import validate  # noqa: E402
 
 __all_commands__ = (
     delete,
@@ -162,7 +162,6 @@ __all_commands__ = (
     shell_completion,
     upload,
     validate,
-    validate_bids,
 )
 
 for cmd in __all_commands__:

--- a/dandi/cli/tests/test_cmd_ls.py
+++ b/dandi/cli/tests/test_cmd_ls.py
@@ -49,8 +49,16 @@ def test_smoke(simple1_nwb_metadata, simple1_nwb, format):
         assert metadata[f] == simple1_nwb_metadata[f]
 
 
+def test_ls_nwb_file(simple2_nwb):
+    bids_file_path = "simple2.nwb"
+    bids_file_path = os.path.join(simple2_nwb, bids_file_path)
+    r = CliRunner().invoke(ls, ["-f", "yaml", bids_file_path])
+    assert r.exit_code == 0, r.output
+    data = yaml_load(r.stdout, "safe")
+    assert len(data) == 1
+
+
 @mark.skipif_no_network
-@pytest.mark.xfail(reason="https://github.com/dandi/dandi-cli/issues/1097")
 def test_ls_bids_file(bids_examples):
     bids_file_path = "asl003/sub-Sub1/anat/sub-Sub1_T1w.nii.gz"
     bids_file_path = os.path.join(bids_examples, bids_file_path)
@@ -58,7 +66,20 @@ def test_ls_bids_file(bids_examples):
     assert r.exit_code == 0, r.output
     data = yaml_load(r.stdout, "safe")
     assert len(data) == 1
-    assert data[0]["subject_id"] == "Sub1"
+    assert data[0]["identifier"] == "Sub1"
+
+
+@mark.skipif_no_network
+def test_ls_zarrbids_file(bids_examples):
+    bids_file_path = (
+        "micr_SEMzarr/sub-01/ses-01/micr/sub-01_ses-01_sample-A_SPIM.ome.zarr"
+    )
+    bids_file_path = os.path.join(bids_examples, bids_file_path)
+    r = CliRunner().invoke(ls, ["-f", "yaml", bids_file_path])
+    assert r.exit_code == 0, r.output
+    data = yaml_load(r.stdout, "safe")
+    assert len(data) == 1
+    assert data[0]["identifier"] == "01"
 
 
 @mark.skipif_no_network

--- a/dandi/cli/tests/test_cmd_validate.py
+++ b/dandi/cli/tests/test_cmd_validate.py
@@ -1,5 +1,6 @@
 import json
 import os
+from pathlib import Path
 
 from click.testing import CliRunner
 import pytest
@@ -50,17 +51,16 @@ def test_validate_bids_grouping_error(bids_error_examples, dataset="invalid_asl0
     assert dataset in r.output
 
 
-def test_validate_nwb_path_grouping(simple4_nwb):
+def test_validate_nwb_path_grouping(organized_nwb_dir3: Path) -> None:
     """
-    This is currently a placeholder test, and should be updated once we have paths with
-    multiple errors for which grouping functionality can actually be tested.
+    This is currently a placeholder test and should be updated once we have
+    paths with multiple errors for which grouping functionality can actually be
+    tested.
     """
-
-    r = CliRunner().invoke(validate, ["--grouping=path", simple4_nwb])
+    r = CliRunner().invoke(validate, ["--grouping=path", str(organized_nwb_dir3)])
     assert r.exit_code == 0
-
     # Does it give required warnings for required path?
-    assert simple4_nwb in r.output
+    assert str(organized_nwb_dir3 / "sub-mouse001" / "sub-mouse001.nwb") in r.output
     assert "NWBI.check_data_orientation" in r.output
 
 

--- a/dandi/cli/tests/test_cmd_validate.py
+++ b/dandi/cli/tests/test_cmd_validate.py
@@ -24,10 +24,21 @@ def test_validate_bids_error(bids_error_examples, dataset):
         assert key in r.output
 
 
+def test_validate_nwb_error(simple3_nwb):
+    """
+    Do we fail on critical NWB validation errors?
+    """
+
+    r = CliRunner().invoke(validate, [simple3_nwb])
+    # does it fail? as per:
+    # https://github.com/dandi/dandi-cli/pull/1157#issuecomment-1312546812
+    assert r.exit_code != 0
+
+
 def test_validate_bids_grouping_error(bids_error_examples, dataset="invalid_asl003"):
     """
     This is currently a placeholder test, and should be updated once we have paths with
-    multiple errors.
+    multiple errors for which grouping functionality can actually be tested.
     """
 
     dataset = os.path.join(bids_error_examples, dataset)
@@ -39,18 +50,18 @@ def test_validate_bids_grouping_error(bids_error_examples, dataset="invalid_asl0
     assert dataset in r.output
 
 
-def test_validate_nwb_path_grouping(simple3_nwb):
+def test_validate_nwb_path_grouping(simple4_nwb):
     """
     This is currently a placeholder test, and should be updated once we have paths with
-    multiple errors.
+    multiple errors for which grouping functionality can actually be tested.
     """
 
-    r = CliRunner().invoke(validate, ["--grouping=path", simple3_nwb])
-    assert r.exit_code != 0
+    r = CliRunner().invoke(validate, ["--grouping=path", simple4_nwb])
+    assert r.exit_code == 0
 
     # Does it give required warnings for required path?
-    assert simple3_nwb in r.output
-    assert "NWBI.check_subject_id_exists" in r.output
+    assert simple4_nwb in r.output
+    assert "NWBI.check_data_orientation" in r.output
 
 
 def test_validate_bids_error_grouping_notification(

--- a/dandi/cli/tests/test_cmd_validate.py
+++ b/dandi/cli/tests/test_cmd_validate.py
@@ -46,8 +46,7 @@ def test_validate_nwb_path_grouping(simple3_nwb):
     """
 
     r = CliRunner().invoke(validate, ["--grouping=path", simple3_nwb])
-    # Does it pass?
-    assert r.exit_code == 0
+    assert r.exit_code != 0
 
     # Does it give required warnings for required path?
     assert simple3_nwb in r.output

--- a/dandi/cli/tests/test_command.py
+++ b/dandi/cli/tests/test_command.py
@@ -46,9 +46,11 @@ def test_no_heavy_imports():
         [
             sys.executable,
             "-c",
-            "import sys; "
-            "import dandi.cli.command; "
-            "print(','.join(set(m.split('.')[0] for m in sys.modules)));",
+            (
+                "import sys; "
+                "import dandi.cli.command; "
+                "print(','.join(set(m.split('.')[0] for m in sys.modules)));"
+            ),
         ],
         env=env,
         stdout=PIPE,

--- a/dandi/cli/tests/test_command.py
+++ b/dandi/cli/tests/test_command.py
@@ -10,9 +10,9 @@ from ..command import __all_commands__, ls, validate
 
 
 @pytest.mark.parametrize("command", (ls, validate))
-def test_smoke(simple2_nwb, command):
+def test_smoke(organized_nwb_dir, command):
     runner = CliRunner()
-    r = runner.invoke(command, [simple2_nwb])
+    r = runner.invoke(command, [str(organized_nwb_dir)])
     assert r.exit_code == 0, f"Exited abnormally. out={r.stdout}"
     assert r.stdout, "There were no output whatsoever"
 

--- a/dandi/cli/tests/test_ls.py
+++ b/dandi/cli/tests/test_ls.py
@@ -91,8 +91,10 @@ def test_ls_path_url():
         [
             "-f",
             "yaml",
-            "https://api.dandiarchive.org/api/dandisets/000027/versions/draft"
-            "/assets/?path=sub-RAT123/",
+            (
+                "https://api.dandiarchive.org/api/dandisets/000027/versions/draft"
+                "/assets/?path=sub-RAT123/"
+            ),
         ],
     )
     assert r.exit_code == 0, r.output

--- a/dandi/consts.py
+++ b/dandi/consts.py
@@ -170,3 +170,31 @@ ZARR_UPLOAD_BATCH_SIZE = 255
 ZARR_DELETE_BATCH_SIZE = 100
 
 BIDS_DATASET_DESCRIPTION = "dataset_description.json"
+
+# Fields which would be used to compose organized filenames
+# TODO: add full description into command --help etc
+# Order matters!
+dandi_layout_fields = {
+    # "type" - if not defined, additional
+    "subject_id": {"format": "sub-{}", "type": "required"},
+    "session_id": {"format": "_ses-{}"},
+    "tissue_sample_id": {"format": "_tis-{}"},
+    "slice_id": {"format": "_slice-{}"},
+    "cell_id": {"format": "_cell-{}"},
+    # disambiguation ones
+    "probe_ids": {"format": "_probe-{}", "type": "disambiguation"},
+    "obj_id": {
+        "format": "_obj-{}",
+        "type": "disambiguation",
+    },  # will be not id, but checksum of it to shorten
+    # "session_description"
+    "modalities": {"format": "_{}", "type": "required_if_not_empty"},
+    "extension": {"format": "{}", "type": "required"},
+}
+# verify no typos
+assert {v.get("type", "additional") for v in dandi_layout_fields.values()} == {
+    "required",
+    "disambiguation",
+    "additional",
+    "required_if_not_empty",
+}

--- a/dandi/dandiapi.py
+++ b/dandi/dandiapi.py
@@ -1250,7 +1250,7 @@ class BaseRemoteAsset(ABC, APIBase):
 
     @classmethod
     def from_base_data(
-        self,
+        cls,
         client: "DandiAPIClient",
         data: Dict[str, Any],
         metadata: Optional[Dict[str, Any]] = None,

--- a/dandi/download.py
+++ b/dandi/download.py
@@ -838,15 +838,14 @@ def _download_zarr(
             digests[path] = d
 
     for entry in entries:
-        etag = entry.get_digest()
+        etag = entry.digest
         assert etag.algorithm is DigestType.md5
-        stat = entry.stat()
         download_gens[str(entry)] = _download_file(
             entry.get_download_file_iter(),
             op.join(download_path, op.normpath(str(entry))),
             toplevel_path=toplevel_path,
-            size=stat.size,
-            mtime=stat.modified,
+            size=entry.size,
+            mtime=entry.modified,
             existing=existing,
             digests={"md5": etag.value},
             lock=lock,

--- a/dandi/files/__init__.py
+++ b/dandi/files/__init__.py
@@ -175,18 +175,19 @@ def dandi_file(
     """
     filepath = Path(filepath)
     if dandiset_path is not None:
+        dandiset_path = Path(dandiset_path)
         path = filepath.relative_to(dandiset_path).as_posix()
         if path == ".":
             raise ValueError("Dandi file path cannot equal Dandiset path")
     else:
         path = filepath.name
     if filepath.is_file() and path == dandiset_metadata_file:
-        return DandisetMetadataFile(filepath=filepath)
+        return DandisetMetadataFile(filepath=filepath, dandiset_path=dandiset_path)
     if bids_dataset_description is None:
         factory = DandiFileFactory()
     else:
         factory = BIDSFileFactory(bids_dataset_description)
-    return factory(filepath, path)
+    return factory(filepath, path, dandiset_path)
 
 
 def find_bids_dataset_description(

--- a/dandi/files/_private.py
+++ b/dandi/files/_private.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
+from typing import ClassVar
 import weakref
 
 from dandi.consts import (
@@ -14,6 +16,7 @@ from dandi.exceptions import UnknownAssetError
 
 from .bases import DandiFile, GenericAsset, LocalAsset, NWBAsset, VideoAsset
 from .bids import (
+    BIDSAsset,
     BIDSDatasetDescriptionAsset,
     GenericBIDSAsset,
     NWBBIDSAsset,
@@ -54,7 +57,7 @@ class DandiFileType(Enum):
 class DandiFileFactory:
     """:meta private:"""
 
-    CLASSES: dict[DandiFileType, type[LocalAsset]] = {
+    CLASSES: ClassVar[Mapping[DandiFileType, type[LocalAsset]]] = {
         DandiFileType.NWB: NWBAsset,
         DandiFileType.ZARR: ZarrAsset,
         DandiFileType.VIDEO: VideoAsset,
@@ -74,7 +77,7 @@ class BIDSFileFactory(DandiFileFactory):
 
     bids_dataset_description: BIDSDatasetDescriptionAsset
 
-    CLASSES = {
+    CLASSES: ClassVar[Mapping[DandiFileType, type[BIDSAsset]]] = {
         DandiFileType.NWB: NWBBIDSAsset,
         DandiFileType.ZARR: ZarrBIDSAsset,
         DandiFileType.VIDEO: GenericBIDSAsset,

--- a/dandi/files/bases.py
+++ b/dandi/files/bases.py
@@ -505,12 +505,12 @@ class NWBAsset(LocalFileAsset):
                     nwbfile_path=self.filepath,
                     skip_validate=True,
                     config=load_config(filepath_or_keyword="dandi"),
-                    importance_threshold=Importance.CRITICAL,
+                    importance_threshold=Importance.BEST_PRACTICE_VIOLATION,
+                    # we might want to switch to a lower threshold once nwbinspector
+                    # upstream reporting issues are clarified:
+                    # https://github.com/dandi/dandi-cli/pull/1162#issuecomment-1322238896
+                    # importance_threshold=Importance.BEST_PRACTICE_SUGGESTION,
                 ):
-                    # unfortunate name collision; the InspectorMessage.severity is used only for
-                    # minor ordering of final report - will have to remove the
-                    # `importance_threshold` currently used to filter DANDI-level CRITICAL
-                    # evaluations as errors vs. validation results
                     severity = NWBI_IMPORTANCE_TO_DANDI_SEVERITY[error.importance.name]
                     kw: Any = {}
                     if error.location:

--- a/dandi/files/bids.py
+++ b/dandi/files/bids.py
@@ -61,7 +61,7 @@ class BIDSDatasetDescriptionAsset(LocalFileAsset):
         """
         The directory on the filesystem in which the BIDS dataset is located
         """
-        return self.filepath.parent.resolve()
+        return self.filepath.parent.absolute()
 
     def _validate(self) -> None:
         with self._lock:
@@ -196,7 +196,7 @@ class BIDSAsset(LocalFileAsset):
         """
         ``/``-separated path to the asset from the root of the BIDS dataset
         """
-        return self.filepath.resolve().relative_to(self.bids_root).as_posix()
+        return self.filepath.absolute().relative_to(self.bids_root).as_posix()
 
     def get_validation_errors(
         self,

--- a/dandi/files/bids.py
+++ b/dandi/files/bids.py
@@ -13,7 +13,7 @@ from dandischema.models import BareAsset
 from .bases import GenericAsset, LocalFileAsset, NWBAsset
 from .zarr import ZarrAsset
 from ..consts import ZARR_MIME_TYPE
-from ..metadata import add_common_metadata, prepare_metadata
+from ..metadata import add_common_metadata
 from ..misctypes import Digest
 from ..validate_types import ValidationResult
 
@@ -102,6 +102,8 @@ class BIDSDatasetDescriptionAsset(LocalFileAsset):
                         print(result)
                         print("jj")
                         assert result.path
+                        print(result.path)
+                        print("kk1")
                         bids_path = result.path.relative_to(self.bids_root).as_posix()
                         self._asset_errors[bids_path].append(result)
                     elif result.id in BIDS_DATASET_ERRORS:
@@ -117,12 +119,6 @@ class BIDSDatasetDescriptionAsset(LocalFileAsset):
                         print(result.path)
                         print("kk1")
                         bids_path = result.path.relative_to(self.bids_root).as_posix()
-                        print("kk2")
-                        assert result.metadata is not None
-                        print("kk3")
-                        self._asset_metadata[bids_path] = prepare_metadata(
-                            result.metadata
-                        )
                         self._bids_version = result.origin.bids_version
                         print("kk4")
                 print("..")

--- a/dandi/files/bids.py
+++ b/dandi/files/bids.py
@@ -61,7 +61,7 @@ class BIDSDatasetDescriptionAsset(LocalFileAsset):
         """
         The directory on the filesystem in which the BIDS dataset is located
         """
-        return self.filepath.parent
+        return self.filepath.parent.resolve()
 
     def _validate(self) -> None:
         with self._lock:
@@ -94,21 +94,38 @@ class BIDSDatasetDescriptionAsset(LocalFileAsset):
                     list
                 )
                 self._asset_metadata = defaultdict(dict)
+                print("..")
                 for result in results:
+                    print(result)
                     if result.id in BIDS_ASSET_ERRORS:
+                        print("jj")
+                        print(result)
+                        print("jj")
                         assert result.path
                         bids_path = result.path.relative_to(self.bids_root).as_posix()
                         self._asset_errors[bids_path].append(result)
                     elif result.id in BIDS_DATASET_ERRORS:
+                        print("ii")
+                        print(result)
                         self._dataset_errors.append(result)
+                        print("ii")
                     elif result.id == "BIDS.MATCH":
+                        print("kk")
+                        print(result)
+                        print("kk")
                         assert result.path
+                        print(result.path)
+                        print("kk1")
                         bids_path = result.path.relative_to(self.bids_root).as_posix()
+                        print("kk2")
                         assert result.metadata is not None
+                        print("kk3")
                         self._asset_metadata[bids_path] = prepare_metadata(
                             result.metadata
                         )
                         self._bids_version = result.origin.bids_version
+                        print("kk4")
+                print("..")
 
     def get_asset_errors(self, asset: BIDSAsset) -> list[ValidationResult]:
         """:meta private:"""
@@ -179,7 +196,7 @@ class BIDSAsset(LocalFileAsset):
         """
         ``/``-separated path to the asset from the root of the BIDS dataset
         """
-        return self.filepath.relative_to(self.bids_root).as_posix()
+        return self.filepath.resolve().relative_to(self.bids_root).as_posix()
 
     def get_validation_errors(
         self,

--- a/dandi/organize.py
+++ b/dandi/organize.py
@@ -2,19 +2,21 @@
 ATM primarily a sandbox for some functionality for  dandi organize
 """
 
+from __future__ import annotations
+
 import binascii
 from collections import Counter
 from copy import deepcopy
 import os
 import os.path as op
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 import re
 from typing import List
 import uuid
 
 import numpy as np
 
-from . import get_logger
+from . import __version__, get_logger
 from .dandiset import Dandiset
 from .exceptions import OrganizeImpossibleError
 from .metadata import get_metadata
@@ -36,6 +38,7 @@ from .utils import (
     move_file,
     yaml_load,
 )
+from .validate_types import Scope, Severity, ValidationOrigin, ValidationResult
 
 lgr = get_logger()
 
@@ -1025,3 +1028,79 @@ def organize(
         msg_(" %d invalid not considered.", skip_invalid),
         dandiset_path.rstrip("/"),
     )
+
+
+LABELREGEX = r"[^_*\\/<>:|\"'?%@;.]+"
+ORGANIZED_FILENAME_REGEX = (
+    rf"sub-{LABELREGEX}"
+    rf"(_ses-{LABELREGEX})?"
+    rf"(_(tis|slice|cell|probe|obj)-{LABELREGEX})*"
+    r"(_[a-z]+(\+[a-z]+)*)?"
+    r"\.nwb"
+)
+ORGANIZED_FOLDER_REGEX = rf"sub-{LABELREGEX}"
+
+
+def validate_organized_path(
+    asset_path: str, filepath: Path, dandiset_path: Path
+) -> list[ValidationResult]:
+    """
+    :param str asset_path:
+        The forward-slash-separated path to the asset within its local Dandiset
+        (i.e., relative to the Dandiset's root)
+    :param pathlib.Path filepath:
+        The actual filesystem path of the asset (used to construct
+        `ValidationResult` objects)
+    :param pathlib.Path dandiset_path:
+        The path to the root of the Dandiset (used to construct
+        `ValidationResult` objects)
+    """
+    path = PurePosixPath(asset_path)
+    if path.suffix != ".nwb":
+        return []
+    errors = []
+    if not re.fullmatch(ORGANIZED_FILENAME_REGEX, path.name):
+        errors.append(
+            ValidationResult(
+                id="DANDI.NON_DANDI_FILENAME",
+                origin=ValidationOrigin(name="dandi", version=__version__),
+                severity=Severity.ERROR,
+                scope=Scope.FILE,
+                path=filepath,
+                message="Filename does not conform to Dandi standard",
+                path_regex=ORGANIZED_FILENAME_REGEX,
+                dandiset_path=dandiset_path,
+            )
+        )
+    if not (
+        len(path.parent.parts) == 1
+        and re.fullmatch(ORGANIZED_FOLDER_REGEX, str(path.parent))
+    ):
+        errors.append(
+            ValidationResult(
+                id="DANDI.NON_DANDI_FOLDERNAME",
+                origin=ValidationOrigin(name="dandi", version=__version__),
+                severity=Severity.ERROR,
+                scope=Scope.FOLDER,
+                path=filepath,
+                message="File is not in folder at root with subject name",
+                path_regex=ORGANIZED_FOLDER_REGEX,
+                dandiset_path=dandiset_path,
+            )
+        )
+    if not errors:
+        m = re.match(ORGANIZED_FOLDER_REGEX, path.name)
+        assert m
+        if str(path.parent) != m[0]:
+            errors.append(
+                ValidationResult(
+                    id="DANDI.METADATA_MISMATCH_SUBJECT",
+                    origin=ValidationOrigin(name="dandi", version=__version__),
+                    severity=Severity.ERROR,
+                    scope=Scope.FILE,
+                    path=filepath,
+                    message="Filename subject does not match folder name subject",
+                    dandiset_path=dandiset_path,
+                )
+            )
+    return errors

--- a/dandi/support/pyout.py
+++ b/dandi/support/pyout.py
@@ -36,11 +36,11 @@ def naturalsize(v):
     return humanize.naturalsize(v)
 
 
-def datefmt(v, fmt=u"%Y-%m-%d/%H:%M:%S"):
+def datefmt(v, fmt="%Y-%m-%d/%H:%M:%S"):
     if isinstance(v, datetime.datetime):
         return v.strftime(fmt)
     else:
-        time.strftime(fmt, time.localtime(v))
+        return time.strftime(fmt, time.localtime(v))
 
 
 # def empty_for_none(v):
@@ -71,8 +71,8 @@ size_style = dict(
     color=dict(
         interval=[
             [0, 1024, "blue"],
-            [1024, 1024 ** 2, "green"],
-            [1024 ** 2, None, "red"],
+            [1024, 1024**2, "green"],
+            [1024**2, None, "red"],
         ]
     ),
     aggregate=lambda x: naturalsize(sum(x)),

--- a/dandi/tests/fixtures.py
+++ b/dandi/tests/fixtures.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 import logging
 import os
 from pathlib import Path
@@ -148,6 +148,45 @@ def simple3_nwb(
         ),
         **simple1_nwb_metadata,
     )
+
+
+@pytest.fixture(scope="session")
+def simple4_nwb(
+    simple1_nwb_metadata: Dict[str, Any], tmp_path_factory: pytest.TempPathFactory
+) -> str:
+    """
+    With, subject, subject_id, species, but including data orientation ambiguity,
+    the only currently non-critical issue in the dandi schema for nwbinspector validation:
+    NWBI.check_data_orientation
+    https://github.com/NeurodataWithoutBorders/nwbinspector/blob/
+    54ac2bc7cdcb92802b9251e29f249f155fb1ff52
+    /src/nwbinspector/internal_configs/dandi.inspector_config.yaml#L10
+    """
+
+    start_time = datetime(2017, 4, 3, 11, tzinfo=timezone.utc)
+    time_series = pynwb.TimeSeries(
+        name="test_time_series",
+        unit="test_units",
+        data=np.zeros(shape=(2, 100)),
+        rate=1.0,
+    )
+
+    nwbfile = NWBFile(
+        session_description="some session",
+        identifier="NWBE4",
+        session_start_time=start_time,
+        subject=Subject(
+            subject_id="mouse001",
+            age="P1D/",
+            sex="O",
+            species="Mus musculus",
+        ),
+    )
+    nwbfile.add_acquisition(time_series)
+    filename = str(tmp_path_factory.mktemp("simple4") / "simple4.nwb")
+    with pynwb.NWBHDF5IO(filename, "w") as io:
+        io.write(nwbfile, cache_spec=False)
+    return filename
 
 
 @pytest.fixture(scope="session")

--- a/dandi/tests/fixtures.py
+++ b/dandi/tests/fixtures.py
@@ -150,11 +150,9 @@ def simple3_nwb(
 
 
 @pytest.fixture(scope="session")
-def simple4_nwb(
-    simple1_nwb_metadata: Dict[str, Any], tmp_path_factory: pytest.TempPathFactory
-) -> str:
+def simple4_nwb(tmp_path_factory: pytest.TempPathFactory) -> str:
     """
-    With, subject, subject_id, species, but including data orientation ambiguity,
+    With subject, subject_id, species, but including data orientation ambiguity,
     the only currently non-critical issue in the dandi schema for nwbinspector validation:
     NWBI.check_data_orientation
     https://github.com/NeurodataWithoutBorders/nwbinspector/blob/
@@ -226,6 +224,19 @@ def organized_nwb_dir2(
     r = CliRunner().invoke(organize, ["-f", "move", "--dandiset-path", str(tmp_path)])
     assert r.exit_code == 0, r.stdout
     assert sum(p.is_dir() for p in tmp_path.iterdir()) == 2
+    return tmp_path
+
+
+@pytest.fixture(scope="session")
+def organized_nwb_dir3(
+    simple4_nwb: str, tmp_path_factory: pytest.TempPathFactory
+) -> Path:
+    tmp_path = tmp_path_factory.mktemp("organized_nwb_dir")
+    (tmp_path / dandiset_metadata_file).write_text("{}\n")
+    r = CliRunner().invoke(
+        organize, ["-f", "copy", "--dandiset-path", str(tmp_path), str(simple4_nwb)]
+    )
+    assert r.exit_code == 0, r.stdout
     return tmp_path
 
 

--- a/dandi/tests/test_dandiapi.py
+++ b/dandi/tests/test_dandiapi.py
@@ -698,7 +698,6 @@ def test_rename_collision(text_dandiset: SampleDandiset) -> None:
     assert asset2.identifier == asset2a.identifier
 
 
-@pytest.mark.xfail(reason="https://github.com/dandi/dandi-archive/issues/1109")
 @pytest.mark.parametrize("dest", ["subdir1", "subdir1/apple.txt/core.dat"])
 def test_rename_type_mismatch(text_dandiset: SampleDandiset, dest: str) -> None:
     asset1 = text_dandiset.dandiset.get_asset_by_path("file.txt")

--- a/dandi/tests/test_dandiapi.py
+++ b/dandi/tests/test_dandiapi.py
@@ -251,16 +251,6 @@ def test_get_content_url_follow_one_redirects_strip_query() -> None:
         )
 
 
-def test_get_content_url_follow_redirects_zarr(zarr_dandiset: SampleDandiset) -> None:
-    asset = zarr_dandiset.dandiset.get_asset_by_path("sample.zarr")
-    assert isinstance(asset, RemoteZarrAsset)
-    url = asset.get_content_url(follow_redirects=True, strip_query=True)
-    assert re.fullmatch(
-        f"http://localhost:9000/dandi-dandisets/zarr/{asset.zarr}/*",
-        url,
-    )
-
-
 def test_remote_asset_json_dict(text_dandiset: SampleDandiset) -> None:
     asset = text_dandiset.dandiset.get_asset_by_path("file.txt")
     assert asset.json_dict() == {

--- a/dandi/tests/test_files.py
+++ b/dandi/tests/test_files.py
@@ -381,36 +381,43 @@ def test_upload_zarr(new_dandiset, tmp_path):
     md = asset.get_raw_metadata()
     assert md["description"] == "A modified Zarr"
 
-    for file_src in [zf, asset]:
-        lgr.debug("Traversing %s", type(file_src).__name__)
-        entries = sorted(file_src.iterfiles(include_dirs=True), key=attrgetter("parts"))
-        assert [str(e) for e in entries] == [
-            ".zgroup",
-            "arr_0",
-            "arr_0/.zarray",
-            "arr_0/0",
-            "arr_1",
-            "arr_1/.zarray",
-            "arr_1/0",
-        ]
-        assert (file_src.filetree / ".zgroup").exists()
-        assert (file_src.filetree / ".zgroup").is_file()
-        assert not (file_src.filetree / ".zgroup").is_dir()
-        assert (file_src.filetree / "arr_0").exists()
-        assert not (file_src.filetree / "arr_0").is_file()
-        assert (file_src.filetree / "arr_0").is_dir()
-        assert not (file_src.filetree / "0").exists()
-        assert not (file_src.filetree / "0").is_file()
-        assert not (file_src.filetree / "0").is_dir()
-        assert not (file_src.filetree / "arr_0" / ".zgroup").exists()
-        assert not (file_src.filetree / "arr_0" / ".zgroup").is_file()
-        assert not (file_src.filetree / "arr_0" / ".zgroup").is_dir()
-        assert not (file_src.filetree / ".zgroup" / "0").exists()
-        assert not (file_src.filetree / ".zgroup" / "0").is_file()
-        assert not (file_src.filetree / ".zgroup" / "0").is_dir()
-        assert not (file_src.filetree / "arr_2" / "0").exists()
-        assert not (file_src.filetree / "arr_2" / "0").is_file()
-        assert not (file_src.filetree / "arr_2" / "0").is_dir()
+    entries = sorted(asset.iterfiles(), key=attrgetter("parts"))
+    assert [str(e) for e in entries] == [
+        ".zgroup",
+        "arr_0/.zarray",
+        "arr_0/0",
+        "arr_1/.zarray",
+        "arr_1/0",
+    ]
+
+    entries = sorted(zf.iterfiles(include_dirs=True), key=attrgetter("parts"))
+    assert [str(e) for e in entries] == [
+        ".zgroup",
+        "arr_0",
+        "arr_0/.zarray",
+        "arr_0/0",
+        "arr_1",
+        "arr_1/.zarray",
+        "arr_1/0",
+    ]
+    assert (zf.filetree / ".zgroup").exists()
+    assert (zf.filetree / ".zgroup").is_file()
+    assert not (zf.filetree / ".zgroup").is_dir()
+    assert (zf.filetree / "arr_0").exists()
+    assert not (zf.filetree / "arr_0").is_file()
+    assert (zf.filetree / "arr_0").is_dir()
+    assert not (zf.filetree / "0").exists()
+    assert not (zf.filetree / "0").is_file()
+    assert not (zf.filetree / "0").is_dir()
+    assert not (zf.filetree / "arr_0" / ".zgroup").exists()
+    assert not (zf.filetree / "arr_0" / ".zgroup").is_file()
+    assert not (zf.filetree / "arr_0" / ".zgroup").is_dir()
+    assert not (zf.filetree / ".zgroup" / "0").exists()
+    assert not (zf.filetree / ".zgroup" / "0").is_file()
+    assert not (zf.filetree / ".zgroup" / "0").is_dir()
+    assert not (zf.filetree / "arr_2" / "0").exists()
+    assert not (zf.filetree / "arr_2" / "0").is_file()
+    assert not (zf.filetree / "arr_2" / "0").is_dir()
 
 
 def test_zarr_properties(tmp_path: Path) -> None:
@@ -467,13 +474,11 @@ def test_upload_zarr_with_excluded_dotfiles(
         "arr_1/.zarray",
         "arr_1/0",
     ]
-    remote_entries = sorted(asset.iterfiles(include_dirs=True), key=attrgetter("parts"))
+    remote_entries = sorted(asset.iterfiles(), key=attrgetter("parts"))
     assert [str(e) for e in remote_entries] == [
         ".zgroup",
-        "arr_0",
         "arr_0/.zarray",
         "arr_0/0",
-        "arr_1",
         "arr_1/.zarray",
         "arr_1/0",
     ]

--- a/dandi/tests/test_files.py
+++ b/dandi/tests/test_files.py
@@ -65,14 +65,28 @@ def test_find_dandi_files(tmp_path: Path) -> None:
         find_dandi_files(tmp_path, dandiset_path=tmp_path), key=attrgetter("filepath")
     )
     assert files == [
-        VideoAsset(filepath=tmp_path / "glarch.mp4", path="glarch.mp4"),
-        ZarrAsset(filepath=tmp_path / "sample01.zarr", path="sample01.zarr"),
-        NWBAsset(filepath=tmp_path / "sample02.nwb", path="sample02.nwb"),
-        NWBAsset(
-            filepath=tmp_path / "subdir" / "sample03.nwb", path="subdir/sample03.nwb"
+        VideoAsset(
+            filepath=tmp_path / "glarch.mp4", path="glarch.mp4", dandiset_path=tmp_path
         ),
         ZarrAsset(
-            filepath=tmp_path / "subdir" / "sample04.zarr", path="subdir/sample04.zarr"
+            filepath=tmp_path / "sample01.zarr",
+            path="sample01.zarr",
+            dandiset_path=tmp_path,
+        ),
+        NWBAsset(
+            filepath=tmp_path / "sample02.nwb",
+            path="sample02.nwb",
+            dandiset_path=tmp_path,
+        ),
+        NWBAsset(
+            filepath=tmp_path / "subdir" / "sample03.nwb",
+            path="subdir/sample03.nwb",
+            dandiset_path=tmp_path,
+        ),
+        ZarrAsset(
+            filepath=tmp_path / "subdir" / "sample04.zarr",
+            path="subdir/sample04.zarr",
+            dandiset_path=tmp_path,
         ),
     ]
 
@@ -81,21 +95,45 @@ def test_find_dandi_files(tmp_path: Path) -> None:
         key=attrgetter("filepath"),
     )
     assert files == [
-        GenericAsset(filepath=tmp_path / "bar.txt", path="bar.txt"),
-        DandisetMetadataFile(filepath=tmp_path / dandiset_metadata_file),
-        GenericAsset(filepath=tmp_path / "foo", path="foo"),
-        VideoAsset(filepath=tmp_path / "glarch.mp4", path="glarch.mp4"),
-        ZarrAsset(filepath=tmp_path / "sample01.zarr", path="sample01.zarr"),
-        NWBAsset(filepath=tmp_path / "sample02.nwb", path="sample02.nwb"),
         GenericAsset(
-            filepath=tmp_path / "subdir" / "cleesh.txt", path="subdir/cleesh.txt"
+            filepath=tmp_path / "bar.txt", path="bar.txt", dandiset_path=tmp_path
         ),
-        GenericAsset(filepath=tmp_path / "subdir" / "gnusto", path="subdir/gnusto"),
-        NWBAsset(
-            filepath=tmp_path / "subdir" / "sample03.nwb", path="subdir/sample03.nwb"
+        DandisetMetadataFile(
+            filepath=tmp_path / dandiset_metadata_file, dandiset_path=tmp_path
+        ),
+        GenericAsset(filepath=tmp_path / "foo", path="foo", dandiset_path=tmp_path),
+        VideoAsset(
+            filepath=tmp_path / "glarch.mp4", path="glarch.mp4", dandiset_path=tmp_path
         ),
         ZarrAsset(
-            filepath=tmp_path / "subdir" / "sample04.zarr", path="subdir/sample04.zarr"
+            filepath=tmp_path / "sample01.zarr",
+            path="sample01.zarr",
+            dandiset_path=tmp_path,
+        ),
+        NWBAsset(
+            filepath=tmp_path / "sample02.nwb",
+            path="sample02.nwb",
+            dandiset_path=tmp_path,
+        ),
+        GenericAsset(
+            filepath=tmp_path / "subdir" / "cleesh.txt",
+            path="subdir/cleesh.txt",
+            dandiset_path=tmp_path,
+        ),
+        GenericAsset(
+            filepath=tmp_path / "subdir" / "gnusto",
+            path="subdir/gnusto",
+            dandiset_path=tmp_path,
+        ),
+        NWBAsset(
+            filepath=tmp_path / "subdir" / "sample03.nwb",
+            path="subdir/sample03.nwb",
+            dandiset_path=tmp_path,
+        ),
+        ZarrAsset(
+            filepath=tmp_path / "subdir" / "sample04.zarr",
+            path="subdir/sample04.zarr",
+            dandiset_path=tmp_path,
         ),
     ]
 
@@ -104,15 +142,31 @@ def test_find_dandi_files(tmp_path: Path) -> None:
         key=attrgetter("filepath"),
     )
     assert files == [
-        DandisetMetadataFile(filepath=tmp_path / dandiset_metadata_file),
-        VideoAsset(filepath=tmp_path / "glarch.mp4", path="glarch.mp4"),
-        ZarrAsset(filepath=tmp_path / "sample01.zarr", path="sample01.zarr"),
-        NWBAsset(filepath=tmp_path / "sample02.nwb", path="sample02.nwb"),
-        NWBAsset(
-            filepath=tmp_path / "subdir" / "sample03.nwb", path="subdir/sample03.nwb"
+        DandisetMetadataFile(
+            filepath=tmp_path / dandiset_metadata_file, dandiset_path=tmp_path
+        ),
+        VideoAsset(
+            filepath=tmp_path / "glarch.mp4", path="glarch.mp4", dandiset_path=tmp_path
         ),
         ZarrAsset(
-            filepath=tmp_path / "subdir" / "sample04.zarr", path="subdir/sample04.zarr"
+            filepath=tmp_path / "sample01.zarr",
+            path="sample01.zarr",
+            dandiset_path=tmp_path,
+        ),
+        NWBAsset(
+            filepath=tmp_path / "sample02.nwb",
+            path="sample02.nwb",
+            dandiset_path=tmp_path,
+        ),
+        NWBAsset(
+            filepath=tmp_path / "subdir" / "sample03.nwb",
+            path="subdir/sample03.nwb",
+            dandiset_path=tmp_path,
+        ),
+        ZarrAsset(
+            filepath=tmp_path / "subdir" / "sample04.zarr",
+            path="subdir/sample04.zarr",
+            dandiset_path=tmp_path,
         ),
     ]
 
@@ -139,45 +193,53 @@ def test_find_dandi_files_with_bids(tmp_path: Path) -> None:
     )
 
     assert files == [
-        NWBAsset(filepath=tmp_path / "bar.nwb", path="bar.nwb"),
+        NWBAsset(filepath=tmp_path / "bar.nwb", path="bar.nwb", dandiset_path=tmp_path),
         BIDSDatasetDescriptionAsset(
             filepath=tmp_path / "bids1" / "dataset_description.json",
             path="bids1/dataset_description.json",
+            dandiset_path=tmp_path,
             dataset_files=ANY,
         ),
         GenericBIDSAsset(
             filepath=tmp_path / "bids1" / "file.txt",
             path="bids1/file.txt",
+            dandiset_path=tmp_path,
             bids_dataset_description_ref=ANY,
         ),
         ZarrBIDSAsset(
             filepath=tmp_path / "bids1" / "subdir" / "glarch.zarr",
             path="bids1/subdir/glarch.zarr",
+            dandiset_path=tmp_path,
             bids_dataset_description_ref=ANY,
         ),
         NWBBIDSAsset(
             filepath=tmp_path / "bids1" / "subdir" / "quux.nwb",
             path="bids1/subdir/quux.nwb",
+            dandiset_path=tmp_path,
             bids_dataset_description_ref=ANY,
         ),
         BIDSDatasetDescriptionAsset(
             filepath=tmp_path / "bids2" / "dataset_description.json",
             path="bids2/dataset_description.json",
+            dandiset_path=tmp_path,
             dataset_files=ANY,
         ),
         GenericBIDSAsset(
             filepath=tmp_path / "bids2" / "movie.mp4",
             path="bids2/movie.mp4",
+            dandiset_path=tmp_path,
             bids_dataset_description_ref=ANY,
         ),
         GenericBIDSAsset(
             filepath=tmp_path / "bids2" / "subbids" / "data.json",
             path="bids2/subbids/data.json",
+            dandiset_path=tmp_path,
             bids_dataset_description_ref=ANY,
         ),
         BIDSDatasetDescriptionAsset(
             filepath=tmp_path / "bids2" / "subbids" / "dataset_description.json",
             path="bids2/subbids/dataset_description.json",
+            dandiset_path=tmp_path,
             dataset_files=ANY,
         ),
     ]
@@ -187,16 +249,19 @@ def test_find_dandi_files_with_bids(tmp_path: Path) -> None:
         GenericBIDSAsset(
             filepath=tmp_path / "bids1" / "file.txt",
             path="bids1/file.txt",
+            dandiset_path=tmp_path,
             bids_dataset_description_ref=ANY,
         ),
         ZarrBIDSAsset(
             filepath=tmp_path / "bids1" / "subdir" / "glarch.zarr",
             path="bids1/subdir/glarch.zarr",
+            dandiset_path=tmp_path,
             bids_dataset_description_ref=ANY,
         ),
         NWBBIDSAsset(
             filepath=tmp_path / "bids1" / "subdir" / "quux.nwb",
             path="bids1/subdir/quux.nwb",
+            dandiset_path=tmp_path,
             bids_dataset_description_ref=ANY,
         ),
     ]
@@ -208,6 +273,7 @@ def test_find_dandi_files_with_bids(tmp_path: Path) -> None:
         GenericBIDSAsset(
             filepath=tmp_path / "bids2" / "movie.mp4",
             path="bids2/movie.mp4",
+            dandiset_path=tmp_path,
             bids_dataset_description_ref=ANY,
         ),
     ]
@@ -219,6 +285,7 @@ def test_find_dandi_files_with_bids(tmp_path: Path) -> None:
         GenericBIDSAsset(
             filepath=tmp_path / "bids2" / "subbids" / "data.json",
             path="bids2/subbids/data.json",
+            dandiset_path=tmp_path,
             bids_dataset_description_ref=ANY,
         ),
     ]
@@ -248,31 +315,41 @@ def test_validate_simple1(simple1_nwb):
     errors = dandi_file(simple1_nwb).get_validation_errors(
         schema_version=get_schema_version()
     )
-    assert not errors
+    assert [e.message for e in errors] == ["File is not inside a Dandiset"]
 
 
 def test_validate_simple1_no_subject(simple1_nwb):
     errors = dandi_file(simple1_nwb).get_validation_errors()
-    assert [e.message for e in errors] == ["Subject is missing."]
+    assert sorted(e.message for e in errors) == [
+        "File is not inside a Dandiset",
+        "Subject is missing.",
+    ]
 
 
-def test_validate_simple2(simple2_nwb):
+def test_validate_simple2(organized_nwb_dir: Path) -> None:
     # this file should be ok since a Subject is included
-    errors = dandi_file(simple2_nwb).get_validation_errors()
+    errors = dandi_file(
+        organized_nwb_dir / "sub-mouse001" / "sub-mouse001.nwb",
+        dandiset_path=organized_nwb_dir,
+    ).get_validation_errors()
     assert not errors
 
 
-def test_validate_simple2_new(simple2_nwb):
+def test_validate_simple2_new(organized_nwb_dir: Path) -> None:
     # this file should be ok
-    errors = dandi_file(simple2_nwb).get_validation_errors(
-        schema_version=get_schema_version()
-    )
+    errors = dandi_file(
+        organized_nwb_dir / "sub-mouse001" / "sub-mouse001.nwb",
+        dandiset_path=organized_nwb_dir,
+    ).get_validation_errors(schema_version=get_schema_version())
     assert not errors
 
 
 def test_validate_simple3_no_subject_id(simple3_nwb):
     errors = dandi_file(simple3_nwb).get_validation_errors()
-    assert [e.message for e in errors] == ["subject_id is missing."]
+    assert sorted(e.message for e in errors) == [
+        "File is not inside a Dandiset",
+        "subject_id is missing.",
+    ]
 
 
 def test_validate_bogus(tmp_path):

--- a/dandi/tests/test_upload.py
+++ b/dandi/tests/test_upload.py
@@ -397,4 +397,5 @@ def test_upload_zarr_with_empty_dir(new_dandiset: SampleDandiset) -> None:
     assert isinstance(asset, RemoteZarrAsset)
     assert asset.asset_type is AssetType.ZARR
     assert asset.path == "sample.zarr"
-    assert not (asset.filetree / "empty").exists()
+    with pytest.raises(NotFoundError):
+        asset.get_entry_by_path("empty")

--- a/dandi/tests/test_upload.py
+++ b/dandi/tests/test_upload.py
@@ -220,7 +220,7 @@ def test_upload_bids(mocker: MockerFixture, bids_dandiset: SampleDandiset) -> No
     # Check existence of assets:
     dandiset = bids_dandiset.dandiset
     # file we created?
-    dandiset.get_asset_by_path("CHANGES")
+    dandiset.get_asset_by_path("README")
     # BIDS descriptor file?
     dandiset.get_asset_by_path("dataset_description.json")
     # actual data file?

--- a/dandi/tests/test_upload.py
+++ b/dandi/tests/test_upload.py
@@ -212,6 +212,20 @@ def test_upload_bids_validation_ignore(
     dandiset.get_asset_by_path("sub-Sub1/anat/sub-Sub1_T1w.nii.gz")
 
 
+def test_upload_bids_metadata(
+    mocker: MockerFixture, bids_dandiset: SampleDandiset
+) -> None:
+    bids_dandiset.upload(existing="force")
+    dandiset = bids_dandiset.dandiset
+    # Automatically check all files, heuristic should remain very BIDS-stable
+    for asset in dandiset.get_assets(order="path"):
+        apath = asset.path
+        if "sub-" in apath:
+            metadata = dandiset.get_asset_by_path(apath).get_metadata()
+            # Hard-coded check for the subject identifier set in the fixture:
+            assert metadata.wasAttributedTo[0].identifier == "Sub1"
+
+
 def test_upload_bids(mocker: MockerFixture, bids_dandiset: SampleDandiset) -> None:
     iter_upload_spy = mocker.spy(LocalFileAsset, "iter_upload")
     bids_dandiset.upload(existing="force")

--- a/dandi/validate.py
+++ b/dandi/validate.py
@@ -6,6 +6,7 @@ from typing import Iterator, Optional, Union
 
 import appdirs
 
+from .consts import dandiset_metadata_file
 from .files import find_dandi_files
 from .utils import find_parent_directory_containing
 from .validate_types import Scope, Severity, ValidationOrigin, ValidationResult
@@ -162,7 +163,11 @@ def validate(
     path, errors
       errors for a path
     """
-    for df in find_dandi_files(*paths, dandiset_path=None, allow_all=allow_any_path):
-        yield from df.get_validation_errors(
-            schema_version=schema_version, devel_debug=devel_debug
-        )
+    for p in paths:
+        dandiset_path = find_parent_directory_containing(dandiset_metadata_file, p)
+        for df in find_dandi_files(
+            p, dandiset_path=dandiset_path, allow_all=allow_any_path
+        ):
+            yield from df.get_validation_errors(
+                schema_version=schema_version, devel_debug=devel_debug
+            )

--- a/dandi/validate.py
+++ b/dandi/validate.py
@@ -147,6 +147,7 @@ def validate_bids(
 
 def validate(
     *paths: str,
+    bids_schema_version: Optional[str] = None,
     schema_version: Optional[str] = None,
     devel_debug: bool = False,
     allow_any_path: bool = False,

--- a/dandi/validate.py
+++ b/dandi/validate.py
@@ -68,6 +68,7 @@ def validate_bids(
     origin = ValidationOrigin(
         name="bidsschematools",
         version=bidsschematools.__version__,
+        bids_version=validation_result["bids_version"],
     )
 
     # Storing variable to not re-compute set paths for each individual file.

--- a/dandi/validate_types.py
+++ b/dandi/validate_types.py
@@ -19,6 +19,7 @@ class Severity(Enum):
 
 class Scope(Enum):
     FILE = "file"
+    FOLDER = "folder"
     DANDISET = "dandiset"
     DATASET = "dataset"
 

--- a/dandi/validate_types.py
+++ b/dandi/validate_types.py
@@ -8,6 +8,7 @@ from typing import Dict, List, Optional
 class ValidationOrigin:
     name: str
     version: str
+    bids_version: Optional[str] = None
 
 
 class Severity(Enum):

--- a/docs/source/cmdline/organize.rst
+++ b/docs/source/cmdline/organize.rst
@@ -65,16 +65,33 @@ Options
     What to do if files without sufficient metadata are encountered  [default:
     ``fail``]
 
+.. option:: --media-files-mode [copy|move|symlink|hardlink]
+
+    How to relocate video files referenced by NWB files [default: ``symlink``]
+
+.. option:: --required-field <field>
+
+    Force a given field to be included in the organized filename of any file
+    for which it is nonempty.  Can be specified multiple times.
+
+    The valid field names are:
+
+    - ``subject_id`` (already required by default)
+    - ``session_id``
+    - ``tissue_sample_id``
+    - ``slice_id``
+    - ``cell_id``
+    - ``probe_ids``
+    - ``obj_id``
+    - ``modalities`` (already required by default)
+    - ``extension`` (already required by default)
+
 .. option:: --update-external-file-paths
 
     Rewrite the ``external_file`` arguments of ImageSeries in NWB files.  The
     new values will correspond to the new locations of the video files after
     being organized.  This option requires :option:`--files-mode` to be
     "``copy``" or "``move``".
-
-.. option:: --media-files-mode [copy|move|symlink|hardlink]
-
-    How to relocate video files referenced by NWB files [default: ``symlink``]
 
 Development Options
 -------------------

--- a/docs/source/modref/dandiapi.rst
+++ b/docs/source/modref/dandiapi.rst
@@ -74,8 +74,4 @@ Zarr Assets
 .. autoclass:: RemoteZarrEntry()
     :show-inheritance:
 
-.. autoclass:: ZarrListing()
-
-.. autoclass:: ZarrEntryStat()
-
-.. Excluded from documentation: APIBase, RemoteDandisetData
+.. Excluded from documentation: APIBase, RemoteDandisetData, ZarrEntryServerData


### PR DESCRIPTION
Currently non-working. The main problem seems to be that the old (functional) design ran the validation from `validate.py`, whereas the new (object-oriented) design runs it as part of the asset instantiation. This makes a lot of things a bit confusing. Currently the immediate issue is that if we validate via BIDS object instantiation, we get the same error reported over and over. Probably has to do with the vanilla validation function using `yield` versus `return`... Will continue digging, though comments are appreciated @yarikoptic @jwodder 

I'm currently testing this on `DANDI:000108` :

```console
(dev) chymera@decohost ~/.local/share/datalad $ dandi validate 000108
2022-11-09 18:57:11,195 [ WARNING] BIDSVersion `1.4.0` is less than the minimal working `schema`. Falling back to `schema`. To force the usage of earlier versions specify them explicitly when calling the validator.
2022-11-09 18:57:12,329 [   ERROR] The `README(?P<extension>|\.md|\.rst|\.txt)` regex pattern file required by BIDS was not found.
..
ValidationResult(id='BIDS.MANDATORY_FILE_MISSING_PLACEHOLDER', origin=ValidationOrigin(name='bidsschematools', version='0.6.0'), scope=<Scope.DATASET: 'dataset'>, asset_paths=None, within_asset_paths=None, dandiset_path=None, dataset_path=None, message='BIDS-required file is not present.', metadata=None, path=None, path_regex='README(?P<extension>|\\.md|\\.rst|\\.txt)', severity=<Severity.ERROR: 'ERROR'>)
ii
ValidationResult(id='BIDS.MANDATORY_FILE_MISSING_PLACEHOLDER', origin=ValidationOrigin(name='bidsschematools', version='0.6.0'), scope=<Scope.DATASET: 'dataset'>, asset_paths=None, within_asset_paths=None, dandiset_path=None, dataset_path=None, message='BIDS-required file is not present.', metadata=None, path=None, path_regex='README(?P<extension>|\\.md|\\.rst|\\.txt)', severity=<Severity.ERROR: 'ERROR'>)
ii
ValidationResult(id='BIDS.MATCH', origin=ValidationOrigin(name='bidsschematools', version='0.6.0'), scope=<Scope.FILE: 'file'>, asset_paths=None, within_asset_paths=None, dandiset_path=PosixPath('/home/chymera/.local/share/datalad/000108'), dataset_path=PosixPath('/home/chymera/.local/share/datalad/000108'), message=None, metadata={}, path=PosixPath('/home/chymera/.local/share/datalad/000108/dataset_description.json'), path_regex=None, severity=None)
kk
ValidationResult(id='BIDS.MATCH', origin=ValidationOrigin(name='bidsschematools', version='0.6.0'), scope=<Scope.FILE: 'file'>, asset_paths=None, within_asset_paths=None, dandiset_path=PosixPath('/home/chymera/.local/share/datalad/000108'), dataset_path=PosixPath('/home/chymera/.local/share/datalad/000108'), message=None, metadata={}, path=PosixPath('/home/chymera/.local/share/datalad/000108/dataset_description.json'), path_regex=None, severity=None)
kk
/home/chymera/.local/share/datalad/000108/dataset_description.json
kk1
kk2
kk3
kk4
..
Counter({'BIDS.MANDATORY_FILE_MISSING_PLACEHOLDER': 3250})
2022-11-09 18:57:12,835 [    INFO] Logs saved in /home/chymera/.cache/dandi-cli/log/20221109235709Z-11928.log
Error: No active exception to reraise
```