### PR TITLE
Restrict mypy to pre-v1.1.1

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ commands =
 
 [testenv:typing]
 deps =
-    mypy
+    mypy<1.1.1
     types-appdirs
     types-python-dateutil
     types-requests


### PR DESCRIPTION
Type-checking of pydantic types is broken in many respects under mypy 1.1.1 (See https://github.com/pydantic/pydantic/issues/5148), so until pydantic publishes a new release with a fix, we need to use an older mypy in order to get type-checking to pass.