### PR TITLE
Pass $USER to tox envs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = lint,typing,py3
 setenv =
     DANDI_ALLOW_LOCALHOST_URLS=1
     DANDI_PAGINATION_DISABLE_FALLBACK=1
-passenv = DANDI_*
+passenv = DANDI_*,USER
 extras = test
 commands =
     # Using pytest-cov instead of using coverage directly leaves a bunch of


### PR DESCRIPTION
Recent versions of Docker and/or Docker Compose require the `$USER` envvar to be set, yet tox unsets this envvar by default.  This PR fixes that.