### PR TITLE
Use `inspect_nwbfile()` instead of `inspect_nwb()`; address bug in recent `ruamel.yaml` versions

### DIFF
--- a/dandi/files/bases.py
+++ b/dandi/files/bases.py
@@ -19,7 +19,7 @@ from dandischema.models import BareAsset, CommonModel
 from dandischema.models import Dandiset as DandisetMeta
 from dandischema.models import get_schema_version
 from etelemetry import get_project
-from nwbinspector import Importance, inspect_nwb, load_config
+from nwbinspector import Importance, inspect_nwbfile, load_config
 from nwbinspector.utils import get_package_version
 from packaging.version import Version
 from pydantic import ValidationError
@@ -492,11 +492,11 @@ class NWBAsset(LocalFileAsset):
         schema_version: Optional[str] = None,
         devel_debug: bool = False,
     ) -> list[ValidationResult]:
-        """Validate NWB asset
+        """
+        Validate NWB asset
 
         If ``schema_version`` was provided, we only validate basic metadata,
-        and completely skip validation using nwbinspector.inspect_nwb
-
+        and completely skip validation using nwbinspector.inspect_nwbfile
         """
         errors: list[ValidationResult] = pynwb_validate(
             self.filepath, devel_debug=devel_debug
@@ -515,7 +515,7 @@ class NWBAsset(LocalFileAsset):
                     version=str(_get_nwb_inspector_version()),
                 )
 
-                for error in inspect_nwb(
+                for error in inspect_nwbfile(
                     nwbfile_path=self.filepath,
                     skip_validate=True,
                     config=load_config(filepath_or_keyword="dandi"),

--- a/dandi/metadata.py
+++ b/dandi/metadata.py
@@ -555,10 +555,8 @@ def parse_purlobourl(
     req.raise_for_status()
     doc = parseString(req.text)
     for elfound in doc.getElementsByTagName("Class"):
-        if (
-            "rdf:about" in elfound.attributes.keys()
-            and elfound.attributes.getNamedItem("rdf:about").value == url
-        ):
+        about = elfound.attributes.getNamedItem("rdf:about")
+        if about is not None and about.value == url:
             break
     else:
         return None
@@ -568,8 +566,8 @@ def parse_purlobourl(
     for key in lookup:
         elchild = elfound.getElementsByTagName(key)
         if elchild:
-            elchild = elchild[0]
-            values[key] = elchild.childNodes[0].nodeValue.capitalize()
+            elchild0 = elchild[0]
+            values[key] = elchild0.childNodes[0].nodeValue.capitalize()
     return values
 
 

--- a/dandi/organize.py
+++ b/dandi/organize.py
@@ -604,7 +604,6 @@ def populate_dataset_yml(filepath, metadata):
         age["minimum"] = min(uvs["age"])
         age["maximum"] = max(uvs["age"])
         if age.get("units", None) in (None,) + DEFAULT_VALUES:  # template
-            age.pop("units", None)
             age.insert(2, "units", "TODO", comment="REQUIRED")
 
     if uvs["sex"]:

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ install_requires =
     pycryptodomex  # for EncryptedKeyring backend in keyrings.alt
     pydantic >= 1.9.0
     pynwb >= 1.0.3,!=1.1.0,!=2.3.0
-    nwbinspector >= 0.4.12
+    nwbinspector >= 0.4.28
     pyout >=0.5, !=0.6.0
     python-dateutil
     requests ~= 2.20


### PR DESCRIPTION
The test suite has been failing for the past few days with the following causes:

- Calls to `nwbinspector.inspect_nwb()` (used to validate NWB files) were returning an error message reading:

    > The API function 'inspect_nwb' has been deprecated and will be removed in a future release! To remove ambiguity, please call either 'inspect_nwbfile' giving a path to the unopened file on a system, or 'inspect_nwbfile_object' passing an already open pynwb.NWBFile object.

  and this ended up in the set of validation errors.  I have replaced `inspect_nwb()` with `inspect_nwbfile()`.

- [A bug in recent versions of `ruamel.yaml`](https://sourceforge.net/p/ruamel-yaml/tickets/461/) was causing a certain spot in `organize.py` to fail.  I addressed this by removing the `age.pop("units", None)` line, which seems to be unnecessary (at least in ruamel.yaml 0.17.21, released 2022-02-12, the last release before this month).