### PR TITLE
Disable NFS caching in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,7 @@ jobs:
         echo "/tmp/nfsmount_ localhost(rw)" | sudo tee /etc/exports
         sudo apt-get install -y nfs-kernel-server
         sudo exportfs -a
-        sudo mount -t nfs localhost:/tmp/nfsmount_ /tmp/nfsmount
+        sudo mount -t nfs -o sync localhost:/tmp/nfsmount_ /tmp/nfsmount
         echo TMPDIR=/tmp/nfsmount/tmp >> "$GITHUB_ENV"
         echo HOME=/tmp/nfsmount/home >> "$GITHUB_ENV"
         echo DANDI_DEVEL_INSTRUMENT_REQUESTS_SUPERLEN=1 >> "$GITHUB_ENV"


### PR DESCRIPTION
By default, NFS caches writes client-side until one of a small number of events occur (none of which apply to the failing `test_dandi_file_zarr_with_excluded_dotfiles` test).  Setting the `sync` option should disable caching.

Closes #1269.