### PR TITLE
Update `test_validate_nwb_path_grouping` test

### DIFF
--- a/dandi/cli/tests/test_cmd_validate.py
+++ b/dandi/cli/tests/test_cmd_validate.py
@@ -46,8 +46,7 @@ def test_validate_nwb_path_grouping(simple3_nwb):
     """
 
     r = CliRunner().invoke(validate, ["--grouping=path", simple3_nwb])
-    # Does it pass?
-    assert r.exit_code == 0
+    assert r.exit_code != 0
 
     # Does it give required warnings for required path?
     assert simple3_nwb in r.output


### PR DESCRIPTION
The test in question was failing because the `validate` command was exiting nonzero.

@TheChymera Seeing as the sample file was expected to fail validation, exactly why was the command expected to exit successfully, and what changed?