### PR TITLE
Fix type errors; unbound mypy

### DIFF
--- a/dandi/metadata.py
+++ b/dandi/metadata.py
@@ -511,7 +511,7 @@ species_map = [
 ]
 
 
-@lru_cache(maxsize=None)
+@lru_cache(maxsize=None)  # type: ignore[arg-type]
 @tenacity.retry(
     reraise=True,
     stop=tenacity.stop_after_attempt(3),
@@ -564,7 +564,9 @@ def extract_species(metadata: dict) -> Optional[models.SpeciesType]:
                 value_id = value_orig
                 lookup = ("rdfs:label", "oboInOwl:hasExactSynonym")
                 try:
-                    result = parse_purlobourl(value_orig, lookup=lookup)
+                    result: Optional[Dict[str, str]] = parse_purlobourl(
+                        value_orig, lookup=lookup
+                    )
                 except ConnectionError:
                     value = None
                 else:

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ commands =
 
 [testenv:typing]
 deps =
-    mypy~=0.900
+    mypy
     types-appdirs
     types-python-dateutil
     types-requests


### PR DESCRIPTION
This silences some typing errors related in some inscrutable way to the latest version of `retrying`.  It also unrestricts the maximum mypy version so that we can use the newly-released v1.0.