### PR TITLE
Renamed failing test, added prospective use case for NWBI warning.

### DIFF
--- a/dandi/cli/tests/test_cmd_validate.py
+++ b/dandi/cli/tests/test_cmd_validate.py
@@ -38,7 +38,7 @@ def test_validate_nwb_error(simple3_nwb):
 def test_validate_bids_grouping_error(bids_error_examples, dataset="invalid_asl003"):
     """
     This is currently a placeholder test, and should be updated once we have paths with
-    multiple errors.
+    multiple errors for which grouping functionality can actually be tested.
     """
 
     dataset = os.path.join(bids_error_examples, dataset)
@@ -50,34 +50,18 @@ def test_validate_bids_grouping_error(bids_error_examples, dataset="invalid_asl0
     assert dataset in r.output
 
 
-def test_validate_nwb_path_grouping(simple2_nwb):
+def test_validate_nwb_path_grouping(simple4_nwb):
     """
     This is currently a placeholder test, and should be updated once we have paths with
-    multiple errors.
+    multiple errors for which grouping functionality can actually be tested.
     """
 
-    r = CliRunner().invoke(validate, ["--grouping=path", simple2_nwb])
-    print(r.output)
+    r = CliRunner().invoke(validate, ["--grouping=path", simple4_nwb])
     assert r.exit_code == 0
 
     # Does it give required warnings for required path?
-    assert simple2_nwb in r.output
+    assert simple4_nwb in r.output
     assert "NWBI.check_data_orientation" in r.output
-
-
-# Awaiting fixture fix:
-# def test_validate_nwb_path_grouping(simple4_nwb):
-#    """
-#    This is currently a placeholder test, and should be updated once we have paths with
-#    multiple errors.
-#    """
-#
-#    r = CliRunner().invoke(validate, ["--grouping=path", simple4_nwb])
-#    assert r.exit_code == 0
-#
-#    # Does it give required warnings for required path?
-#    assert simple4_nwb in r.output
-#    assert "NWBI.check_data_orientation" in r.output
 
 
 def test_validate_bids_error_grouping_notification(

--- a/dandi/cli/tests/test_cmd_validate.py
+++ b/dandi/cli/tests/test_cmd_validate.py
@@ -24,6 +24,17 @@ def test_validate_bids_error(bids_error_examples, dataset):
         assert key in r.output
 
 
+def test_validate_nwb_error(simple3_nwb):
+    """
+    Do we fail on critical NWB validation errors?
+    """
+
+    r = CliRunner().invoke(validate, [simple3_nwb])
+    # does it fail? as per:
+    # https://github.com/dandi/dandi-cli/pull/1157#issuecomment-1312546812
+    assert r.exit_code != 0
+
+
 def test_validate_bids_grouping_error(bids_error_examples, dataset="invalid_asl003"):
     """
     This is currently a placeholder test, and should be updated once we have paths with
@@ -39,18 +50,19 @@ def test_validate_bids_grouping_error(bids_error_examples, dataset="invalid_asl0
     assert dataset in r.output
 
 
-def test_validate_nwb_path_grouping(simple3_nwb):
-    """
-    This is currently a placeholder test, and should be updated once we have paths with
-    multiple errors.
-    """
-
-    r = CliRunner().invoke(validate, ["--grouping=path", simple3_nwb])
-    assert r.exit_code != 0
-
-    # Does it give required warnings for required path?
-    assert simple3_nwb in r.output
-    assert "NWBI.check_subject_id_exists" in r.output
+# Awaiting fixture fix:
+# def test_validate_nwb_path_grouping(simple4_nwb):
+#    """
+#    This is currently a placeholder test, and should be updated once we have paths with
+#    multiple errors.
+#    """
+#
+#    r = CliRunner().invoke(validate, ["--grouping=path", simple4_nwb])
+#    assert r.exit_code == 0
+#
+#    # Does it give required warnings for required path?
+#    assert simple4_nwb in r.output
+#    assert "NWBI.check_data_orientation" in r.output
 
 
 def test_validate_bids_error_grouping_notification(

--- a/dandi/cli/tests/test_cmd_validate.py
+++ b/dandi/cli/tests/test_cmd_validate.py
@@ -50,6 +50,21 @@ def test_validate_bids_grouping_error(bids_error_examples, dataset="invalid_asl0
     assert dataset in r.output
 
 
+def test_validate_nwb_path_grouping(simple2_nwb):
+    """
+    This is currently a placeholder test, and should be updated once we have paths with
+    multiple errors.
+    """
+
+    r = CliRunner().invoke(validate, ["--grouping=path", simple2_nwb])
+    print(r.output)
+    assert r.exit_code == 0
+
+    # Does it give required warnings for required path?
+    assert simple2_nwb in r.output
+    assert "NWBI.check_data_orientation" in r.output
+
+
 # Awaiting fixture fix:
 # def test_validate_nwb_path_grouping(simple4_nwb):
 #    """

--- a/dandi/files/bases.py
+++ b/dandi/files/bases.py
@@ -505,12 +505,14 @@ class NWBAsset(LocalFileAsset):
                     nwbfile_path=self.filepath,
                     skip_validate=True,
                     config=load_config(filepath_or_keyword="dandi"),
-                    importance_threshold=Importance.CRITICAL,
+                    #importance_threshold=Importance.BEST_PRACTICE_VIOLATION,
+                    importance_threshold=Importance.BEST_PRACTICE_SUGGESTION,
                 ):
                     # unfortunate name collision; the InspectorMessage.severity is used only for
                     # minor ordering of final report - will have to remove the
                     # `importance_threshold` currently used to filter DANDI-level CRITICAL
                     # evaluations as errors vs. validation results
+                    print(error.importance.name)
                     severity = NWBI_IMPORTANCE_TO_DANDI_SEVERITY[error.importance.name]
                     kw: Any = {}
                     if error.location:

--- a/dandi/files/bases.py
+++ b/dandi/files/bases.py
@@ -505,14 +505,12 @@ class NWBAsset(LocalFileAsset):
                     nwbfile_path=self.filepath,
                     skip_validate=True,
                     config=load_config(filepath_or_keyword="dandi"),
-                    #importance_threshold=Importance.BEST_PRACTICE_VIOLATION,
-                    importance_threshold=Importance.BEST_PRACTICE_SUGGESTION,
+                    importance_threshold=Importance.BEST_PRACTICE_VIOLATION,
+                    # we might want to switch to a lower threshold once nwbinspector
+                    # upstream reporting issues are clarified:
+                    # https://github.com/dandi/dandi-cli/pull/1162#issuecomment-1322238896
+                    # importance_threshold=Importance.BEST_PRACTICE_SUGGESTION,
                 ):
-                    # unfortunate name collision; the InspectorMessage.severity is used only for
-                    # minor ordering of final report - will have to remove the
-                    # `importance_threshold` currently used to filter DANDI-level CRITICAL
-                    # evaluations as errors vs. validation results
-                    print(error.importance.name)
                     severity = NWBI_IMPORTANCE_TO_DANDI_SEVERITY[error.importance.name]
                     kw: Any = {}
                     if error.location:

--- a/dandi/tests/fixtures.py
+++ b/dandi/tests/fixtures.py
@@ -150,6 +150,42 @@ def simple3_nwb(
     )
 
 
+# @pytest.fixture(scope="session")
+# def simple4_nwb(
+#    simple1_nwb_metadata: Dict[str, Any], tmp_path_factory: pytest.TempPathFactory
+# ) -> str:
+#    """
+#    With, subject, subject_id, species, but including data orientation ambiguity,
+#    the only currently non-critical issue in the dandi schema for nwbinspector validation:
+#    https://github.com/NeurodataWithoutBorders/nwbinspector/blob/
+#        54ac2bc7cdcb92802b9251e29f249f155fb1ff52
+#        /src/nwbinspector/internal_configs/dandi.inspector_config.yaml#L10
+#    """
+#    from datetime import datetime, timezone
+#    start_time = datetime(2017, 4, 3, 11, tzinfo=timezone.utc)
+#    create_date = datetime(2017, 4, 15, 12, tzinfo=timezone.utc)
+#    time_series=pynwb.TimeSeries(
+#            name="test_time_series",
+#            unit="test_units",
+#            data=np.zeros(shape=(2, 100)),
+#            rate=1.0,
+#    )
+#    nwbfile = NWBFile(
+#        session_description="demonstrate external files",
+#        identifier="NWBE4",
+#        session_start_time=start_time,
+#        file_create_date=create_date,
+#        age="P1D/",
+#        sex="O",
+#        species="Mus musculus",
+#    )
+#    nwbfile.add_acquisition(time_series)
+#    filename = str(tmp_path_factory.mktemp("simple4") / "simple4.nwb")
+#    with pynwb.NWBHDF5IO(filename, "w") as io:
+#        io.write(nwbfile, cache_spec=False)
+#    return filename
+
+
 @pytest.fixture(scope="session")
 def organized_nwb_dir(
     simple2_nwb: str, tmp_path_factory: pytest.TempPathFactory

--- a/dandi/tests/fixtures.py
+++ b/dandi/tests/fixtures.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 import logging
 import os
 from pathlib import Path
@@ -162,7 +162,6 @@ def simple4_nwb(
     54ac2bc7cdcb92802b9251e29f249f155fb1ff52
     /src/nwbinspector/internal_configs/dandi.inspector_config.yaml#L10
     """
-    from datetime import datetime, timezone
 
     start_time = datetime(2017, 4, 3, 11, tzinfo=timezone.utc)
     time_series = pynwb.TimeSeries(

--- a/dandi/tests/fixtures.py
+++ b/dandi/tests/fixtures.py
@@ -150,40 +150,44 @@ def simple3_nwb(
     )
 
 
-# @pytest.fixture(scope="session")
-# def simple4_nwb(
-#    simple1_nwb_metadata: Dict[str, Any], tmp_path_factory: pytest.TempPathFactory
-# ) -> str:
-#    """
-#    With, subject, subject_id, species, but including data orientation ambiguity,
-#    the only currently non-critical issue in the dandi schema for nwbinspector validation:
-#    https://github.com/NeurodataWithoutBorders/nwbinspector/blob/
-#        54ac2bc7cdcb92802b9251e29f249f155fb1ff52
-#        /src/nwbinspector/internal_configs/dandi.inspector_config.yaml#L10
-#    """
-#    from datetime import datetime, timezone
-#    start_time = datetime(2017, 4, 3, 11, tzinfo=timezone.utc)
-#    create_date = datetime(2017, 4, 15, 12, tzinfo=timezone.utc)
-#    time_series=pynwb.TimeSeries(
-#            name="test_time_series",
-#            unit="test_units",
-#            data=np.zeros(shape=(2, 100)),
-#            rate=1.0,
-#    )
-#    nwbfile = NWBFile(
-#        session_description="demonstrate external files",
-#        identifier="NWBE4",
-#        session_start_time=start_time,
-#        file_create_date=create_date,
-#        age="P1D/",
-#        sex="O",
-#        species="Mus musculus",
-#    )
-#    nwbfile.add_acquisition(time_series)
-#    filename = str(tmp_path_factory.mktemp("simple4") / "simple4.nwb")
-#    with pynwb.NWBHDF5IO(filename, "w") as io:
-#        io.write(nwbfile, cache_spec=False)
-#    return filename
+@pytest.fixture(scope="session")
+def simple4_nwb(
+    simple1_nwb_metadata: Dict[str, Any], tmp_path_factory: pytest.TempPathFactory
+) -> str:
+    """
+    With, subject, subject_id, species, but including data orientation ambiguity,
+    the only currently non-critical issue in the dandi schema for nwbinspector validation:
+    NWBI.check_data_orientation
+    https://github.com/NeurodataWithoutBorders/nwbinspector/blob/
+        54ac2bc7cdcb92802b9251e29f249f155fb1ff52
+        /src/nwbinspector/internal_configs/dandi.inspector_config.yaml#L10
+    """
+    from datetime import datetime, timezone
+
+    start_time = datetime(2017, 4, 3, 11, tzinfo=timezone.utc)
+    time_series = pynwb.TimeSeries(
+        name="test_time_series",
+        unit="test_units",
+        data=np.zeros(shape=(2, 100)),
+        rate=1.0,
+    )
+
+    nwbfile = NWBFile(
+        session_description="some session",
+        identifier="NWBE4",
+        session_start_time=start_time,
+        subject=Subject(
+            subject_id="mouse001",
+            age="P1D/",
+            sex="O",
+            species="Mus musculus",
+        ),
+    )
+    nwbfile.add_acquisition(time_series)
+    filename = str(tmp_path_factory.mktemp("simple4") / "simple4.nwb")
+    with pynwb.NWBHDF5IO(filename, "w") as io:
+        io.write(nwbfile, cache_spec=False)
+    return filename
 
 
 @pytest.fixture(scope="session")

--- a/dandi/tests/fixtures.py
+++ b/dandi/tests/fixtures.py
@@ -159,8 +159,8 @@ def simple4_nwb(
     the only currently non-critical issue in the dandi schema for nwbinspector validation:
     NWBI.check_data_orientation
     https://github.com/NeurodataWithoutBorders/nwbinspector/blob/
-        54ac2bc7cdcb92802b9251e29f249f155fb1ff52
-        /src/nwbinspector/internal_configs/dandi.inspector_config.yaml#L10
+    54ac2bc7cdcb92802b9251e29f249f155fb1ff52
+    /src/nwbinspector/internal_configs/dandi.inspector_config.yaml#L10
     """
     from datetime import datetime, timezone
 


### PR DESCRIPTION
Addressing https://github.com/dandi/dandi-cli/issues/1158

- [x] Properly rename the test which is now testing that we properly fail on a critical error
- [x] Formulate a new test for checking that we properly display non-critical errors (i.e. WARNINGs)

The issue with the latter is that for validation via DANDI there is only one none-critical type of error, namely [`check_data_orientation`](https://github.com/NeurodataWithoutBorders/nwbinspector/blob/54ac2bc7cdcb92802b9251e29f249f155fb1ff52/src/nwbinspector/internal_configs/dandi.inspector_config.yaml#L10). Though going by the comment that too appears to be temporary.

@CodyCBakerPhD (1) do you know how I could create a test case for this if this will likely be long-term-stable behaviour or (2) is there anything else we could add as `BEST_PRACTICE_VIOLATION` (apparently the second-highest criterion for NWBI errors) so that we can check warning reporting functionality?