### PR TITLE
Don't treat certain broken symlinks as absent files

### DIFF
--- a/dandi/dandiset.py
+++ b/dandi/dandiset.py
@@ -38,8 +38,10 @@ class Dandiset:
                 )
         self.path = str(path)
         self.path_obj = Path(path)
-        if not allow_empty and not (self.path_obj / dandiset_metadata_file).exists():
-            raise ValueError(f"No Dandiset at {path}")
+        if not allow_empty and not os.path.lexists(
+            self.path_obj / dandiset_metadata_file
+        ):
+            raise ValueError(f"No dandiset at {path}")
         self.metadata: Optional[dict] = None
         self._metadata_file_obj = self.path_obj / dandiset_metadata_file
         self._load_metadata()

--- a/dandi/files/__init__.py
+++ b/dandi/files/__init__.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from collections import deque
 from collections.abc import Iterator
+import os.path
 from pathlib import Path
 from typing import Optional
 
@@ -115,7 +116,7 @@ def find_dandi_files(
             if p.is_symlink():
                 lgr.warning("%s: Ignoring unsupported symbolic link to directory", p)
             elif dandiset_path is not None and p == Path(dandiset_path):
-                if (p / BIDS_DATASET_DESCRIPTION).exists():
+                if os.path.lexists(p / BIDS_DATASET_DESCRIPTION):
                     bids = dandi_file(p / BIDS_DATASET_DESCRIPTION, dandiset_path)
                     assert isinstance(bids, BIDSDatasetDescriptionAsset)
                     bidsdd = bids
@@ -129,7 +130,7 @@ def find_dandi_files(
                     # (ie., it's not a Zarr or any other directory asset type
                     # we may add later), so traverse through it as a regular
                     # directory.
-                    if (p / BIDS_DATASET_DESCRIPTION).exists() and not any(
+                    if os.path.lexists(p / BIDS_DATASET_DESCRIPTION) and not any(
                         i in p.parents for i in bids_roots
                     ):  # No nested BIDS
                         bids2 = dandi_file(p / BIDS_DATASET_DESCRIPTION, dandiset_path)

--- a/dandi/files/bids.py
+++ b/dandi/files/bids.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime
+import os.path
 from pathlib import Path
 from threading import Lock
 from typing import List, Optional
@@ -81,7 +82,7 @@ class BIDSDatasetDescriptionAsset(LocalFileAsset):
                 for ext in readme_extensions:
                     readme_candidate = self.bids_root / Path("README" + ext)
                     if (
-                        readme_candidate.exists()
+                        os.path.lexists(readme_candidate)
                         and str(readme_candidate) not in bids_paths
                     ):
                         bids_paths += [str(readme_candidate)]

--- a/dandi/files/zarr.py
+++ b/dandi/files/zarr.py
@@ -7,6 +7,7 @@ from contextlib import closing
 from dataclasses import dataclass, field, replace
 from datetime import datetime
 import os
+import os.path
 from pathlib import Path
 from time import sleep
 from typing import Any, Optional
@@ -71,7 +72,7 @@ class LocalZarrEntry(BasePath):
             return replace(self, filepath=self.filepath.parent, parts=self.parts[:-1])
 
     def exists(self) -> bool:
-        return self.filepath.exists()
+        return os.path.lexists(self.filepath)
 
     def is_file(self) -> bool:
         return self.filepath.is_file()

--- a/dandi/move.py
+++ b/dandi/move.py
@@ -444,7 +444,7 @@ class LocalMover(LocalizedMover):
         """
         rpath, needs_dir = self.resolve(path)
         p = self.dandiset_path / rpath
-        if not p.exists():
+        if not os.path.lexists(p):
             raise NotFoundError(f"No asset at local path {path!r}")
         if p.is_dir():
             if is_src:

--- a/dandi/upload.py
+++ b/dandi/upload.py
@@ -373,10 +373,9 @@ def upload(
             path_prefix = reduce(os.path.commonprefix, relpaths)  # type: ignore[arg-type]
             to_delete = []
             for asset in remote_dandiset.get_assets_with_path_prefix(path_prefix):
-                if (
-                    any(p == "" or path_is_subpath(asset.path, p) for p in relpaths)
-                    and not Path(dandiset.path, asset.path).exists()
-                ):
+                if any(
+                    p == "" or path_is_subpath(asset.path, p) for p in relpaths
+                ) and not os.path.lexists(Path(dandiset.path, asset.path)):
                     to_delete.append(asset)
             if to_delete and click.confirm(
                 f"Delete {pluralize(len(to_delete), 'asset')} on server?"

--- a/dandi/utils.py
+++ b/dandi/utils.py
@@ -426,7 +426,7 @@ def find_parent_directory_containing(
         path = path.absolute()
 
     while True:
-        if (path / filename).exists():
+        if op.lexists(path / filename):
             return path
         if path.parent == path:
             return None


### PR DESCRIPTION
Closes #1289.

@yarikoptic I can't tell which uses of `exists()` in `dandi/organize.py` should be replaced with `lexists()` and which rely on the file actually being present/openable.  Could you go through the file and check the uses of `exists()` there?