### PR TITLE
validate: resolved issues with relative path input

### DIFF
--- a/dandi/tests/test_validate.py
+++ b/dandi/tests/test_validate.py
@@ -16,6 +16,17 @@ def test_validate_nwb_error(simple3_nwb: Path) -> None:
     assert len([i for i in validation_result if i.severity]) > 0
 
 
+def test_validate_relative_path(
+    bids_examples: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    selected_dataset_path = bids_examples / "asl003"
+    monkeypatch.chdir(selected_dataset_path)
+    # improper relative path handling would fail with:
+    # ValueError: Path '.' is not inside Dandiset path '/tmp/.../asl003'
+    validate(".")
+
+
 def test_validate_empty(tmp_path: Path) -> None:
     assert list(validate(tmp_path)) == [
         ValidationResult(

--- a/dandi/validate.py
+++ b/dandi/validate.py
@@ -149,7 +149,7 @@ def validate(
       errors for a path
     """
     for p in paths:
-        p = os.path.abspath(os.path.expanduser(p))
+        p = os.path.abspath(p)
         dandiset_path = find_parent_directory_containing(dandiset_metadata_file, p)
         if dandiset_path is None:
             yield ValidationResult(

--- a/dandi/validate.py
+++ b/dandi/validate.py
@@ -149,6 +149,7 @@ def validate(
       errors for a path
     """
     for p in paths:
+        p = os.path.abspath(os.path.expanduser(p))
         dandiset_path = find_parent_directory_containing(dandiset_metadata_file, p)
         if dandiset_path is None:
             yield ValidationResult(


### PR DESCRIPTION
This is what could happen before this:

```
(dev) [deco]~/src/bids-examples/asl003 ❱ dandi validate .
2023-04-03 12:43:56,852 [    INFO] Note: NumExpr detected 12 cores but "NUMEXPR_MAX_THREADS" not set, so enforcing safe limit of 8.
2023-04-03 12:43:56,852 [    INFO] NumExpr defaulting to 8 threads.
2023-04-03 12:43:58,230 [    INFO] Logs saved in /home/chymera/.cache/dandi-cli/log/20230403164355Z-7402.log
Error: Path '.' is not inside Dandiset path '/home/chymera/src/bids-examples/asl003'
```