### PR TITLE
Drop dependency on importlib-metadata backport for Python 3.7

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,6 @@ install_requires =
     fscacher >= 0.3.0
     hdmf != 3.5.0
     humanize
-    importlib-metadata;  python_version < "3.8"
     interleave ~= 0.1
     joblib
     keyring != 23.9.0


### PR DESCRIPTION
Since we no longer support Python 3.7.