### PR TITLE
Limit bidsschematools version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ project_urls =
 python_requires = >=3.7
 install_requires =
     appdirs
-    bidsschematools >= 0.5.0
+    bidsschematools >= 0.5.0, <0.7.0
     click
     click-didyoumean
     dandischema ~= 0.8.0


### PR DESCRIPTION
Before we merge https://github.com/dandi/dandi-cli/pull/1243 , dandi-cli is not compatible with newest BST.