### PR TITLE
Allow user to specify mandatory (if not empty) fields in organize

### DIFF
--- a/dandi/cli/cmd_organize.py
+++ b/dandi/cli/cmd_organize.py
@@ -46,6 +46,8 @@ from ..consts import file_operation_modes
     default=None,
     help="How to relocate video files referenced by NWB files",
 )
+# TODO: add --mandatory-if-not-empty to define entities which must be present in the filename
+# (unless empty, i.e. no value). Propagate to create_unique_filenames_from_metadata
 @click.argument("paths", nargs=-1, type=click.Path(exists=True))
 @devel_debug_option()
 @map_to_click_exceptions
@@ -57,6 +59,7 @@ def organize(
     devel_debug=False,
     update_external_file_paths=False,
     media_files_mode=None,
+    mandatory_if_not_empty=None,
 ):
     """(Re)organize files according to the metadata.
 
@@ -101,4 +104,5 @@ def organize(
         devel_debug=devel_debug,
         update_external_file_paths=update_external_file_paths,
         media_files_mode=media_files_mode,
+        mandatory_if_not_empty=mandatory_if_not_empty,
     )

--- a/dandi/cli/cmd_organize.py
+++ b/dandi/cli/cmd_organize.py
@@ -64,7 +64,7 @@ from ..organize import potential_fields
 @map_to_click_exceptions
 def organize(
     paths,
-    required_fields: tuple[str, ...],
+    required_fields,
     dandiset_path=None,
     invalid="fail",
     files_mode="auto",

--- a/dandi/cli/cmd_organize.py
+++ b/dandi/cli/cmd_organize.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import click
 
 from .base import dandiset_path_option, devel_debug_option, map_to_click_exceptions
-from ..consts import file_operation_modes
-from ..organize import potential_fields
+from ..consts import dandi_layout_fields, file_operation_modes
 
 
 @click.command()
@@ -52,7 +51,7 @@ from ..organize import potential_fields
 @click.option(
     "--required-field",
     "required_fields",
-    type=click.Choice(list(potential_fields)),
+    type=click.Choice(list(dandi_layout_fields)),
     multiple=True,
     help=(
         "Force a given field to be included in the organized filename of any"

--- a/dandi/cli/cmd_organize.py
+++ b/dandi/cli/cmd_organize.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import click
 
 from .base import dandiset_path_option, devel_debug_option, map_to_click_exceptions
 from ..consts import file_operation_modes
+from ..organize import potential_fields
 
 
 @click.command()
@@ -46,20 +49,28 @@ from ..consts import file_operation_modes
     default=None,
     help="How to relocate video files referenced by NWB files",
 )
-# TODO: add --mandatory-if-not-empty to define entities which must be present in the filename
-# (unless empty, i.e. no value). Propagate to create_unique_filenames_from_metadata
+@click.option(
+    "--required-field",
+    "required_fields",
+    type=click.Choice(list(potential_fields)),
+    multiple=True,
+    help=(
+        "Force a given field to be included in the organized filename of any"
+        " file for which it is nonempty.  Can be specified multiple times."
+    ),
+)
 @click.argument("paths", nargs=-1, type=click.Path(exists=True))
 @devel_debug_option()
 @map_to_click_exceptions
 def organize(
     paths,
+    required_fields: tuple[str, ...],
     dandiset_path=None,
     invalid="fail",
     files_mode="auto",
     devel_debug=False,
     update_external_file_paths=False,
     media_files_mode=None,
-    mandatory_if_not_empty=None,
 ):
     """(Re)organize files according to the metadata.
 
@@ -104,5 +115,5 @@ def organize(
         devel_debug=devel_debug,
         update_external_file_paths=update_external_file_paths,
         media_files_mode=media_files_mode,
-        mandatory_if_not_empty=mandatory_if_not_empty,
+        required_fields=required_fields,
     )

--- a/dandi/consts.py
+++ b/dandi/consts.py
@@ -170,3 +170,31 @@ ZARR_UPLOAD_BATCH_SIZE = 255
 ZARR_DELETE_BATCH_SIZE = 100
 
 BIDS_DATASET_DESCRIPTION = "dataset_description.json"
+
+# Fields which would be used to compose organized filenames
+# TODO: add full description into command --help etc
+# Order matters!
+dandi_layout_fields = {
+    # "type" - if not defined, additional
+    "subject_id": {"format": "sub-{}", "type": "required"},
+    "session_id": {"format": "_ses-{}"},
+    "tissue_sample_id": {"format": "_tis-{}"},
+    "slice_id": {"format": "_slice-{}"},
+    "cell_id": {"format": "_cell-{}"},
+    # disambiguation ones
+    "probe_ids": {"format": "_probe-{}", "type": "disambiguation"},
+    "obj_id": {
+        "format": "_obj-{}",
+        "type": "disambiguation",
+    },  # will be not id, but checksum of it to shorten
+    # "session_description"
+    "modalities": {"format": "_{}", "type": "required_if_not_empty"},
+    "extension": {"format": "{}", "type": "required"},
+}
+# verify no typos
+assert {v.get("type", "additional") for v in dandi_layout_fields.values()} == {
+    "required",
+    "disambiguation",
+    "additional",
+    "required_if_not_empty",
+}

--- a/dandi/organize.py
+++ b/dandi/organize.py
@@ -92,8 +92,8 @@ def filter_invalid_metadata_rows(metadata_rows):
 
 
 def create_unique_filenames_from_metadata(
-    metadata, required_fields: Optional[Sequence[str]] = None
-):
+    metadata: list[dict], required_fields: Optional[Sequence[str]] = None
+) -> list[dict]:
     """Create unique filenames given metadata
 
     Parameters
@@ -105,7 +105,7 @@ def create_unique_filenames_from_metadata(
 
     Returns
     -------
-    dict
+    list of dict
       Adjusted metadata. A copy, which might have removed some metadata fields
       Do not rely on it being the same
     """

--- a/docs/source/cmdline/organize.rst
+++ b/docs/source/cmdline/organize.rst
@@ -65,16 +65,33 @@ Options
     What to do if files without sufficient metadata are encountered  [default:
     ``fail``]
 
+.. option:: --media-files-mode [copy|move|symlink|hardlink]
+
+    How to relocate video files referenced by NWB files [default: ``symlink``]
+
+.. option:: --required-field <field>
+
+    Force a given field to be included in the organized filename of any file
+    for which it is nonempty.  Can be specified multiple times.
+
+    The valid field names are:
+
+    - ``subject_id`` (already required by default)
+    - ``session_id``
+    - ``tissue_sample_id``
+    - ``slice_id``
+    - ``cell_id``
+    - ``probe_ids``
+    - ``obj_id``
+    - ``modalities`` (already required by default)
+    - ``extension`` (already required by default)
+
 .. option:: --update-external-file-paths
 
     Rewrite the ``external_file`` arguments of ImageSeries in NWB files.  The
     new values will correspond to the new locations of the video files after
     being organized.  This option requires :option:`--files-mode` to be
     "``copy``" or "``move``".
-
-.. option:: --media-files-mode [copy|move|symlink|hardlink]
-
-    How to relocate video files referenced by NWB files [default: ``symlink``]
 
 Development Options
 -------------------


### PR DESCRIPTION
Closes: #69

- [x] finish the code (CLI option, which would list available entities from `potential_fields` 
- [x] add tests to ensure that it has desired effect