### PR TITLE
Update `parse_purlobourl()` test for change to rat metadata

### DIFF
--- a/dandi/tests/test_metadata.py
+++ b/dandi/tests/test_metadata.py
@@ -392,7 +392,7 @@ def test_time_extract_gest() -> None:
             "http://purl.obolibrary.org/obo/NCBITaxon_10116",
             {
                 "rdfs:label": "Rattus norvegicus",
-                "oboInOwl:hasExactSynonym": "Norway rat",
+                "oboInOwl:hasExactSynonym": "Rat",
             },
         ),
         (

--- a/dandi/tests/test_metadata.py
+++ b/dandi/tests/test_metadata.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import shutil
 from typing import Any, Dict, Optional, Tuple, Union
 
+from anys import AnyIn
 from dandischema.consts import DANDI_SCHEMA_VERSION
 from dandischema.metadata import validate
 from dandischema.models import AgeReferenceType
@@ -392,7 +393,9 @@ def test_time_extract_gest() -> None:
             "http://purl.obolibrary.org/obo/NCBITaxon_10116",
             {
                 "rdfs:label": "Rattus norvegicus",
-                "oboInOwl:hasExactSynonym": "Rat",
+                "oboInOwl:hasExactSynonym": AnyIn(
+                    ["Rat", "Rats", "Brown rat", "Norway rat"]
+                ),
             },
         ),
         (


### PR DESCRIPTION
`test_metadata.py::test_parseobourl[http://purl.obolibrary.org/obo/NCBITaxon_10116-value1]` is currently failing because the obolibrary resource now lists "rat" rather than "Norway rat" as the first `oboInOwl:hasExactSynonym` entry.