### PR TITLE
Fix wait_until_valid to properly wait for a publishable version

### DIFF
--- a/dandi/dandiapi.py
+++ b/dandi/dandiapi.py
@@ -1023,7 +1023,7 @@ class RemoteDandiset:
         start = time()
         while time() - start < max_time:
             v = self.get_version(self.version_id)
-            if v.status is VersionStatus.VALID:
+            if v.status is VersionStatus.VALID and not v.asset_validation_errors:
                 return
             sleep(0.5)
         # TODO: Improve the presentation of the error messages


### PR DESCRIPTION
This brings the CLI up to parity with https://github.com/dandi/dandi-archive/pull/1548. The tldr is that it's not enough to check the version status to know if a version is publishable since the assets must also be valid.

cc @AlmightyYakob @jwodder 