### PR TITLE
ENH: Add support for _desc- entity to label different processings of a file

### DIFF
--- a/dandi/consts.py
+++ b/dandi/consts.py
@@ -194,6 +194,7 @@ dandi_layout_fields = {
     "slice_id": {"format": "_slice-{}"},
     "cell_id": {"format": "_cell-{}"},
     # disambiguation ones
+    "description": {"format": "_desc-{}", "type": "disambiguation"},
     "probe_ids": {"format": "_probe-{}", "type": "disambiguation"},
     "obj_id": {
         "format": "_obj-{}",

--- a/dandi/organize.py
+++ b/dandi/organize.py
@@ -1032,7 +1032,7 @@ LABELREGEX = r"[^_*\\/<>:|\"'?%@;.]+"
 ORGANIZED_FILENAME_REGEX = (
     rf"sub-{LABELREGEX}"
     rf"(_ses-{LABELREGEX})?"
-    rf"(_(tis|slice|cell|probe|obj)-{LABELREGEX})*"
+    rf"(_(tis|slice|cell|desc|probe|obj)-{LABELREGEX})*"
     r"(_[a-z]+(\+[a-z]+)*)?"
     r"\.nwb"
 )

--- a/dandi/tests/test_organize.py
+++ b/dandi/tests/test_organize.py
@@ -237,6 +237,21 @@ def test_ambiguous_probe1() -> None:
     ]
 
 
+def test_ambiguous_desc() -> None:
+    base = dict(subject_id="1", session="2", modalities=["mod"], extension="nwb")
+    # fake filenames should be ok since we never should get to reading them for object_id
+    metadata = [
+        dict(path="1.nwb", **base),
+        dict(path="2.nwb", description="ms5", **base),
+    ]
+    metadata_ = create_unique_filenames_from_metadata(metadata)
+    assert metadata_ != metadata
+    assert [m["dandi_path"] for m in metadata_] == [
+        op.join("sub-1", "sub-1_mod.nwb"),
+        op.join("sub-1", "sub-1_desc-ms5_mod.nwb"),
+    ]
+
+
 @pytest.mark.parametrize(
     "sym_success,hard_success,result",
     [
@@ -332,6 +347,11 @@ def test_video_organize_common(video_mode, nwbfiles_video_common):
     [
         ("XCaMPgf/XCaMPgf_ANM471996_cell01.dat", []),
         ("sub-RAT123/sub-RAT123.nwb", []),
+        ("sub-RAT123/sub-RAT123_desc-label.nwb", []),  # _desc- is supported now
+        (
+            "sub-RAT123/sub-RAT123_notsupported-irrelevant.nwb",
+            ["DANDI.NON_DANDI_FILENAME"],
+        ),
         ("sub-RAT123/sub-RAT124.nwb", ["DANDI.METADATA_MISMATCH_SUBJECT"]),
         ("sub-RAT124.nwb", ["DANDI.NON_DANDI_FOLDERNAME"]),
         ("foo/sub-RAT124.nwb", ["DANDI.NON_DANDI_FOLDERNAME"]),


### PR DESCRIPTION
ref: #1314 

TODO outside of this PR:  check/decide on possibility of `organize` to actually automagically assign such `desc`... unlikely since the space is huge...