### PR TITLE
Revert "Restrict mypy to pre-v1.1.1"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ commands =
 
 [testenv:typing]
 deps =
-    mypy<1.1.1
+    mypy
     types-appdirs
     types-python-dateutil
     types-requests


### PR DESCRIPTION
This reverts commit 042eff5e7feb555caf19ec4786001445c98193b5 / #1246.

Pydantic 1.10.6, released yesterday, fixes the mypy integration.