### PR TITLE
Ignore unclosed connection resource warning from VCR

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -66,6 +66,7 @@ filterwarnings =
     ignore:.*Value with data type .* is being converted:hdmf.build.warnings.DtypeConversionWarning
     ignore:.*find_spec\(\) not found:ImportWarning
     ignore:'cgi' is deprecated:DeprecationWarning:botocore
+    ignore:.*unclosed.*:ResourceWarning:vcr
 
 [coverage:run]
 parallel = True


### PR DESCRIPTION
locally (vcr 5.1.0) it causes tests to fail, possibly masking another issue ref: https://github.com/dandi/dandi-cli/issues/1332 which I otherwise fail to reproduce locally