### PR TITLE
skip test_nwb2asset_remote_asset if no fsspec installed

### DIFF
--- a/dandi/tests/test_metadata.py
+++ b/dandi/tests/test_metadata.py
@@ -800,6 +800,7 @@ def test_nwb2asset(simple2_nwb: Path) -> None:
 def test_nwb2asset_remote_asset(
     new_dandiset: SampleDandiset, organized_nwb_dir: Path
 ) -> None:
+    pytest.importorskip("fsspec")
     d = new_dandiset.dandiset
     dspath = new_dandiset.dspath
     (nwb_file,) = [


### PR DESCRIPTION
fsspec installed only in "[extras]" extra_requires, so not by default. I tested that it is enough of "pip install fsspec" without "[http]" extras and test passes then.

Discovered needed while downstream testing  https://github.com/dandi/dandi-schema/pull/100 . Since we are installing `dandi` as released IIRC also for downstream in dandi-archive, I am marking this one for release so we get green again.