### PR TITLE
RF/BF: make find_parent_directory_containing operate on absolute path

### DIFF
--- a/dandi/utils.py
+++ b/dandi/utils.py
@@ -408,13 +408,19 @@ def find_parent_directory_containing(
 ) -> Optional[Path]:
     """Find a directory, on the path to 'path' containing filename
 
-    if no 'path' - path from cwd
-    Returns None if no such found, pathlib's Path to the directory if found
+    if no 'path' - path from cwd. If 'path' is not absolute, absolute path
+    is taken assuming relative to cwd.
+
+    Returns None if no such found, pathlib's Path (absolute) to the directory
+    if found.
     """
     if not path:
         path = Path.cwd()
     else:  # assure pathlib object
         path = Path(path)
+
+    if not path.is_absolute():
+        path = path.absolute()
 
     while True:
         if (path / filename).exists():


### PR DESCRIPTION
The problem was that it would not work whenever path is relative path -- it would simply not go up the hierarchy since parents would not include parent directory above current directory so we would not be able to determine the parent above CWD given relative path from CWD.

As a side effect we change return value of find_parent_directory_containing to always be absolute path

Closes #1187 

TODOs
- [x] add dedicated test for `find_parent_directory_containing` - it seems that there is none, so not surprising we had buggy implementation.  ~~@jwodder @TheChymera  could you please enrich with the test here?~~