### PR TITLE
Update `asset_validation_errors` structure

### DIFF
--- a/dandi/dandiapi.py
+++ b/dandi/dandiapi.py
@@ -693,6 +693,10 @@ class RemoteValidationError(APIBase):
     message: str
 
 
+class RemoteAssetValidationError(RemoteValidationError):
+    path: str
+
+
 class VersionInfo(Version):
     """
     .. versionadded:: 0.49.0
@@ -701,7 +705,7 @@ class VersionInfo(Version):
     errors
     """
 
-    asset_validation_errors: List[RemoteValidationError]
+    asset_validation_errors: List[RemoteAssetValidationError]
     version_validation_errors: List[RemoteValidationError]
 
 

--- a/dandi/dandiapi.py
+++ b/dandi/dandiapi.py
@@ -694,7 +694,7 @@ class RemoteValidationError(APIBase):
 
 
 class RemoteAssetValidationError(RemoteValidationError):
-    path: str
+    path: Optional[str] = None
 
 
 class VersionInfo(Version):


### PR DESCRIPTION
Blocked by https://github.com/dandi/dandi-archive/pull/1579.

Replaces #1288.