### PR TITLE
Cancel any still-running tests when pushing to a branch or PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: '0 6 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
If a commit is pushed while tests are still running on that branch, the older tests will currently continue to run to completion, likely delaying the start of the tests for the newer commit.  This PR causes any still-running tests to be automatically cancelled when new tests start on the same branch.