### PR TITLE
List in documentation the "high level" interfaces corresponding to CLI

### DIFF
--- a/dandi/delete.py
+++ b/dandi/delete.py
@@ -188,6 +188,11 @@ def delete(
     force: bool = False,
     skip_missing: bool = False,
 ) -> None:
+    """Delete dandisets and assets from the server.
+
+    PATH could be a local path or a URL to an asset, directory, or an entire
+    dandiset.
+    """
     deleter = Deleter(skip_missing=skip_missing)
     for p in paths:
         if is_url(p):

--- a/dandi/validate.py
+++ b/dandi/validate.py
@@ -27,7 +27,7 @@ def validate_bids(
 
     Parameters
     ----------
-    paths : *str
+    paths : list(str)
         Paths to validate.
     schema_version : str, optional
         BIDS schema version to use, this setting will override the version specified in the dataset.
@@ -46,7 +46,7 @@ def validate_bids(
 
     Notes
     -----
-    * Eventually this should be migrated to BIDS schema specified errors, see discussion here:
+    - Eventually this should be migrated to BIDS schema specified errors, see discussion here:
         https://github.com/bids-standard/bids-specification/issues/1262
     """
 
@@ -155,7 +155,7 @@ def validate(
 
     Parameters
     ----------
-    paths: *str
+    paths: list(str)
       Could be individual (.nwb) files or a single dandiset path.
 
     Yields

--- a/docs/source/cmdline/index.rst
+++ b/docs/source/cmdline/index.rst
@@ -1,3 +1,5 @@
+.. _chap_cmdline:
+
 **********************
 Command-Line Interface
 **********************

--- a/docs/source/modref/index.rst
+++ b/docs/source/modref/index.rst
@@ -12,12 +12,32 @@ Python API
 High-level user interfaces
 ==========================
 
+Such interfaces mirror :ref:`Command-Line Interfaces <chap_cmdline>`.
+
+.. autosummary::
+   :toctree: generated
+
+   delete
+   download
+   move
+   organize
+   upload
+   validate
+
+Mid-level user interfaces
+==========================
+
+These interfaces provide Object-Oriented-Programming oriented interfaces to manipulate dandisets and assets in the
+archive.
+
 .. toctree::
 
    dandiarchive
 
-Mid-level user interfaces
+Low-level user interfaces
 =========================
+
+Low level interfaces to e.g. interact with archive REST API interfaces and files directly.
 
 .. toctree::
 

--- a/docs/source/modref/index.rst
+++ b/docs/source/modref/index.rst
@@ -27,7 +27,7 @@ Such interfaces mirror :ref:`Command-Line Interfaces <chap_cmdline>`.
 Mid-level user interfaces
 ==========================
 
-These interfaces provide Object-Oriented-Programming oriented interfaces to manipulate dandisets and assets in the
+These interfaces provide object-oriented interfaces to manipulate Dandisets and assets in the
 archive.
 
 .. toctree::


### PR DESCRIPTION
as consequence, lower the other two levels to Mid/Low levels (unless there is objection)

but how to point to the specific functions (e.g. `download.download`) instead of full modref -- @jwodder could you make it happen since I have tried some ways and keep making sphinx unhappy