### PR TITLE
Retry test that intermittently fails on NFS

### DIFF
--- a/dandi/tests/test_files.py
+++ b/dandi/tests/test_files.py
@@ -294,6 +294,8 @@ def test_find_dandi_files_with_bids(tmp_path: Path) -> None:
         assert asset.bids_dataset_description is bidsdd
 
 
+# This test sometimes fails and sometimes passes when running on NFS.
+@pytest.mark.flaky(reruns=10)
 def test_dandi_file_zarr_with_excluded_dotfiles(tmp_path: Path) -> None:
     zarr_path = tmp_path / "foo.zarr"
     mkpaths(

--- a/setup.cfg
+++ b/setup.cfg
@@ -88,6 +88,7 @@ test =
     pytest
     pytest-cov
     pytest-mock
+    pytest-rerunfailures
     responses
 tools=
     boto3


### PR DESCRIPTION
`test_files.py::test_dandi_file_zarr_with_excluded_dotfiles` keeps intermittently failing on NFS, so this PR uses pytest-rerunfailures to rerun it up to ten times until it succeeds.