### PR TITLE
Log results of `requests.utils.super_len()` when `DANDI_DEVEL_INSTRUMENT_REQUESTS_SUPERLEN` is set

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,6 +82,7 @@ jobs:
         sudo mount -t nfs localhost:/tmp/nfsmount_ /tmp/nfsmount
         echo TMPDIR=/tmp/nfsmount/tmp >> "$GITHUB_ENV"
         echo HOME=/tmp/nfsmount/home >> "$GITHUB_ENV"
+        echo DANDI_DEVEL_INSTRUMENT_REQUESTS_SUPERLEN=1 >> "$GITHUB_ENV"
 
     - name: Run all tests
       if: matrix.mode != 'dandi-api'

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -78,6 +78,10 @@ development command line options.
   tests will not pull the latest needed Docker images at the start of a run if
   older versions of the images are already present.
 
+- `DANDI_DEVEL_INSTRUMENT_REQUESTS_SUPERLEN` -- When set, the `upload()`
+  function will patch `requests` to log the results of calls to
+  `requests.utils.super_len()`
+
 ## Sourcegraph
 
 The [Sourcegraph](https://sourcegraph.com) browser extension can be used to

--- a/dandi/files/zarr.py
+++ b/dandi/files/zarr.py
@@ -3,14 +3,13 @@ from __future__ import annotations
 from base64 import b64encode
 from collections.abc import Generator, Iterator
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
-from contextlib import ExitStack, closing
+from contextlib import closing
 from dataclasses import dataclass, field, replace
 from datetime import datetime
 import os
 from pathlib import Path
 from time import sleep
 from typing import Any, Optional
-from unittest.mock import patch
 
 from dandischema.digests.zarr import get_checksum
 from dandischema.models import BareAsset, DigestType
@@ -541,38 +540,14 @@ class ZarrAsset(LocalDirectoryAsset[LocalZarrEntry]):
 def _upload_zarr_file(
     storage_session: RESTFullAPIClient, upload_url: str, item: UploadItem
 ) -> int:
-    with ExitStack() as stack:
-        if os.environ.get("DANDI_DEVEL_INSTRUMENT_REQUESTS_SUPERLEN"):
-            from requests.utils import super_len
-
-            def new_super_len(o):
-                try:
-                    n = super_len(o)
-                except Exception:
-                    lgr.debug(
-                        "requests.utils.super_len() failed while uploading %s:",
-                        item.filepath,
-                        exc_info=True,
-                    )
-                    raise
-                else:
-                    lgr.debug(
-                        "requests.utils.super_len() reported %d while uploading %s",
-                        n,
-                        item.filepath,
-                    )
-                    return n
-
-            stack.enter_context(patch("requests.models.super_len", new_super_len))
-
-        with item.filepath.open("rb") as fp:
-            storage_session.put(
-                upload_url,
-                data=fp,
-                json_resp=False,
-                retry_if=_retry_zarr_file,
-                headers={"Content-MD5": item.base64_digest},
-            )
+    with item.filepath.open("rb") as fp:
+        storage_session.put(
+            upload_url,
+            data=fp,
+            json_resp=False,
+            retry_if=_retry_zarr_file,
+            headers={"Content-MD5": item.base64_digest},
+        )
     return item.size
 
 


### PR DESCRIPTION
Part of #1257.