### PR TITLE
Check if URL matches the API URL so we do not hardcode wrong "False" for is_api

### DIFF
--- a/dandi/utils.py
+++ b/dandi/utils.py
@@ -596,6 +596,7 @@ class ServerInfo(BaseModel):
 
 def get_instance(dandi_instance_id: str | DandiInstance) -> DandiInstance:
     dandi_id = None
+    is_api = True
     redirector_url = None
     if isinstance(dandi_instance_id, DandiInstance):
         instance = dandi_instance_id
@@ -605,8 +606,10 @@ def get_instance(dandi_instance_id: str | DandiInstance) -> DandiInstance:
         dandi_id = known_instances_rev.get(redirector_url.rstrip("/"))
         if dandi_id is not None:
             instance = known_instances[dandi_id]
+            is_api = instance.api.rstrip("/") == redirector_url.rstrip("/")
         else:
             instance = None
+            is_api = False
             bits = urlparse(redirector_url)
             redirector_url = urlunparse((bits[0], bits[1], "", "", "", ""))
     else:
@@ -616,7 +619,7 @@ def get_instance(dandi_instance_id: str | DandiInstance) -> DandiInstance:
         assert instance is not None
         return _get_instance(instance.api.rstrip("/"), True, instance, dandi_id)
     else:
-        return _get_instance(redirector_url.rstrip("/"), False, instance, dandi_id)
+        return _get_instance(redirector_url.rstrip("/"), is_api, instance, dandi_id)
 
 
 @lru_cache


### PR DESCRIPTION
I have spotted odd log msg while preparing example for https://github.com/dandi/dandi-cli/issues/1317#issuecomment-1673250340:

```shell
❯ dandi download --download dandiset.yaml DANDI:000026
2023-08-10 09:41:54,008 [ WARNING] Request to https://api.dandiarchive.org/api failed (404 Client Error: Not Found for url: https://api.dandiarchive.org/api/api/info/)
2023-08-10 09:41:54,008 [ WARNING] Using hard-coded URLs
...
```

which was apparently due to our assumption that provided URL (here from DANDI: identifiers.org redirect) is not API URL.  I have not looked deeper into that logic, but rather just fixed checking for known instances in case if URL does match a known API end point.