### PR TITLE
BF+RF validation

### DIFF
--- a/dandi/files/bases.py
+++ b/dandi/files/bases.py
@@ -470,6 +470,12 @@ class NWBAsset(LocalFileAsset):
         schema_version: Optional[str] = None,
         devel_debug: bool = False,
     ) -> list[ValidationResult]:
+        """Validate NWB asset
+
+        If `schema_version` was provided, we only validate basic metadata,
+        and completely skip validation using nwbinspector.inspect_nwb
+
+        """
         errors: list[ValidationResult] = pynwb_validate(
             self.filepath, devel_debug=devel_debug
         )

--- a/dandi/files/bases.py
+++ b/dandi/files/bases.py
@@ -181,23 +181,7 @@ class LocalAsset(DandiFile):
         except ValidationError as e:
             if devel_debug:
                 raise
-            # TODO: how do we get **all** errors from validation - there must be a way
-            return [
-                ValidationResult(
-                    origin=ValidationOrigin(
-                        name="dandischema",
-                        version=dandischema.__version__,
-                    ),
-                    severity=Severity.ERROR,
-                    id="dandischema.TODO",
-                    scope=Scope.FILE,
-                    # metadata=metadata,
-                    path=self.filepath,  # note that it is not relative .path
-                    message=str(e),
-                    # TODO? dataset_path=dataset_path,
-                    dandiset_path=self.dandiset_path,
-                )
-            ]
+            return _pydantic_errors_to_validation_results(e, str(self.filepath))
         except Exception as e:
             if devel_debug:
                 raise

--- a/dandi/files/bases.py
+++ b/dandi/files/bases.py
@@ -478,7 +478,7 @@ class NWBAsset(LocalFileAsset):
     ) -> list[ValidationResult]:
         """Validate NWB asset
 
-        If `schema_version` was provided, we only validate basic metadata,
+        If ``schema_version`` was provided, we only validate basic metadata,
         and completely skip validation using nwbinspector.inspect_nwb
 
         """

--- a/dandi/files/bases.py
+++ b/dandi/files/bases.py
@@ -131,7 +131,7 @@ class DandisetMetadataFile(DandiFile):
                 if devel_debug:
                     raise
                 return _pydantic_errors_to_validation_results(
-                    [e], str(self.filepath), scope=Scope.DANDISET
+                    [e], self.filepath, scope=Scope.DANDISET
                 )
             return []
 
@@ -186,7 +186,7 @@ class LocalAsset(DandiFile):
             if devel_debug:
                 raise
             return _pydantic_errors_to_validation_results(
-                e, str(self.filepath), scope=Scope.FILE
+                e, self.filepath, scope=Scope.FILE
             )
         except Exception as e:
             if devel_debug:
@@ -535,7 +535,7 @@ class NWBAsset(LocalFileAsset):
                     raise
                 # TODO: might reraise instead of making it into an error
                 return _pydantic_errors_to_validation_results(
-                    [e], str(self.filepath), scope=Scope.FILE
+                    [e], self.filepath, scope=Scope.FILE
                 )
 
         from .bids import NWBBIDSAsset
@@ -740,7 +740,7 @@ def _get_nwb_inspector_version():
 
 def _pydantic_errors_to_validation_results(
     errors: list[dict | Exception] | ValidationError,
-    file_path: str,
+    file_path: Path,
     scope: Scope,
 ) -> list[ValidationResult]:
     """Convert list of dict from pydantic into our custom object."""
@@ -773,7 +773,7 @@ def _pydantic_errors_to_validation_results(
                 severity=Severity.ERROR,
                 id=id,
                 scope=scope,
-                path=Path(file_path),
+                path=file_path,
                 message=message,
                 # TODO? dataset_path=dataset_path,
                 # TODO? dandiset_path=dandiset_path,

--- a/dandi/files/zarr.py
+++ b/dandi/files/zarr.py
@@ -190,12 +190,13 @@ class ZarrAsset(LocalDirectoryAsset[LocalZarrEntry]):
         schema_version: Optional[str] = None,
         devel_debug: bool = False,
     ) -> list[ValidationResult]:
+        errors: list[ValidationResult] = []
         try:
             data = zarr.open(self.filepath)
         except Exception:
             if devel_debug:
                 raise
-            return [
+            errors.append(
                 ValidationResult(
                     origin=ValidationOrigin(
                         name="zarr",
@@ -207,9 +208,10 @@ class ZarrAsset(LocalDirectoryAsset[LocalZarrEntry]):
                     path=self.filepath,
                     message="Error opening file.",
                 )
-            ]
+            )
+            data = None
         if isinstance(data, zarr.Group) and not data:
-            return [
+            errors.append(
                 ValidationResult(
                     origin=ValidationOrigin(
                         name="zarr",
@@ -221,12 +223,12 @@ class ZarrAsset(LocalDirectoryAsset[LocalZarrEntry]):
                     path=self.filepath,
                     message="Zarr group is empty.",
                 )
-            ]
+            )
         if self._is_too_deep():
             msg = f"Zarr directory tree more than {MAX_ZARR_DEPTH} directories deep"
             if devel_debug:
                 raise ValueError(msg)
-            return [
+            errors.append(
                 ValidationResult(
                     origin=ValidationOrigin(
                         name="zarr",
@@ -238,9 +240,8 @@ class ZarrAsset(LocalDirectoryAsset[LocalZarrEntry]):
                     path=self.filepath,
                     message=msg,
                 )
-            ]
-        # TODO: Should this be appended to the above errors?
-        return super().get_validation_errors(
+            )
+        return errors + super().get_validation_errors(
             schema_version=schema_version, devel_debug=devel_debug
         )
 

--- a/dandi/files/zarr.py
+++ b/dandi/files/zarr.py
@@ -31,7 +31,7 @@ from dandi.dandiapi import (
     RESTFullAPIClient,
 )
 from dandi.metadata import get_default_metadata
-from dandi.misctypes import BasePath, Digest
+from dandi.misctypes import DUMMY_DANDI_ZARR_CHECKSUM, BasePath, Digest
 from dandi.support.digests import get_digest, get_zarr_checksum, md5file_nocache
 from dandi.utils import chunked, exclude_from_zarr, pluralize
 
@@ -132,6 +132,8 @@ class ZarrStat:
 
 class ZarrAsset(LocalDirectoryAsset[LocalZarrEntry]):
     """Representation of a local Zarr directory"""
+
+    _DUMMY_DIGEST = DUMMY_DANDI_ZARR_CHECKSUM
 
     @property
     def filetree(self) -> LocalZarrEntry:

--- a/dandi/files/zarr.py
+++ b/dandi/files/zarr.py
@@ -192,7 +192,7 @@ class ZarrAsset(LocalDirectoryAsset[LocalZarrEntry]):
     ) -> list[ValidationResult]:
         errors: list[ValidationResult] = []
         try:
-            data = zarr.open(self.filepath)
+            data = zarr.open(str(self.filepath))
         except Exception:
             if devel_debug:
                 raise

--- a/dandi/misctypes.py
+++ b/dandi/misctypes.py
@@ -53,7 +53,7 @@ class Digest:
 DUMMY_DANDI_ETAG = Digest(algorithm=DigestType.dandi_etag, value=32 * "d" + "-1")
 DUMMY_DANDI_ZARR_CHECKSUM = Digest(
     algorithm=DigestType.dandi_zarr_checksum,
-    value="2ed39fd5ae56fd4177c4eb503d163528-1--1",
+    value=32 * "d" + "-1--1",
 )
 
 P = TypeVar("P", bound="BasePath")

--- a/dandi/misctypes.py
+++ b/dandi/misctypes.py
@@ -50,7 +50,11 @@ class Digest:
 
 #: Placeholder digest used in some situations where a digest is required but
 #: not actually relevant and would be too expensive to calculate
-DUMMY_DIGEST = Digest(algorithm=DigestType.dandi_etag, value=32 * "d" + "-1")
+DUMMY_DANDI_ETAG = Digest(algorithm=DigestType.dandi_etag, value=32 * "d" + "-1")
+DUMMY_DANDI_ZARR_CHECKSUM = Digest(
+    algorithm=DigestType.dandi_zarr_checksum,
+    value="2ed39fd5ae56fd4177c4eb503d163528-1--1",
+)
 
 P = TypeVar("P", bound="BasePath")
 

--- a/dandi/pynwb_utils.py
+++ b/dandi/pynwb_utils.py
@@ -346,7 +346,6 @@ def validate(
         else:  # Fallback if an older version
             with pynwb.NWBHDF5IO(path=path, mode="r", load_namespaces=True) as reader:
                 error_outputs = pynwb.validate(io=reader)
-        # TODO: return ValidationResult structs
         for error_output in error_outputs:
             errors.append(
                 ValidationResult(

--- a/dandi/pynwb_utils.py
+++ b/dandi/pynwb_utils.py
@@ -364,20 +364,18 @@ def validate(
     except Exception as exc:
         if devel_debug:
             raise
-        errors.extend(
-            [
-                ValidationResult(
-                    origin=ValidationOrigin(
-                        name="pynwb",
-                        version=pynwb.__version__,
-                    ),
-                    severity=Severity.ERROR,
-                    id="pywnb.GENERIC",
-                    scope=Scope.FILE,
-                    path=Path(path),
-                    message=f"{exc}",
-                )
-            ]
+        errors.append(
+            ValidationResult(
+                origin=ValidationOrigin(
+                    name="pynwb",
+                    version=pynwb.__version__,
+                ),
+                severity=Severity.ERROR,
+                id="pywnb.GENERIC",
+                scope=Scope.FILE,
+                path=Path(path),
+                message=f"{exc}",
+            )
         )
 
     # To overcome


### PR DESCRIPTION
Might still be incomplete since I left  in place the odd dichotomy of results in validation depending on either schema_version is provided or not, as emphasized in the tests at https://github.com/dandi/dandi-cli/blob/HEAD/dandi/tests/test_files.py#L313 . @jwodder @TheChymera do you remember a reason why we did it this way?

meanwhile I made `LocalAsset` to always validate against schema even if a `schema_version` is not provided and that might be going against some logic which is pointed to above.  But I think we should simplify/harmonize it here one way or another: we might want to always validate against everything possible and then results just filtered, or would need to pass some *filtering* option (e.g. listing validation `id` prefixes thus to enable only some) to select which validators to use.  So if no objections/concerns would be stated, I would proceed to remove dichotomy in NWBAsset validation and always include super's validation (thus validation against schema).

Then I fixed up validation of zarrs in that their metadata records should be populated with zarr specific  dummy checksum (previously tests would not even get to that case I believe).