### PR TITLE
Fail upload only for validation ERRORs and not necessarily WARNINGs or HINTs + log all errors

### DIFF
--- a/dandi/upload.py
+++ b/dandi/upload.py
@@ -155,8 +155,8 @@ def upload(
                                 strpath,
                                 len(validation_errors),
                             )
-                            for i, e in enumerate(validation_errors):
-                                lgr.warning(" Error %d: %s", i + 1, e)
+                            for i, e in enumerate(validation_errors, start=1):
+                                lgr.warning(" Error %d: %s", i, e)
                             yield skip_file("failed validation")
                             return
                     else:

--- a/dandi/upload.py
+++ b/dandi/upload.py
@@ -22,6 +22,7 @@ from .files import (
 )
 from .misctypes import Digest
 from .utils import ensure_datetime, get_instance, pluralize
+from .validate_types import Severity
 
 if TYPE_CHECKING:
     from .support.typing import TypedDict
@@ -141,11 +142,21 @@ def upload(
                 # TODO: enable back validation of dandiset.yaml
                 if isinstance(dfile, LocalAsset) and validation != "skip":
                     yield {"status": "pre-validating"}
-                    validation_errors = dfile.get_validation_errors()
+                    validation_statuses = dfile.get_validation_errors()
+                    validation_errors = [
+                        s for s in validation_statuses if s.severity == Severity.ERROR
+                    ]
                     yield {"errors": len(validation_errors)}
                     # TODO: split for dandi, pynwb errors
                     if validation_errors:
                         if validation == "require":
+                            lgr.warning(
+                                "%r had %d validation errors preventing its upload:",
+                                strpath,
+                                len(validation_errors),
+                            )
+                            for i, e in enumerate(validation_errors):
+                                lgr.warning(" Error %d: %s", i + 1, e)
                             yield skip_file("failed validation")
                             return
                     else:


### PR DESCRIPTION
Reported by a user in slack to be unable to upload a file, although validation did not report any errors.  Apparently we did not log errors and it was impossible to figure out what is going on.  So I have also added logging of those validation errors, without any custom serialization into a string so we log the most complete (and possibly the most useful since provides information on paths within file etc) representation.

Closes #1185 