### PR TITLE
Upload test to check for metadata

### DIFF
--- a/dandi/tests/test_upload.py
+++ b/dandi/tests/test_upload.py
@@ -220,8 +220,9 @@ def test_upload_bids_metadata(
     # Automatically check all files, heuristic should remain very BIDS-stable
     for asset in dandiset.get_assets(order="path"):
         apath = asset.path
-        if "Sub1" in apath:
+        if "sub-" in apath:
             metadata = dandiset.get_asset_by_path(apath).get_metadata()
+            # Hard-coded check for the subject identifier set in the fixture:
             assert metadata.wasAttributedTo[0].identifier == "Sub1"
 
 

--- a/dandi/tests/test_upload.py
+++ b/dandi/tests/test_upload.py
@@ -215,22 +215,14 @@ def test_upload_bids_validation_ignore(
 def test_upload_bids_metadata(
     mocker: MockerFixture, bids_dandiset: SampleDandiset
 ) -> None:
-    from pprint import pprint
-
     bids_dandiset.upload(existing="force")
     dandiset = bids_dandiset.dandiset
-    metadata = dandiset.get_asset_by_path(
-        "sub-Sub1/anat/sub-Sub1_T1w.nii.gz"
-    ).get_raw_metadata()
-    pprint(metadata)
-    # Could be automated somehow, but we're already hard-coding the path.
-    assert metadata["wasAttributedTo"][0]["identifier"] == "Sub1"
-    print("AAAAAAAAAAAAAAAAAAAAAA")
-    metadata = dandiset.get_asset_by_path(
-        "sub-Sub1/anat/sub-Sub1_T1w.nii.gz"
-    ).get_metadata()
-    pprint(metadata)
-    print("AAAAAAAAAAAAAAAAAAAAAA")
+    # Automatically check all files, heuristic should remain very BIDS-stable
+    for asset in dandiset.get_assets(order="path"):
+        apath = asset.path
+        if "Sub1" in apath:
+            metadata = dandiset.get_asset_by_path(apath).get_metadata()
+            assert metadata.wasAttributedTo[0].identifier == "Sub1"
 
 
 def test_upload_bids(mocker: MockerFixture, bids_dandiset: SampleDandiset) -> None:

--- a/dandi/tests/test_upload.py
+++ b/dandi/tests/test_upload.py
@@ -215,22 +215,22 @@ def test_upload_bids_validation_ignore(
 def test_upload_bids_metadata(
     mocker: MockerFixture, bids_dandiset: SampleDandiset
 ) -> None:
-    iter_upload_spy = mocker.spy(LocalFileAsset, "iter_upload")
+    from pprint import pprint
+
     bids_dandiset.upload(existing="force")
-    # Check whether upload was run
-    iter_upload_spy.assert_called()
-    # Check existence of assets:
     dandiset = bids_dandiset.dandiset
-    # file we created?
-    dandiset.get_asset_by_path("README")
-    # BIDS descriptor file?
-    dandiset.get_asset_by_path("dataset_description.json")
-    # actual data file?
-    dandiset.get_asset_by_path("sub-Sub1/anat/sub-Sub1_T1w.nii.gz")
-    dspath = dandiset.dspath
-    ds_orig = APIDandiset(dspath)
-    ds_metadata = ds_orig.metadata
-    print(ds_metadata)
+    metadata = dandiset.get_asset_by_path(
+        "sub-Sub1/anat/sub-Sub1_T1w.nii.gz"
+    ).get_raw_metadata()
+    pprint(metadata)
+    # Could be automated somehow, but we're already hard-coding the path.
+    assert metadata["wasAttributedTo"][0]["identifier"] == "Sub1"
+    print("AAAAAAAAAAAAAAAAAAAAAA")
+    metadata = dandiset.get_asset_by_path(
+        "sub-Sub1/anat/sub-Sub1_T1w.nii.gz"
+    ).get_metadata()
+    pprint(metadata)
+    print("AAAAAAAAAAAAAAAAAAAAAA")
 
 
 def test_upload_bids(mocker: MockerFixture, bids_dandiset: SampleDandiset) -> None:

--- a/dandi/tests/test_upload.py
+++ b/dandi/tests/test_upload.py
@@ -212,6 +212,27 @@ def test_upload_bids_validation_ignore(
     dandiset.get_asset_by_path("sub-Sub1/anat/sub-Sub1_T1w.nii.gz")
 
 
+def test_upload_bids_metadata(
+    mocker: MockerFixture, bids_dandiset: SampleDandiset
+) -> None:
+    iter_upload_spy = mocker.spy(LocalFileAsset, "iter_upload")
+    bids_dandiset.upload(existing="force")
+    # Check whether upload was run
+    iter_upload_spy.assert_called()
+    # Check existence of assets:
+    dandiset = bids_dandiset.dandiset
+    # file we created?
+    dandiset.get_asset_by_path("README")
+    # BIDS descriptor file?
+    dandiset.get_asset_by_path("dataset_description.json")
+    # actual data file?
+    dandiset.get_asset_by_path("sub-Sub1/anat/sub-Sub1_T1w.nii.gz")
+    dspath = dandiset.dspath
+    ds_orig = APIDandiset(dspath)
+    ds_metadata = ds_orig.metadata
+    print(ds_metadata)
+
+
 def test_upload_bids(mocker: MockerFixture, bids_dandiset: SampleDandiset) -> None:
     iter_upload_spy = mocker.spy(LocalFileAsset, "iter_upload")
     bids_dandiset.upload(existing="force")


### PR DESCRIPTION
Closes: https://github.com/dandi/dandisets/issues/220

The idea is to add a test which ensures that the upload code produces BIDS assets for which the correct data can always be retrieved. Currently we just check a few of the files being uploaded. I think it already works in any case, but would be a good add-on test.

@yarikoptic @jwodder any ideas how I can access the metadata of the remote asset? I tried to look at other tests which check metadata, but thus far I haven't found anything that does that. 