### PR TITLE
Re-record VCR tapes using newer versions of libraries

### DIFF
--- a/dandi/cli/tests/data/update_dandiset_from_doi/biorxiv.vcr.yaml
+++ b/dandi/cli/tests/data/update_dandiset_from_doi/biorxiv.vcr.yaml
@@ -7,7 +7,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - dandi/0.53.0+17.gc2f268f.dirty requests/2.28.2 CPython/3.11.3
+      - dandi/0.56.2+5.ga0199fce.dirty requests/2.31.0 CPython/3.11.6
       accept:
       - application/json
     method: GET
@@ -21,7 +21,7 @@ interactions:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 7bd8e4c52e4a8215-IAD
+      - 81727698abd08c87-EWR
       Connection:
       - keep-alive
       Content-Length:
@@ -29,19 +29,19 @@ interactions:
       Content-Type:
       - text/html;charset=utf-8
       Date:
-      - Tue, 25 Apr 2023 19:11:45 GMT
+      - Mon, 16 Oct 2023 18:46:12 GMT
       NEL:
       - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=SJS2DJ8aGNbnuREMgLzy912O9dvXnZb2JaxDoyHf%2Bt89NGxInojmjPbXGHH6obSowIxEvUFRQOXV0D%2BUUd80pcYWDjAyb8upDquZQJH6wK90J%2BJbBnc2KRGYXFnlLN9zuBrwVX8%3D"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=EDGcAsnWWLKU8tj03j7uq9EVlzy6xYZBi3MtNGzcjVP%2FFeXDm5vKv0bmihqXEY6T5Fl2CaX6you4Hx5FgLmEu%2BEqJQP526h221xcfmW2wn6UJHsxA52UV%2FE%3D"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       alt-svc:
-      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
+      - h3=":443"; ma=86400
       expires:
-      - Tue, 25 Apr 2023 19:32:12 GMT
+      - Mon, 16 Oct 2023 19:27:25 GMT
       location:
       - https://api.crossref.org/v1/works/10.1101%2F2020.01.17.909838/transform
       permissions-policy:
@@ -59,120 +59,134 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - dandi/0.53.0+17.gc2f268f.dirty requests/2.28.2 CPython/3.11.3
+      - dandi/0.56.2+5.ga0199fce.dirty requests/2.31.0 CPython/3.11.6
       accept:
       - application/json
     method: GET
     uri: https://api.crossref.org/v1/works/10.1101%2F2020.01.17.909838/transform
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAA/7Vca3PbuJL9Kyh/mqkSaT5F0nVrt/yMHduJ1/Ykd+Z6agsiIQkRRejyYUfJzn/f
-        0yD1oCwnFu/4iy1RJNDo5+lugN/3ZFaUsqxKqbK9g39938v4VOwd7A2kuv0qH/f++rOHWxLxVSR7
-        B9/3El4KY8bzssDN/3Isx+15Pdv7E3fpn0qpn6YfDMszbO/eCg5c58Bx/9jr7dGvRcmns70Dux/a
-        nh/4nhtF1l+9vZkqyhemsHp2zw7+/BN3jXJVzTBJmdIsH0SVqyKWIosFRs/FUOT02YhVlZV7B30f
-        41aDVBZjkeP+Y5Um7G6Wy2zEznk+UDm74vjLS5XPMUCsslJkpZGoKZeZpqX59C+sL8ZcxZTnEyPH
-        InIZ1ywb8rQQII3HsZj9YAlWL9JL4AM8zGOQt/ePL7wsDmb/dZOrEcYsmMxYsxyWi39XEhcZ+JUl
-        PE/kN5EwXhR8XrCnsSrolqJKy4LFPGMD+soTmc5ZMea5SHosVtNZ/QkD4NdZrpIqpkH0Sli6WLoU
-        hclum9/lQKaynPfYWD2JR5HjAy8wvMgYx5AgLc+IzmyN9z1Ga5VxlfIcBAzB16ngRZWLKdhZMDVk
-        U1WB4oEY80epcpOdQ1LsSYBY9cTKMS8xemulJS8mrFQMVGFtiYhlAXYbUz4h6YGAqQSXmjUVy+XJ
-        QbpiTLPQKb7IGa63V/yZhi3kKCOW1PMR5WOw0RhK6Hs9hSYOvBzIDPOQ+tYKtRQGVjcTOQm/4qnm
-        9SNPK2EMeIGbFpSzmvJaGLTw1mJzaBmtC4soVazqYcRXjCuJhRgXQk2eIM4eK9SwrD/RTXgCMgWr
-        6xXpkTCi7Vk1+Q0PCsgyazGAeFiOcyGYtha6tCQOFKQihjIzH6OkqaZfSzAeKxnrhyEbzrR1xZA5
-        f+QSo4PJ0H1OSzfZleC5XlUxExjqCXr0yHOp71qIRpOISdcp67FBVTJStRVj6GFS6FSUJJJae/An
-        U4xEKIcSVlCyRA4bH6DXt9C37Sp/TZPjrsVDZZs/PFFkzxgfLOA5tCqVnIgCMx5lQcKG54RyyR5d
-        mvGiZEUFL1AU9DQWNQRPSDI1X3GPoAfgG7TS1A9XBURIJJKi89r4SO9HlUz0SmW+YLrJ7sdize5z
-        yBRENNZTc+frhqUtnEND2LBKIaznvuAFE8F885XKr5motpS2zamEOLiYd6mcj7QM0FBls1xgRtxE
-        VgElKURZ82UmMoNr8rBwldJfTFQl85fMHqJTkP1IZCLnWFCP+DTHrwm0APoBveTlGMPATBJyA2Mp
-        Hun5vO3kNv0Y2YOqRmOt/zUj5KOoCVzcwmcYAiOCPf942G8cOGLHyccLeHTbMm3bsh/2yeeblm3a
-        gRlZUeiGFP3mM4padaQzmmBDYQee+4exL9wSXi3Dsg07vLeiA9s/sJ+FVz+IXDeMbNeyKLwWqoKL
-        ohhI8kakxO2yMJYhMzEG80XYtB0aqg6xd63osxZHtNDXvDxp9AviwlSQPVzqikG4xKtyrPJ1yAFt
-        YxdgSp5xCq1Q7SMy/3aMLhAXdbw/2BvKvCD+8eEQ4uQNgkGM/b43gtzwZe8TT+FCOW4acljxHJcO
-        YVlpCiJvVZLLUSW+tUflSSLr6bcP/fH2+OIE943LcnbwsP+wr/JYJqbKRw/74DXkYlmOEfV9ywij
-        vtOsFBzSupkY+vYGNvSWhJ5ghezUbBGajUQKRr4FeX7f8wzPdrxXknfOs4yP2XWLwCM+B6z626mz
-        Dd9xQqMf2eErqfsgY1jsQ2VZQ6dFIAiJYfx/P42u4YWhZQT98LUCvuZlKdQ6dcc8h0EhvL2N/nmh
-        4QV9+5XknUHA8zZ13wQoLt6CuH7oRYbv2v1XEveOC+ARdtjSvuMxn1XyTehzHcs33CB6rXUcZplg
-        lxvUwd+OUwj4TQgM7dAIg+CfryTwd56N1qk74dluZC0GOkXaAzfF3rcWeyKeZFl2G/Gaz1tWccar
-        dJLt6ldWfmoKoNIaT+WUrr2Jm7KD0IjsIHilFK54BSff9qHnXJTfRPoWSuL0AxchyH8teYDDY65J
-        WaOuAph9Ax8P/xk5thH6zmsd1J3KvnB21GaeGr5NAApCJzAi33ttADoTskVX9RbyDCMnMoIofL1X
-        qmbrVF2OeU3B386uEHKEU7f8V1J2PM5lUaoZ0jh215LoZc6LTPJJN+u/yAgDAJOuD3lFYfYL0ij+
-        JpoChA0fYEWvXPofSB14PmdnrWVfU9K+o0t+ndIEXkCFuFfDlHdIOxW7b1Mn5Je3sbPQDwN4Avu1
-        3PuAtI5nUqQbAehaFpM3EC/ZnAcCrfC1gfZ+rKa8YCdt6vJCxsZZqka7OvpVkCwQJotxy8tcI5pM
-        8OVtEHgUGK7bd1+57veCZ8YNQvc6gR9U1/UepuILoFPeQgY3mOIT//bvnTO2pduZ58j8xPqYt0iG
-        edYRuryHRCrOLlrCvgPdIn8TWGr3g8CwvfC11nLJc5XKjLM/2hQquKBuK74VAxHHrXT6XuSbefnf
-        pYKBZfR9+7UqqEF4O4P+LedvYh39yPIMx7Vfi13OqaSRwa+2sd8nkY/4W4QloCvLBoV+9FoKr2Uq
-        ig2n+hlJ14563A7wkmebQ8q0UG8Q5xDiANYMx+5br1zwBVKzTTj5GUnM20RhJ/J9iCN4bcJLmYLI
-        NrT5s1JvkieEnmsDwrivJe4wK8eqXSz4gydqF4DwZ29vKqYD3ZRzPJp4WYjUBcGJoFGpymlbtmM7
-        MLo+EWz977O66qNvkpInShqccpVSlzLx9Krxt16ctdzwYb/wbK8fGBiUOBAZ/T3i1m6TEqCqsqLM
-        q7iEsBJiTDF+Uirpwd+yHqPqdmr22MXRFTte1ZNVVpfGb6gI+dSDgXw22S+YM/rVZHclFXkTMROZ
-        rqZPVSJSqqRSj6mYx2Ng5jnABE9XBf6k0v3MjT4TxlKxyRYdUpPRDOxjhtGE2WG55IV1vdWY8RHJ
-        1wYywrVHlVZTsezIXmTsMHnki/4LTQ9aL7Khyqd68eyG+lVFQSTfzYtSTIvlKEQOxba54FoxQFAH
-        Sr2t2hCvyt6tZXi+81w/fNfFdXLMuq2ZrtZn93zLqnu0JTxcwVI5LKn7gA+6w7PRYVhfG0bdWFxv
-        74uqEBrSVUeblyS0p6LDwv2dFi68qO9a62sPfN972BdXcijMxY+b67+m5tLRvKx7Wq3WzViOxkbT
-        QJlVJZvJGelu3d5bNAXrvlHdKipVFY+LOBcYo+6VxmqUSd1yoTUUxbTujyw5GLb4F23h3ylR34F3
-        /Z14p1Pw5z7FD+FPHIuQgWdEW7j3SXc/l60nUhtKyWHRuiHIGZlFKuqelJzykTbsplU2mMO0szkr
-        BW/bjK+TuyVfHGu7XsFJdWBMsBNjbN9ucyYMqBVm+5ZTg6UNhhyJuYJ21K0gpDezA8bLMpeDqnaU
-        1CNb//bMi0J7EGZaHqStJP4WZui+tMluECA6cCTcJdrY/Yf9L2YsUvgFE+MHphWaFjzn7vNGO8zr
-        O+7D/vsPp7/dfrw7vjD7/TAycB0T2R1mtq1dA2yWZ64X+F3m6hLMteHZIUBgEBnfuszq7KTmfTfY
-        TkffqelwI6Ljub6f0s4QqC/MmowfSpEimDcegbYEqFjStoKm17zaAFJHU23EWu/vmjsGonyirTm0
-        TP1Do/Irc2hZQ/hSyDmvpiY7IkjRhXvuzvqRma4Hteowl/ccdx2f3n5gpwi6NcLoAW5Np1Um6+/1
-        VoyPVZkLHo/ZO9pBpgFXCMClH0XmSJs5bsVM5SVxMGC/0A+/dgFK9k/D8Cb1Y56nFE8PzTvCjWc8
-        nfSQmeDjPSRFO7A+0Jcb4GOZc1w1T/SPtLmhx07q3xI5UvSU/no8rmin0Xv6fIQxMPgtfX43VsW4
-        x+7qiS7FoIjHVZrSndcryErMcSww517vn1hws5wbJzmlAOxIjtjHGX3Q7flGFw+aa/jxBCFLc/1e
-        b+egmH+3WDIWWGXxyoO/E5mAkRSmFgPtQ3tcg62e22MZSDRbOgT0/rDPcXsuHg0dLOHd4Nvg5PDf
-        7YIa7e0I4Ic6jMkcQ+9m6DDf9sD6Y5txPDfqMtcuISui3StfBB8gWlhIcyi17jLnLuHKdiDPxumZ
-        TuiZvocR7X7QxUM4u0cr7VftyPU7JYI7RKx1iO32yR93mG+3WOW3sKrrRtbD/oin/KsUhWd5kLG3
-        JVB9HGBs2jL1UIEqjwz1osaj9YXDWMP0dxgIn2L2ocLTkj1J2naFyHb6SAj/XOXyGzzyvYCDi5Es
-        rEcm76fJ0LuGzC5M2h6SXvbCZ8Cf8Zic7U3tHT+DfRlyaZHDe56ahnamyOPJU38wD+nbnUw5vNh1
-        /U3z6P03gUQXF89XbvSQXfMMEi9KpV3hPQD8MoD/clPMD/N/ysdfWy7OtR0XmqKKoSkVIPQ0+Tru
-        wgbvWb7rbMPhh+sVCsj1sNnkRjvxkLzTzspbUUBY8fiAMvip0hjm2Z7hIywSv2udWGx7vB8Llc+N
-        o0qmiS5M6AHjOfs4HLaQShuqBFsU4j09XDaljYauu7JKunBme5j+MYxXGXlF29Ug3uriip1dwowb
-        kCuueWDOVCYwaRj2g05eY+d4s57Q9r3IcLrM2i3y2FHfNj3awNBlzui5df94VyGhpGanWIO1mr1F
-        QEwNnGr28hBIw4Vznuf062UNt5omEm7UXoEXfCLJLdCXscgIcNHHUshsKspvS//xGUiPPM6p+Xsb
-        felaYA2iMLEsRbwE/vXGY/mthrrkTjhLeT4SRhHzRelgkT+0Embg+/pIBwudIAzcTlXA7bH1Zbd6
-        oQDTZELMem/e0LJ/IViB5X0ez9m1IndRLfbTL1wMO6OdvNmoYIdY9RlVn5GtX6k7di0SkznmD6xk
-        ijssWg1cX4f17ZR91l4BHB9IBSRKriGkEQFBu8y9Pa6/MHfkEm7JEcsnZRR0sRP3pyFys14Yui0s
-        0a4X1j9uBpZb6DyUNK63CA8kp63xRTWoGwXl+sGJRQGbTrcgj4CzHcpEq7EsmC6Vc+CLRBQzOuiy
-        rH/jyRnuV5hAd5aW8aRVSd5aFOtaLHR3KzEHlvWC3uSwSrJ2IGCzTs43+XeiZnwqkQSOALJ02wAT
-        4DE6EXLEm7rh8pwFfgGyEFlBTu14xUB68FboZO4THU1ZZ5Otd+38pHqoSe3CqV2i7EbmgcTKsDoZ
-        8U+LuRtO6grIdOHrNwLBWc6/6T1Frmry6Q+iVLUzw5dDyCHlY0q8P2kfr7g+7qEdPp1R0An7lf4G
-        J8wXP12UxUQ9Eta8rmFljls5fT/ciATkKkFTweUBFdzpFE/ZVMuHOZ+KJ5XXx5Zmq76KLoxS5RTu
-        f1FBZgXVP6ZIs89IfZoUWy4aM3HBojYAdcPoYX8ItRqSivomsbuTm/lpBfkH0jhDoBVUoLjUYRds
-        UvFE4/FDU1dIroSgsGv83jBcApkqir2ar9fVt28VFUyoRMJnQOETlXJVNWF8cQAAA56ZukDyeSx4
-        CdKGZfPUH1Uc80ZoG9URSOVT3XHTKZG77IfURy2Wx7QIQ9cnPNYFszhBJLJHCYHoGt8qQteMBM6M
-        TLAxCPyN+sfqhMnaPV2Esx2fvZhLbtQ97SB42LcDz+9Hdh8Rt2/1w21e7Lauc9bVOECvG93KTNVo
-        vpZWnKsnpAQlXP+Jqg8e3Qo63MM+xnGV//e6zwpamYKzxWPdIG2bATaZi7lMyrho3zI7LApKH9av
-        d+HcLvWNJZ6O3Lo+7FiRMe/S29yptrEZZ3zSFeJXh4m3A6OXrfhaZImqt2MGnOxN2/NJXo3UkyyR
-        ajfu9BMSRYBzMtkLfYegXRhk4WSzqhqJsrFWMp56nyQ12M/MZQ2Xjg3J6QxJJwXDdBEM6UjeNnRB
-        40gqqE+XSqkdqD6kSM3MCvnrnE4eJkINh2tW6WM+P9xiivUPXdi6ZRfBNe1Ry8nl1fVbVT7KTMaT
-        pVejBRwh756T5ztZJQxnFP1n1BCrizN684A+TLfqq9bXDthh1uo8IkNYbShoOpPlkzJ4DjzNBnRM
-        pdQnZFfM8Pq27URdkghvR+BpW1a/H7Ybi23QHw+kubpr0/ucV1NyzVndjE74rKyFTowZ82xUb1V4
-        dgizBZJaGGlr5/nm6uMdlcpnVamZ1KW16G0Hlj8tXVqh36kw7HUpgsxi8iUYyzO7FTC9XfHZDR02
-        bmDUpeJzisfaJZzSCbmxboNoNPC7oq7CYW0mJ3R6XZAvqXspYzkAjBb0sEYL9W4vYLEaSdzzbELd
-        lM8vmRi5GpjNIRzEtEq1ChlqaJw+NiD7ng6Q/6YB2Kc6tt9UKaU75Fz0UeMPsK9R3f2Dwn2SeVm3
-        nTip2xKY6S7cWgvEdrYCM5hrk3B27Hh4uwKzG6xqBvIbOER9q5LnclhM5sbVPMsWEtLHDNacdrt8
-        crlyWFd8VjTGt81Rgwg6hE5d0LSpYbBf1l/58OsWV9y33dDppJW7lKq2VuZcO+jSCfJ2RhLUPQ07
-        mZ5vPRfrrRhwii462lzHlzLLBPRe28GXAQHuKe1GSykUFVQjZ3Qv0h2oPaVA1aiYVTCsvIHMx6mq
-        Ekpl8Hk0nCvdiryT2TifFKQeqZDZEoALDDgRTbFsA2DP6ORxYSTi8WG//nwAFE//GdJl02a//IGc
-        P1Gd2rT+roDmVs2Xhbsjrvl1rlPACdIw2Sxo3Wds3+anV3b6Vb8BZLEN4GSeYYhYR+KjtSh8sjhO
-        fV0fpz5dbQfYTBWoDUVVoX6wDZ88u6cLw3YoT61XhmzbtTrNt2sH507wgUqTxjtp3ot8UupL72un
-        YzVbLIsFDDpFNqamgl7mUm+rIGhQlHqD5fVi76Vuat3MadMrlBIjTHGBdOG9iZy0SijmHOMjbAUJ
-        OL0N4m4iZzM627Qg6UaU+Po/FQxNZIOKmvDNaTsaoICIT9Q8JTvgX9cZ6fhWaD3sX/MvcIBG5AyG
-        duTQHpMujsbfsnUC2GigwSYHDzKk0zJ7Eriii9xU1WaXciCRJZPVH/OpQIxiJ9BQTTSUW++3WKtX
-        UJSczaniQEZbFvMD9miZ/n9qrTsBFe0jIVUEyMjtkhb7u20GQBI8tiw/pEJfh8l222J3uLHDzrf1
-        Xm7P6Lt9bep24CK93JaGU6J0bp6aev/HsnU7Q2Sm94Pkj6KFefv2z/cOHUKZyCr0f9qa3GX9HTbU
-        rXLagPCRZXcpuPvdUvhmi5fjeEaXelh/9+0JsZpOC9ujXWcd5ts10NGhGQpnOgN//rIMpOy68LY8
-        VUkIWje+Fm8MoGqavmPRXyNg0KDsVgL/MjzUUfJYar98GMuEfebkQDll7+wwbZp5j7q2Vv90u3ol
-        lwbc57Qb+Xcp0oTpPcvLwLqlyOaYUeCCiT8qsi3u6SKBXRo7elbXj/xOKq3P623I8zPyEjVtIFZd
-        Tcgk8MtH+v5R1y6jS7iAZivZuRoUFNE0fruqJrwqJsu69TsxRVyjRJru1lJ/hv/OeQqQmE2Qsf2+
-        2DNBEfiobnnmwC9j9UhK8H6j1h1A6NMnTS5sjWJnnunwEVL4uKO3q1G00jv0fv2P4kl/l0Tb7sPB
-        h2bf7FI46/tbJKJU2iRLzQaJn7z2hq2MYrFdhBpB9CK7smD/xy4z9ZSKZLR8rVYmSmoMAOHo16sp
-        NqDdF4yzUaoGmOBHXWI9A+zD1K/+o3I12Wy+8Pn0JjwFVyDX4gBdg1JM9Nmd326v9uojR4U+c1TM
-        69cy0eB0RuBJ5qI+gtS8AelhH5J42P/hq5MWb+ZrXqEEhs4AjodSJGs/It8v9AkjBDESoaTLCRX1
-        ZstSH35s3udFGxqhqDFBa73URMxUIV96EZNDb/Cz7S1vYnIM2zJs+95xDizvwLKeveiw7/uOH3qk
-        I/QmpljleNKmM0+LtzJ934Mspzyf08cVAzX/qLlM4tAsS5WaVLOfc+wvmqgarMmnGKu8XBeYLIrq
-        5y9cXJ7LKtZfqrhBYvLVBEE1hT8UYy7SRgrf6e1Ts0aHDTXUqiOThYAxHAkweZ5PIArWRwlalou1
-        fhFxCTn+tXrl408XRxxq3snVULL31/8DS3k0ZhFTAAA=
+      string: '{"institution":[{"name":"bioRxiv"}],"indexed":{"date-parts":[[2023,7,31]],"date-time":"2023-07-31T10:13:47Z","timestamp":1690798427865},"posted":{"date-parts":[[2020,1,17]]},"group-title":"Neuroscience","reference-count":65,"publisher":"Cold
+        Spring Harbor Laboratory","content-domain":{"domain":[],"crossmark-restriction":false},"accepted":{"date-parts":[[2020,10,9]]},"abstract":"<jats:p>Progress
+        in science requires standardized assays whose results can be readily shared,
+        compared, and reproduced across laboratories. Reproducibility, however, has
+        been a concern in neuroscience, particularly for measurements of mouse behavior.
+        Here we show that a standardized task to probe decision-making in mice produces
+        reproducible results across multiple laboratories. We designed a task for
+        head-fixed mice that combines established assays of perceptual and value-based
+        decision making, and we standardized training protocol and experimental hardware,
+        software, and procedures. We trained 140 mice across seven laboratories in
+        three countries, and we collected 5 million mouse choices into a publicly
+        available database. Learning speed was variable across mice and laboratories,
+        but once training was complete there were no significant differences in behavior
+        across laboratories. Mice in different laboratories adopted similar reliance
+        on visual stimuli, on past successes and failures, and on estimates of stimulus
+        prior probability to guide their choices. These results reveal that a complex
+        mouse behavior can be successfully reproduced across multiple laboratories.
+        They establish a standard for reproducible rodent behavior, and provide an
+        unprecedented dataset and open-access tools to study decision-making in mice.
+        More generally, they indicate a path towards achieving reproducibility in
+        neuroscience through collaborative open-science approaches.<\/jats:p>","DOI":"10.1101\/2020.01.17.909838","type":"posted-content","created":{"date-parts":[[2020,1,18]],"date-time":"2020-01-18T09:15:13Z","timestamp":1579338913000},"source":"Crossref","is-referenced-by-count":12,"title":"Standardized
+        and reproducible measurement of decision-making in mice","prefix":"10.1101","author":[{"name":"The
+        International Brain Laboratory","sequence":"first","affiliation":[]},{"given":"Valeria","family":"Aguillon-Rodriguez","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0002-9650-8962","authenticated-orcid":false,"given":"Dora
+        E.","family":"Angelaki","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0002-5644-4124","authenticated-orcid":false,"given":"Hannah
+        M.","family":"Bayer","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0001-5228-6918","authenticated-orcid":false,"given":"Niccol\u00f2","family":"Bonacchi","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0003-4880-7682","authenticated-orcid":false,"given":"Matteo","family":"Carandini","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0002-9648-4761","authenticated-orcid":false,"given":"Fanny","family":"Cazettes","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0002-6849-5316","authenticated-orcid":false,"given":"Gaelle
+        A.","family":"Chapuis","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0002-3205-3794","authenticated-orcid":false,"given":"Anne
+        K.","family":"Churchland","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0002-3818-877X","authenticated-orcid":false,"given":"Yang","family":"Dan","sequence":"additional","affiliation":[]},{"given":"Eric
+        E. J.","family":"Dewitt","sequence":"additional","affiliation":[]},{"given":"Mayo","family":"Faulkner","sequence":"additional","affiliation":[]},{"given":"Hamish","family":"Forrest","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0001-5178-9177","authenticated-orcid":false,"given":"Laura
+        M.","family":"Haetzel","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0002-2673-8957","authenticated-orcid":false,"given":"Michael","family":"Hausser","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0003-4921-8521","authenticated-orcid":false,"given":"Sonja
+        B.","family":"Hofer","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0001-7827-9548","authenticated-orcid":false,"given":"Fei","family":"Hu","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0002-8929-7984","authenticated-orcid":false,"given":"Anup","family":"Khanal","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0001-8852-6805","authenticated-orcid":false,"given":"Christopher
+        S.","family":"Krasniak","sequence":"additional","affiliation":[]},{"given":"In\u00eas","family":"Laranjeira","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0001-7913-9109","authenticated-orcid":false,"given":"Zachary
+        F.","family":"Mainen","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0002-7473-0482","authenticated-orcid":false,"given":"Guido
+        T.","family":"Meijer","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0001-8587-4919","authenticated-orcid":false,"given":"Nathaniel
+        J.","family":"Miska","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0002-8947-408X","authenticated-orcid":false,"given":"Thomas
+        D.","family":"Mrsic-Flogel","sequence":"additional","affiliation":[]},{"given":"Masayoshi","family":"Murakami","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0001-5297-3363","authenticated-orcid":false,"given":"Jean-Paul","family":"Noel","sequence":"additional","affiliation":[]},{"given":"Alejandro","family":"Pan-Vazquez","sequence":"additional","affiliation":[]},{"given":"Cyrille","family":"Rossant","sequence":"additional","affiliation":[]},{"given":"Joshua
+        I.","family":"Sanders","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0002-1677-1489","authenticated-orcid":false,"given":"Karolina
+        Z.","family":"Socha","sequence":"additional","affiliation":[]},{"given":"Rebecca","family":"Terry","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0001-5270-6513","authenticated-orcid":false,"given":"Anne
+        E.","family":"Urai","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0001-6904-2311","authenticated-orcid":false,"given":"Hernando
+        M.","family":"Vergara","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0003-4014-2591","authenticated-orcid":false,"given":"Miles
+        J.","family":"Wells","sequence":"additional","affiliation":[]},{"given":"Christian
+        J.","family":"Wilson","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0003-0548-2160","authenticated-orcid":false,"given":"Ilana
+        B.","family":"Witten","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0002-2955-2576","authenticated-orcid":false,"given":"Lauren
+        E.","family":"Wool","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0002-8431-9136","authenticated-orcid":false,"given":"Anthony","family":"Zador","sequence":"additional","affiliation":[]}],"member":"246","reference":[{"key":"2020101212001600000_2020.01.17.909838v5.1","doi-asserted-by":"publisher","DOI":"10.1038\/s41467-016-0009-6"},{"key":"2020101212001600000_2020.01.17.909838v5.2","unstructured":"Ashwood,
+        Z. , et al., IBL Collaboration, and Pillow, J.W. (2019). State-dependent modeling
+        of psychophysical behavior during decision making. Soc. Neurosci. 2019 Online."},{"key":"2020101212001600000_2020.01.17.909838v5.3","first-page":"1947","volume-title":"In
+        Advances in Neural Information Processing Systems","volume":"29","year":"2016"},{"key":"2020101212001600000_2020.01.17.909838v5.4","doi-asserted-by":"crossref","first-page":"452","DOI":"10.1038\/533452a","article-title":"1,500
+        scientists lift the lid on reproducibility","volume":"533","year":"2016","journal-title":"Nat.
+        News"},{"key":"2020101212001600000_2020.01.17.909838v5.5","doi-asserted-by":"crossref","first-page":"e49630","DOI":"10.7554\/eLife.49630","article-title":"MouseBytes,
+        an open-access high-throughput pipeline and database for rodent touchscreen-based
+        cognitive assessment","volume":"8","year":"2019","journal-title":"ELife"},{"key":"2020101212001600000_2020.01.17.909838v5.6","doi-asserted-by":"crossref","first-page":"84","DOI":"10.1038\/s41586-020-2314-9","article-title":"Variability
+        in the analysis of a single neuroimaging dataset by many teams","volume":"582","year":"2020","journal-title":"Nature"},{"key":"2020101212001600000_2020.01.17.909838v5.7","doi-asserted-by":"crossref","first-page":"151","DOI":"10.1087\/20150211","article-title":"Beyond
+        authorship: attribution, contribution, collaboration, and credit","volume":"28","year":"2015","journal-title":"Learn.
+        Publ"},{"key":"2020101212001600000_2020.01.17.909838v5.8","doi-asserted-by":"publisher","DOI":"10.1016\/j.celrep.2017.08.047"},{"key":"2020101212001600000_2020.01.17.909838v5.9","doi-asserted-by":"publisher","DOI":"10.1523\/JNEUROSCI.6689-10.2011"},{"key":"2020101212001600000_2020.01.17.909838v5.10","doi-asserted-by":"publisher","DOI":"10.1038\/nrn3475"},{"key":"2020101212001600000_2020.01.17.909838v5.11","doi-asserted-by":"publisher","DOI":"10.1038\/s41586-018-0579-z"},{"key":"2020101212001600000_2020.01.17.909838v5.12","doi-asserted-by":"crossref","first-page":"637","DOI":"10.1038\/s41562-018-0399-z","article-title":"Evaluating
+        the replicability of social science experiments in Nature and Science between
+        2010 and 2015","volume":"2","year":"2018","journal-title":"Nat. Hum. Behav"},{"key":"2020101212001600000_2020.01.17.909838v5.13","doi-asserted-by":"publisher","DOI":"10.1038\/nn.3410"},{"key":"2020101212001600000_2020.01.17.909838v5.14","unstructured":"CERN
+        Education , Communications and Outreach Group (2018). CERN Annual Report 2017
+        (CERN)."},{"key":"2020101212001600000_2020.01.17.909838v5.15","doi-asserted-by":"crossref","unstructured":"Charles,
+        A.S. , Falk, B. , Turner, N. , Pereira, T.D. , Tward, D. , Pedigo, B.D. ,
+        Chung, J. , Burns, R. , Ghosh, S.S. , Kebschull, J.M. , et al. (2020). Toward
+        Community-Driven Big Open Brain Science: Open Big Data and Tools for Structure,
+        Function, and Genetics. Annu. Rev. Neurosci.43, null.","DOI":"10.1146\/annurev-neuro-100119-110036"},{"key":"2020101212001600000_2020.01.17.909838v5.16","doi-asserted-by":"publisher","DOI":"10.1038\/nn1102-1101"},{"key":"2020101212001600000_2020.01.17.909838v5.17","doi-asserted-by":"publisher","DOI":"10.1038\/nn.2439"},{"key":"2020101212001600000_2020.01.17.909838v5.18","doi-asserted-by":"publisher","DOI":"10.1901\/jeab.2005.23-05"},{"key":"2020101212001600000_2020.01.17.909838v5.19","doi-asserted-by":"publisher","DOI":"10.1126\/science.284.5420.1670"},{"key":"2020101212001600000_2020.01.17.909838v5.20","doi-asserted-by":"publisher","DOI":"10.1038\/nature19356"},{"key":"2020101212001600000_2020.01.17.909838v5.21","doi-asserted-by":"publisher","DOI":"10.7554\/eLife.36018"},{"key":"2020101212001600000_2020.01.17.909838v5.22","doi-asserted-by":"crossref","first-page":"54","DOI":"10.3390\/galaxies4040054","article-title":"Observing\u2014and
+        Imaging\u2014Active Galactic Nuclei with the Event Horizon Telescope","volume":"4","year":"2016","journal-title":"Galaxies"},{"key":"2020101212001600000_2020.01.17.909838v5.23","doi-asserted-by":"crossref","unstructured":"Forscher,
+        P.S. , Wagenmakers, E.-J. , Coles, N.A. , Silan, M.A. , and IJzerman, H. (2020).
+        A Manifesto for Team Science (PsyArXiv).","DOI":"10.31234\/osf.io\/2mdxh"},{"key":"2020101212001600000_2020.01.17.909838v5.24","first-page":"421","article-title":"A
+        Collaborative Approach to Infant Research: Promoting Reproducibility, Best
+        Practices, and Theory-Building. Infancy Off","volume":"22","year":"2017","journal-title":"J.
+        Int. Soc. Infant Stud"},{"key":"2020101212001600000_2020.01.17.909838v5.25","doi-asserted-by":"publisher","DOI":"10.1016\/j.conb.2013.08.009"},{"key":"2020101212001600000_2020.01.17.909838v5.26","doi-asserted-by":"publisher","DOI":"10.1371\/journal.pone.0088678"},{"key":"2020101212001600000_2020.01.17.909838v5.27","doi-asserted-by":"publisher","DOI":"10.1038\/s41586-020-2649-2"},{"key":"2020101212001600000_2020.01.17.909838v5.28","doi-asserted-by":"publisher","DOI":"10.1901\/jeab.1961.4-267"},{"key":"2020101212001600000_2020.01.17.909838v5.29","unstructured":"International
+        Brain Laboratory , Bonacchi, N. , Chapuis, G. , Churchland, A. , Harris, K.D.
+        , Rossant, C. , Sasaki, M. , Shen, S. , Steinmetz, N.A. , Walker, E.Y. , et
+        al. (2019). Data architecture and visualization for a large-scale neuroscience
+        collaboration. BioRxiv 827873."},{"key":"2020101212001600000_2020.01.17.909838v5.30","doi-asserted-by":"crossref","unstructured":"Ioannidis,
+        J.P.A. (2005). Why Most Published Research Findings Are False. PLoS Med. 2.","DOI":"10.1371\/journal.pmed.0020124"},{"key":"2020101212001600000_2020.01.17.909838v5.31","doi-asserted-by":"publisher","DOI":"10.1016\/j.neubiorev.2018.01.003"},{"key":"2020101212001600000_2020.01.17.909838v5.32","doi-asserted-by":"publisher","DOI":"10.1093\/nar\/gkt977"},{"key":"2020101212001600000_2020.01.17.909838v5.33","doi-asserted-by":"crossref","first-page":"e49834","DOI":"10.7554\/eLife.49834","article-title":"Reinforcement
+        biases subsequent perceptual decisions when confidence is low, a widespread
+        behavioral phenomenon","volume":"9","year":"2020","journal-title":"ELife"},{"key":"2020101212001600000_2020.01.17.909838v5.34","doi-asserted-by":"crossref","first-page":"700","DOI":"10.1016\/j.neuron.2019.11.018","article-title":"Dopaminergic
+        and Prefrontal Basis of Learning from Sensory Confidence and Reward Value","volume":"105","year":"2020","journal-title":"Neuron"},{"key":"2020101212001600000_2020.01.17.909838v5.35","doi-asserted-by":"publisher","DOI":"10.1901\/jeab.2005.110-04"},{"key":"2020101212001600000_2020.01.17.909838v5.36","doi-asserted-by":"crossref","unstructured":"Lopes,
+        G. , Bonacchi, N. , Fraz\u00e3o, J. , Neto, J.P. , Atallah, B.V. , Soares,
+        S. , Moreira, L. , Matias, S. , Itskov, P.M. , Correia, P.A. , et al. (2015).
+        Bonsai: an event-based framework for processing and controlling data streams.
+        Front. Neuroinformatics 9.","DOI":"10.3389\/fninf.2015.00007"},{"key":"2020101212001600000_2020.01.17.909838v5.37","doi-asserted-by":"crossref","unstructured":"Lopes,
+        G. , Farrell, K. , Horrocks, E.A.B. , Lee, C.-Y. , Morimoto, M.M. , Muzzu,
+        T. , Papanikolaou, A. , Rodrigues, F.R. , Wheatcroft, T. , Zucca, S. , et
+        al. (2020). BonVision \u2013 an open-source software to create and control
+        visual environments. BioRxiv 2020.03.09.983775.","DOI":"10.1101\/2020.03.09.983775"},{"key":"2020101212001600000_2020.01.17.909838v5.38","doi-asserted-by":"crossref","first-page":"537","DOI":"10.1177\/1745691612460688","article-title":"Replications
+        in Psychology Research: How Often Do They Really Occur?","volume":"7","year":"2012","journal-title":"Perspect.
+        Psychol. Sci. J. Assoc. Psychol. Sci"},{"key":"2020101212001600000_2020.01.17.909838v5.39","doi-asserted-by":"publisher","DOI":"10.1038\/s41593-018-0209-y"},{"key":"2020101212001600000_2020.01.17.909838v5.40","doi-asserted-by":"publisher","DOI":"10.1016\/j.neuron.2015.09.012"},{"key":"2020101212001600000_2020.01.17.909838v5.41","doi-asserted-by":"crossref","unstructured":"Mendon\u00e7a,
+        A.G. , Drugowitsch, J. , Vicente, M.I. , DeWitt, E. , Pouget, A. , and Mainen,
+        Z.F. (2018). The impact of learning on perceptual decisions and its implication
+        for speed-accuracy tradeoffs. BioRxiv 501858.","DOI":"10.1101\/501858"},{"key":"2020101212001600000_2020.01.17.909838v5.42","unstructured":"Miller,
+        K.J. , Botvinick, M.M. , and Brody, C.D. (2019). From predictive models to
+        cognitive models: An analysis of rat behavior in the two-armed bandit task.
+        BioRxiv 461129."},{"key":"2020101212001600000_2020.01.17.909838v5.43","doi-asserted-by":"crossref","first-page":"e1006681","DOI":"10.1371\/journal.pcbi.1006681","article-title":"Human
+        online adaptation to changes in prior probability","volume":"15","year":"2019","journal-title":"PLOS
+        Comput. Biol"},{"key":"2020101212001600000_2020.01.17.909838v5.44","doi-asserted-by":"publisher","DOI":"10.1038\/nature08539"},{"key":"2020101212001600000_2020.01.17.909838v5.45","doi-asserted-by":"publisher","DOI":"10.1016\/j.cpc.2010.04.018"},{"key":"2020101212001600000_2020.01.17.909838v5.46","doi-asserted-by":"crossref","unstructured":"Pinto,
+        L. , Koay, S.A. , Engelhard, B. , Yoon, A.M. , Deverett, B. , Thiberge, S.Y.
+        , Witten, I.B. , Tank, D.W. , and Brody, C.D. (2018). An Accumulation-of-Evidence
+        Task Using Visual Pulses for Mice Navigating in Virtual Reality. Front. Behav.
+        Neurosci.12.","DOI":"10.3389\/fnbeh.2018.00036"},{"key":"2020101212001600000_2020.01.17.909838v5.47","doi-asserted-by":"crossref","unstructured":"Pisupati,
+        S. , Chartarifsky-Lynn, L. , Khanal, A. , and Churchland, A.K. (2019). Lapses
+        in perceptual decisions reflect exploration (Neuroscience).","DOI":"10.1101\/613828"},{"key":"2020101212001600000_2020.01.17.909838v5.48","doi-asserted-by":"publisher","DOI":"10.1371\/journal.pone.0083171"},{"key":"2020101212001600000_2020.01.17.909838v5.49","doi-asserted-by":"publisher","DOI":"10.1038\/nn.3818"},{"key":"2020101212001600000_2020.01.17.909838v5.50","unstructured":"Reback,
+        J. , McKinney, W. , jbrockmendel, Bossche , J.V. den , Augspurger, T. , Cloud,
+        P. , gfyoung, Sinhrks , Klein, A. , Roeschke, M. , et al. (2020). pandas-dev\/pandas:
+        Pandas 1.0.1 (Zenodo)."},{"key":"2020101212001600000_2020.01.17.909838v5.51","doi-asserted-by":"crossref","unstructured":"Roy,
+        N.A. , Bak, J.H. , Akrami, A. , Brody, C.D. , and Pillow, J.W. (2020). Extracting
+        the Dynamics of Behavior in Decision-Making Experiments. BioRxiv 2020.05.21.109678.","DOI":"10.1101\/2020.05.21.109678"},{"key":"2020101212001600000_2020.01.17.909838v5.52","doi-asserted-by":"publisher","DOI":"10.7554\/eLife.11308"},{"key":"2020101212001600000_2020.01.17.909838v5.53","doi-asserted-by":"crossref","unstructured":"Seabold,
+        S. , and Perktold, J. (2010). Statsmodels: Econometric and Statistical Modeling
+        with Python. p. Smith, N.J., Hudon, C., broessli, Skipper Seabold, Peter Quackenbush,
+        Michael Hudson-Doyle, Max","DOI":"10.25080\/Majora-92bf1922-011"},{"key":"2020101212001600000_2020.01.17.909838v5.54","unstructured":"Humber,
+        Katrin Leinweber , Hassan Kibirige , Cameron Davidson-Pilon , et al. (2018).
+        pydata\/patsy: v0.5.1 (Zenodo)."},{"key":"2020101212001600000_2020.01.17.909838v5.55","doi-asserted-by":"publisher","DOI":"10.1038\/nmeth.2935"},{"key":"2020101212001600000_2020.01.17.909838v5.56","doi-asserted-by":"publisher","DOI":"10.1037\/h0058700"},{"key":"2020101212001600000_2020.01.17.909838v5.57","doi-asserted-by":"crossref","first-page":"A1","DOI":"10.1051\/0004-6361\/201732098","article-title":"The
+        H.E.S.S. Galactic plane survey","volume":"612","year":"2018","journal-title":"Astron.
+        Astrophys"},{"key":"2020101212001600000_2020.01.17.909838v5.58","doi-asserted-by":"publisher","DOI":"10.1016\/j.neuron.2017.12.013"},{"key":"2020101212001600000_2020.01.17.909838v5.59","doi-asserted-by":"publisher","DOI":"10.1038\/s41592-018-0224-7"},{"key":"2020101212001600000_2020.01.17.909838v5.60","doi-asserted-by":"publisher","DOI":"10.1038\/ncomms14637"},{"key":"2020101212001600000_2020.01.17.909838v5.61","doi-asserted-by":"crossref","unstructured":"Urai,
+        A.E. , Aguillon-Rodriguez, V. , Laranjeira, I.C. , Cazettes, F. , Laboratory,
+        T.I.B. , Mainen, Z.F. , and Churchland, A.K. (2020). Citric Acid Water as
+        an Alternative to Water Restriction for High-Yield Mouse Behavior. BioRxiv
+        2020.03.02.973016.","DOI":"10.1101\/2020.03.02.973016"},{"key":"2020101212001600000_2020.01.17.909838v5.62","doi-asserted-by":"publisher","DOI":"10.1101\/359513"},{"key":"2020101212001600000_2020.01.17.909838v5.63","unstructured":"Waskom,
+        M. , Botvinnik, O. , O\u2019Kane, D. , Hobson, P. , Lukauskas, S. , Gemperline,
+        D.C. , Augspurger, T. , Halchenko, Y. , Cole, J.B. , Warmenhoven, J. , et
+        al. (2017). mwaskom\/seaborn: v0.8.1 (September 2017) (Zenodo)."},{"key":"2020101212001600000_2020.01.17.909838v5.64","doi-asserted-by":"publisher","DOI":"10.1167\/8.6.2"},{"key":"2020101212001600000_2020.01.17.909838v5.65","unstructured":"Wool,
+        L. , and The International Brain Laboratory . (2020). PsyArXiv Preprints |
+        Knowledge across networks: how to build a global neuroscience collaboration.
+        PsyArxiv."}],"container-title":[],"original-title":[],"link":[{"URL":"https:\/\/syndication.highwire.org\/content\/doi\/10.1101\/2020.01.17.909838","content-type":"unspecified","content-version":"vor","intended-application":"similarity-checking"}],"deposited":{"date-parts":[[2022,10,11]],"date-time":"2022-10-11T22:04:00Z","timestamp":1665525840000},"score":1,"resource":{"primary":{"URL":"http:\/\/biorxiv.org\/lookup\/doi\/10.1101\/2020.01.17.909838"}},"subtitle":[],"short-title":[],"issued":{"date-parts":[[2020,1,17]]},"references-count":65,"URL":"http:\/\/dx.doi.org\/10.1101\/2020.01.17.909838","relation":{"is-preprint-of":[{"id-type":"doi","id":"10.7554\/eLife.63711","asserted-by":"subject"}]},"published":{"date-parts":[[2020,1,17]]},"subtype":"preprint"}'
     headers:
       access-control-allow-headers:
       - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
@@ -190,7 +204,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Tue, 25 Apr 2023 19:11:45 GMT
+      - Mon, 16 Oct 2023 18:46:12 GMT
       link:
       - "<http://dx.doi.org/10.1101/2020.01.17.909838>; rel=\"canonical\", <https://syndication.highwire.org/content/doi/10.1101/2020.01.17.909838>;
         version=\"vor\"; rel=\"item\", <http://orcid.org/0000-0002-9650-8962>; title=\"Dora

--- a/dandi/cli/tests/data/update_dandiset_from_doi/elife.vcr.yaml
+++ b/dandi/cli/tests/data/update_dandiset_from_doi/elife.vcr.yaml
@@ -7,7 +7,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - dandi/0.53.0+17.gc2f268f.dirty requests/2.28.2 CPython/3.11.3
+      - dandi/0.56.2+5.ga0199fce.dirty requests/2.31.0 CPython/3.11.6
       accept:
       - application/json
     method: GET
@@ -21,7 +21,7 @@ interactions:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 7bd8e4d0ed810a87-IAD
+      - 817276a29b4e8c27-EWR
       Connection:
       - keep-alive
       Content-Length:
@@ -29,19 +29,19 @@ interactions:
       Content-Type:
       - text/html;charset=utf-8
       Date:
-      - Tue, 25 Apr 2023 19:11:47 GMT
+      - Mon, 16 Oct 2023 18:46:14 GMT
       NEL:
       - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=QUTWDNgdwecDEbb5843KwTxVRiS8gF9O42Xw37fKYWDNGlOerwt2x7v%2Fk170xKRWtYqyEl%2B4MwIaycw8zAoTVsbQIIdgBS3WAK7rS5%2FAjNpDOUmgN28IcHd3as3uSobb%2BFioqTE%3D"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=7qGy5%2BKy6LRTIOWYMy8lpDgvEKsVVtVYXiyDO%2BXzuuY%2Bm1a9zI7wHNfPZXVqHJLuLgmFmAhl4ZRPCgNEs%2BRn%2B%2FZa2d1PshMMKBLDYphsrLbuR0C%2FYDtJZQQ%3D"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       alt-svc:
-      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
+      - h3=":443"; ma=86400
       expires:
-      - Tue, 25 Apr 2023 19:22:17 GMT
+      - Mon, 16 Oct 2023 19:01:13 GMT
       location:
       - https://api.crossref.org/v1/works/10.7554%2FeLife.48198/transform
       permissions-policy:
@@ -59,168 +59,254 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - dandi/0.53.0+17.gc2f268f.dirty requests/2.28.2 CPython/3.11.3
+      - dandi/0.56.2+5.ga0199fce.dirty requests/2.31.0 CPython/3.11.6
       accept:
       - application/json
     method: GET
     uri: https://api.crossref.org/v1/works/10.7554%2FeLife.48198/transform
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAA/919e3PbRpbvV0Hxj92kioDwfqi27pQtK7FmLEdXcjaZiVK3mkSTRAQCCBqQTU/N
-        d99zuhsgGmySQpTdrbqTmYlNgkD36fP4nSf+OcuKlH6h6ezyn7OUNNSsSN2w2eUvv7i26839ueP+
-        +utcfNVkWzq7nOEXpu2bjvvJsS/d+NL1/jGbz/Bb1pBtNbt0wthxk8CzvcRO/jWf1XRFa1osqbks
-        26KZXSbxfFa1izxjG1rDLemHbEWNh2WGFzHjDr9akiYrCzY3PjQp3B4+oAWD5//yzxk8pm60K7bn
-        ztz1NCu2TdsxXe+TbV/y/45XHERJ5EWhjf+BFS/LoqFFYz7TmsEq4B7PZQ0/SWlOdmZWmCnZwTPt
-        +ezH+w/w7aZpqsvHi8eLZU1h3c90WW63sHqrrNePF3Lt7PFisXu88C378WL2r/n/zj7I9v+LbTTp
-        n7wPWOOqBVmoOYe9++EGbuPYloNM/Hjh2OI/Djy0IHwXHzl/krxjW+M74O2Uf4grKzOTMEbrhqbm
-        YgfX7/l9PiOfSQ0i98vs+5qkLZDGuKeMknq5Mb6jeV5+ZpusMt59f206nusHcTD7FQl9bFWuZlU3
-        BWuypm1AnMqV8Z6SvNm8fF33tmN8fLCTwA0cePav+yNIyy3JCn7a8k+/4Ld1ydiW1E9mDWdYZ0tO
-        hssVyRmF8yML+JAsgUlm//Ebadhl9X/u6rKqs3JJK7x0bjQbajA8Flzuokx3RlWyTHy3LZ/pFh4+
-        N0iRGrD8cpkB0VJjVdagL+ZGTXEpDH5S1vnO4OfImrJM50ZKWZUBgbOGGcsabrgE4tRlDp8U/Y0t
-        47ZkjcGaNs0EwQgwjuHCA41qsNBnKr6ACxjsvilxxWW9M5YlEPTL3NgQuIRl2yrHz7YgC7DKgrY1
-        MN9j69pOYgAZsmdYBzynKfm2u1XgbfHvG9xls6nLdr0xWEWW1DJ+ZFmxhiuRIAbS8gn+Pjc+w9Pw
-        sgbvBcKwKGvkpmaTMSBKLlQo8tIC1rMheAa0zr7ivTblZ7nLbkk78ROxsM8bpBGpt/3ymGX8RIHk
-        LV8daYA2/CJTXASyOAfK59kTNZY5HFK2FJ/C+bB2CefEVm0OdKmAJsAgQBhcwgoEtK0F0ZFQcDr9
-        cmDFxZriicOdiie6w02R5QY+QtKRek3hVOEcm8+w4LJ+4sSCdb4vP1PQFUCfDS2QSA3+mz6TvOV8
-        w+kzWjw8FplYPJ1yTqtwF8/7A2Kc4AMKbEmx647XSDM46rKBcy9YxlBYcqQobJfh4eLJ7okKd6yB
-        zZsNXp5yPod1f9rAtfAb1uawMdau1yBN4lHOtwfkgY3LA8yKZd4Cp+8fx0++Y6j9Y9O2xrPnVMQ/
-        4C7db8U+xMXw/G5D/c2AYnm2XYB8IHOl2Yqbc9yevN8pmln/8XghZR40TK/CoiDwHy9oDobf8mMn
-        idEC7CrUYb+VbQ0qDI4GpDWnM1QvFM/tj9kYx0Eb4yQ6GxNFrpMIGwNyBMoEfnqFbACQBS7PmNlj
-        F1SXHX7xPLxVk+Plb8QRAPVATYAK3GlVgwG3KPGEQG5BWcHG2MHpwAOB4Kvsy55C8NFzmbd8Swkq
-        6LbZlMJE/XB/dfNuaOtAF2apsHBoFEw0DGaQeL6ZOMnP8sdwIoisYDf88tllU7d0PlvDkaFZvScU
-        Dvs9XLwi2yxH+3AFUppu2noHHzL6e4u0gI9XGWhYvOlqleWZMHu4LGmH3lE8o06rvc3KLQo9cO91
-        sQYK0Jqrr49Am81nOBFaF8aPRcbte7ObG9fPBOwX6n74FPnvAVmPcbghn/Cwg59tmfERuZVJG9xb
-        vfngdriCu6xp2KKt15u58ufR7bmZfQllPdNN7NB0nOCFlP1ryTYtMW6GpP0e1CS3uwO6klRoA5If
-        J+4NiGSd9hQGqipEANO6rsn2BHmvNrDUdXmCuur54feg0oBp4bfIj4uMKDf8SD8bfwcFfOKO/2iX
-        T7QGTWPcgs9hvK3BYhtvKVjMrKyHBzftAS8+MceMwygwI8e3X3ZiHyg1rofHdZvl+R85rv9+WVCf
-        cLfZAUrOy/XuT2QBflNc9C0uHpbNtf09nN8C9izszase97DJ6pzujPsdsMgbftPdB7I4/lMOS7d0
-        u+AupO9FqC07NAtnClCkoCdNxtA15QcGEANutcgWzlmozPUf3HXNrU1sD22bA2oB0LnlOV7sJ7gs
-        acrMzmi8o0ChbVb0ZnrbMvjeKOusM96ME3hb8gMA68CGtsCxw4E1mL1Bl2MHDgR+lcT4xM6Idk/8
-        q/h7z4GIrcZMyI+jp4F7lgZjY45evOWBYtRt+W6Eo2Fzy7YhBS1bxpG/3DVohU0LaoIBngVGwxNf
-        INZB0FvWAr9vM8RqYMzbvHO4etJECmFqriCNBwKqdk8jAOKxhkZ8AyoRvGmM4ER+oHCCHXmPF1VB
-        mGVHduI6rmMHGuL8J6kzsgAGWMMCEVEBFSpaFIi3BGuMjj9QdvkVIP1wd7Zud3cf3zyom/Onbc4P
-        Rlzuho8X0uhYkQsoI9bt7Q0g75WUMkBD1Q4QTwaeboaoHsBkJk4YYJTElbD5qm2G+3Udf7jft+Aj
-        KwzvaLYr3XJ1x8F5F3i0eoDkAi4boIQowLjnDMAxF0rwPo3PGfhM4Np04LymwKQpnCDrsDF4vu0S
-        XZzUWJewvhR+wb2fRWf7QCTbgvvNYBJp2vk6PQH6tSyy8v5L9qySApyg+oCzB4dkO48Xnh14nq+S
-        Ipx2+JGjMrYTuIDrC8tJktCKQsu1xBVj+t0feCSdhwAOSMrdCnD0hQsITA/2GFzerAA9UdMFnDOp
-        e4dHkXJF/70F7FMOOSIJT6tAjpeq3k6qlIkmKv/Ec7SkATm0rdizAkteckibTixWgNeAAMhRuHtY
-        ZKXERy6FA0aLtCpBFRoLAI4pWAvjN/yrmYO3m4sP/zKkUuydoBIu7xVUig/oYCe6PZrs95aHQbaU
-        MH7MuEvuSBlgmQmIzBo+xbiejBeAUIFfTKqqDwKju7/hISxzCfcy2gbgwdcD1a9qiSsgaV0WU9ji
-        bctAAkGa/824Br+8BDszwL7q/pNpXAJmUTUMDijPB9uzfdO3o/CbJPwWRNeJTVuvQg/oiOtdl2XK
-        1wt/XmVCI4H3iWoW451GIUAQyNABkRVhis7RLTpNN0EsioG/EZUce6Iw2Z5Kp8AFA/rXj9c/3v/w
-        cHUDdDPtyLTxMlQ9OmLdkicekxiGrjhLgXrpYxcGx4M8kIcxo0sj3QEOheMmrAL1LKJKoPq5T49G
-        uGw416Ivr1riEekyAKmZQjudkKFVGQsa0xksZyISdZzYPUk/x7QD08bLkH46rfTH6CeIRQWdBHLt
-        KCZCrgd2gMCX3FYifRn35jkD98EpEPrnjLXwYxnqUwjvnCW8DhW8nPDn4e9IviNVvuMYXIDId0w3
-        CG0wwY8XAJFtR8exV+UWAE8XuRfRSE6gjvvgLC7BRpRbERvuIuNIIW4AgODrHAPh4m9AeHBQpQMh
-        HAsRKR8SUDENV3BfxTK8wH6e8h2cibg59A6VI5in0IyTxPsm9r9N4DPH1LpSGcPI9ppykwkPG0bw
-        AxnMpD0cU9kaNNYa8JNAoF3ETjgWWacCBBxTSGcnI+JVW3LeBRMhjy7TMyLYRCzuer4WcwDNEsAb
-        QECdZAMvtHnJngCyYtRoTbnS3gHC4vZYmGYwvISLOP0C5Ckwjn8ovBX5vGdDVAxlzeCOY+gmsj6K
-        2MYq6fbBxT2CPWNtTsISLQj9G3Dpsvkk0yaHwPr7rHnfLs4uzEXhbYs9oh9eaNy/twy8hliG+jzL
-        EPe3DDtwF/bKsQwMVDEeqVqDYoWvwGBjYnK7yMni8WL0+9EOdUf74OwjyyLWLML7JAcyaVyJP3XH
-        sLPTz99TgIZe6C1XxyhQY/x5uSnBr3TMfah8TIFIQwEhpuDw36L+/G/e8dIy1Oftd5hGYRjZ5894
-        9PvRDuOJ1ieODhXob5ZQfqgObMtOLFsrHFediQYZB8knTck1gvC5Lg9l/7G1bWLf9knL2vgOl2Jc
-        lTxsQYx3AkphrJBbcqr4JOFIAbSgC3OwVIoG0GEmLvbFiE4TUXgQaOj0YDu+bYaRF37juN+GgMJD
-        U+fKvM/WGxMsDChJUPdLmSirMBK1ocj3mCOvyxxtCUGtmAIJU8Qv3KFpQNWSKqfrjCjGJFaRTJkD
-        ZB/79N4RKPMB19GM4nYTIbfjqRED2wPkUhSWFwv3ceyLGDksq4A1msILBXtRlxggATSCF6+yZYam
-        QFrTFUj0AhQZ/izlnlwJLu0WrgCoAl7JoRenMMg7kpI6J41CjkDHHjyPfALRueeh9IgIzHf8ELwN
-        9MqCJEjMnU7zZoi9ZIyoyokIYUp72CNimQXsQAhmrE2BagHcsqfZkTzf7B19AueeHAR4juwekOS2
-        LTq3ebT/iYjWdf2RrERSVgI3+NmObBAeX+dAPCj5T2AOzP3zUFi7gCc/4x9BjGRoQ9R0LEWUI81k
-        cYco/UIOqcV3TBR/HOEZT3HD3mW/iVSTAml1qKLLP2FavU9KdXVoI/Kdh7RjGUIvnDme62kDI7Ss
-        16SQYQxjQZvPlBaqEuZulNSzVVnJaDcWCFQlVjCJGha9Z6r49Nc5Izuq6lgdxH8JG+lA+PfAx1c3
-        ogDAxDKLLszDSyrggyzlhRdD7dnFgw5NNc/AG//Z/UrZSF0wVRdEh/aaX2S8Q1PtRGCZX7E4yxgt
-        ZmjXsR6CWfD/yyf6RRSrCCP/Ow+5xnZk/PKGV77A3d/RJc9VGc6cr+vXkcl3z8emVZMf6tQ2Pz/H
-        TmIdRALXoynrHsODHLEKKIEFZ1wmge84XOuLjxYoD6Y0azlsYpBz2WetFLfSj5XUxHWzyUa2zD3K
-        dyOCTIxQO3qPyEnC2PIcC/7Rce493W+n2tUAXFIMOKDW2VfagNHiDjS4RHwlnR7HXQMwAlHtxFRR
-        Sophv37mGciBkxjqFPlL/Rx3YpRaDVHbifd4AX4aqA1MVMI/es8aHMBFy0u14BTRa5VAsVfpozAZ
-        d/1Qm2oiZUNiYJUjHfnM2njNVXfDK3FDlQZ6lLzcF/Co+SsvOtQ1vFgCQ6hYjaA46JfGmy7YdSWB
-        HebBRbKCa5MPJUh7KW3RYG/NVyUWoA382lFiho7rfWPH34ZgajG4oW5uIrQNo/FzFHMND3SDRGeI
-        3tSDEkTUAVtMTjOeylqjfVrwYsaUphzedzKBoT8BfWS9mILyneAUSRKdDphgi73zEPcwTQkyXbB8
-        CyqckFVsa8Htzck0M+6Z56a1JV7D7SsQ9jtQkZuREtQZ366Q+BNfaBcO7OotRhSYGhcOj8WL/MTH
-        TJWOM36CG1HM0+5gpRg5+wtYyzrbJ+rVJFVXQckjwvwMEdqOEtdK2PG7FqsL1cT8a3JS3kSIm0Tx
-        oWwO3ebIsgPLdnVuswyBAjdkYEJTASlQFy73ykJnFRIlSfU9AUW4VrJy2vCXzvn1phYnBKMY9Sg3
-        YLsmpgfwMrCaPI8w3vQPQt33pcU9bMVPRWa7qzsFByfNYPNMsLEad+XVH2ADEPDL6C1np9PJFleh
-        HOLnsioxoKmoW51ueXHY35sYh3V8LspHiiK8yE9ibVGEOE+0pXtYL4NmA77Zk1Qhg+e9iBAndMxo
-        0xOhpxup4XoHmxF2SWDaPJRwpvJnIB/cvxM5iz4XNC7nUfe6oaoh0UUCrkhB0gy09ODE9zVxnPfu
-        gOe2oOg1KmQi6vR8VaYGdRGBFXkArcQVB5ZmW5GsFtIA6+uTXnsZQYEAcvTpt7JtRgrXMm4s1LYN
-        xltoXZc1O0E6oO8oq6sj3otV7dQqiaMWyHH8CC2Qzh73UUZw7FpsDeN6RqZqOzd4UD+H+YcUq6kl
-        cmN9KlLodIPBbyuM1VUlVugD4Tiha6LqaAWsvierhg4KjmCtZyrsTlNuYmzX8fxETznbdhJLelRj
-        yl0XtAZm34JuzWRISpKtXPwGOoUbrkpTP+fYsbp5xkolkKJ14F68+Ymo1klGe3fAZP0m7w5CFoUW
-        q4CFvFDn3N1gIRkTmVNwctGvBSgG1rrjF7UKcc81CPR4XKrgTUYUrRc4gVjrzwyP8M+9BW9VIouy
-        LP6dnXJ93EAJxrynhPdi9YIY6TT1yGTdHSGoP7XAItCkWsFNCCMz8SNwR7xvMfHqmlpNzmibloe1
-        KAL83JUYvSuOFfRgy4uJ6QLengWGv5LdfMPoga8SKiu+qoKnC4Sr6fN9vY7xb8Y7LDB602XBVMJN
-        RNBB5J/kxCBBTrRDz9ZR7p525m+VUUSLY/eJ9iUnS9IAO6HrzT3qQ0faVwW0XVClGjJIXsFNEwG0
-        qEM+TpTQFUSJPX08SiXK3Fhg+rjFzPEg9CuksC2WTQclwVQ2lIf7VKLJchENzUL7JM3CF4DGozSb
-        CMMD74xKi7lKcwPnBYw0DIhzOrF2AUJHct4/VxbPWB+KTqWkk9BqsoeRR27AwTWXFP3e3Fjv6rbv
-        SyI57EZT/eCqVYXvd8+YEaR+DU6qgi8iXXzrpUSdisPdMQ7vcVjsWX5iBZa85HS2QuZpRh2RvN+w
-        L3eQRmFJFc2lpG3+SgvMkKl4XKe7Xmo3/YkQPXBHNalDt8Sxo0Bf+tXmTVbxbNYw6duzBO/LlaVg
-        fdjvWMdb1xHXqAFi11Z0/N8IUagU6bSX1mvxJyJ11/FOuGpuHFiB74WWvExXOyMBw3YPSlUqjahy
-        1I1VQ+R/I09ULVx7OQnOg3BtTiqOAl28R6QyTbQ8eQcXmfBHBzlM0Z1Ms/qgRFekC7Yi6S80+IqM
-        ys5Cdetq5ONEXvdUSsqfiKh939ZQprAAROqckL5AYth5iwddtHne1T9W2M/TNDyPIlN4qCs6x00X
-        CXIilRbtapSydHRuxtk8N9dEIyudaCLfb9JnwsdtwG5kMOum4AkwvvK7fZBftloqq62zrxv6zJ7U
-        yi131G4xtRRhnNMax+NcCytZtFnnu76VC4NKInHR6S6dRA7anFc5OkRdXIIBmeQvsVAh+yoGDYgK
-        /MW+d+pECfWHLAfBqEk1O1fEoYvrBZOR6ajlY2/6UKdZniWuOAj8D0P5B44zd5qwHYOgHGc8uJmt
-        N13OzzJubm4s3tmzFA4T/YJdf1j5Ieonh+QJFJ3/oaQLxTK+JhARuGN6RML4HfbcsWxdiJacfUi/
-        Ig0uW5Y+Fj0BjLe3N5riJ17lxp2L7GgWYLDPIh35zriwUbZaXAXPmxv3bfbV/FTW6FHdz40HYMSv
-        Tzvj9qe5IZpPjQ/XPKvtWMb/zHasYY0vXqS0f76VIbWHEhQR71W9fXvF09sOeF1Fy1UK5woJ3a/K
-        ohNSCSlurq+vR5nwYHJc29b3JoG7GLnHAiT3fRHFwTQPOVWhUxBY18QHHOS74YgD+BtAa1qTfj5C
-        H7tT4ynJGZ54DS4MzuPkni6eFyePF6uC7RgSJeEBJJ3Bk9YAOIMP1eC8xD155AHZ6AYK40myxIOj
-        87gUJ+FDuxz1X+owzndA7ibD3CPeVdPfP9r7REzs+Ikm9jFK97hgXrTYSAdxq5zsMMRoYIkHjyb2
-        o2UwaiSZgndEpKSSUoc1O5nqPCQKsW4JzieZ/ZGUUDC1ZiKM9L1rtu1HvI5cZziwEDKH/3VWAuXY
-        jbFnS8j8ltJGZjL4WB+hHfoEmeSgM3kyx7VVonwFffmkUOU19ROBBhH93xZsHe9lB/f6lsKTZVqP
-        R5D41JxPNcFWu7eD3s2bvs6TXYIm3OIwJ3SoQUPDpWXVaYT9VpbfkTQd+crRaHkTIa2urhX+LzR9
-        z42/id1vE9uOHfNnLbwterTEdaGMPGUieCqHFGFopexyDV0wRoArUsPxliaYlnK5zKqs6UMwoj5N
-        7WYd+wC3sB/QJLNzKTxJcs46pzopgokRZjeMjkUOksSKXWzfFJccJifOdDixCqepoMnYp0ZHE3iG
-        ZImV/OZtWY/qY3Qq86XsHk5F4lGspwqYjMC2ZIfQYcVQLZA0Tr7K2H4C0SfCnsx3tKJFKtKaXdYX
-        vr91eM8/D171lQN9PoeMNGU0olFdfh7qBG2V54uJNBF4x0eUJ4hzYHmx5VviigNXpWQSUgvZQddy
-        X/c6iJ/s248ueUvnMBAqNBN2PEkHXMZlsGuHYGidA64DAnqxSsC2aMA0N3zM0l4bvQaQh6+MIQvd
-        hY2xXuLb38Qx6C43iEwtpi97lNZ3aw1cPDF0SZNO/wvHxrmEptiMvqtKnH6VKYpKzQPetowR8+aZ
-        5KkSr4m1BdnDiTwfKKLyUdQi1MPcY9Vr7ihsbGPxxptL+Ldvh3Hohl6oE8mbHnB35leA1q5/WuSN
-        FV9NUUMfSUpJOzuXg5GdHrBT0Rsw2urU7jY70mfVQb6PpzwfODjLDgCXqMxlKvboSi1U5K9xXUf4
-        /SNh2fnejBfLykQI69uuRlb2jZIRyErsBNrk3dDdF0rlRPyWW7ROtDoCViIM0LlDWtjmq5NpPtKc
-        qVUHsbYO/4RBDydi2jA8Zrk8zznGO7f6mO6pkK7oR8CxkkMABdTZCxhOdLm+/b4becgjl8dZ64fF
-        7s9jrAmR4eH0HsdztNG1YS0wVvWZ2CaPrT7DYuADcep7f1D3DIulBRU5/ldUj0KOLQAgZayNtmpS
-        M7QnnAieo9HMFNsGjlkW1HJ9PzgZEYY9FHQPhbt5mqJH+8DGi45kxMRkSX5vqQ4bixq9ngh3JF3Q
-        en3WdR7wxRVHX8KscR7RcMdEjJyE41agkeMc8/ZCTzu7otO5g0o3GUJlsuGfVFnad5WpAqL4gHdA
-        0OVmds4F1DnG0UT86ztnkrQOT2wnQaQLFtzV5W8S73e1J+Zh7cm5ahPOLx5Rq0wOs0lqGuFug7Hn
-        Ss2pvWASwrFEbDQRE/vjAVidLAGI8x3b146/+sSjBKg5mrLCEqVhZ9Rerk5LjusraO1OKNvTQeYR
-        EV4gOtFkdJuMpmbtnYTQ8nhi2tbOMekHGwyLRfqhSXvukSZqVVMMSYJNRlW8VAvaPMXQYGpnQ74+
-        EYVJXjUyaWLI1uXdDaPwi0yxigqHsha1e7d7jHF6/fGow8WOHi+SKDYd0/MT0w5t1zWd/+eOuiyi
-        qXUGJ7VCHPDSjSDW5hGR2fiUEiDoosWWaSyB3YJWlK189TAk3ZQkHZU1DmeK0YZrwv0Jq33VQCL2
-        RKfy/1ElMLVA+GAg4j6m4lsRj6mIS85NCRxkXLvq8JNFB6OBxKBIDytrh2SLXJVqbfrvG3C0Fcol
-        r6n2jCaiVz86bXhiX7CY8JAOqj5zwhoBygajUGSBFGY2aQt+EOUJp30ef1BbBewIhMS8sMJcvmJj
-        7gHSKaylI9BLWWtqHbEbHEn2OHbsWa5+xsEb8GEAEwBlJBjpixP6IezSsMjG7SVuvTCKFu6iuoNq
-        Z9N9hjo6HZfIvkqXvnb2A1YzeG6srfBR0xgYhwNp6uaQyqlyhXG0A0q1KYrs3JdbdQTf8Tb10X6n
-        glFdBesIjDqWrR1CeqtEh7YLmjJDmB1TDK4XQTaujUlhoL+CZjfVdV/PjoYl71vG1MKWl8LUeGo1
-        70FN017RelZko6LV1zN9KJksjVBauOCvotA+pTjHQcCLl7RpKED9Abx5HLCt8MNr3Nl4amTWPWp/
-        eFeGa4krtLkQkZPiKKsvgspwmF6NUytYy+vnmUwFn2zQUCjknaXQa6Ku8eTWt1E4sR9UGzuWZyVa
-        v0aIz5A1FAIYOcJVc5Vhm3unY8SQFNJslCJSdejJAymoCtZ1FuVwgG08FXYGo0FjY74ILXnJAWPI
-        ENho4MIeoIzfrKCOzsN3gmRY1ryRXLNhAAGbwTw9hCrdINQTbLMsm+bP45mpYdlEg7GZ47qhb9oO
-        wGvX9bSTc94Jo4p7f5alxghhyZb1PaOSW2TtcjaqGVWw7QNNU3UiinakwDAA/7bNc8xJj/Y/tYAg
-        Hk1dU9roF5taNnqMcX9Z4UD+aoNvRCFVn6lZgK4Fa4Nu/RsRGsLI7AkH11WpQPMhwj9ChpMN9PHU
-        ZjfXViNl4+mSPp8uiZdZEjcfIDGMyyM2P0yX9spWylIXERKzEIXYjYflqCNfHzYk3dJNPTuH3l/c
-        D6qdo/ETvpBliW3gqP7KhiJoRtDYv2GHNX3l7KCd7/7N7c0DwO88N34ctMv39yX1z+p0Z9hPPUKW
-        mnEn4irj73PjY8aedtgUKAaf/DnrtAy+ruHgE1J/gQ/46xXIguGcSyzLDGKAXiPyTcWy7vF6FKzN
-        trWj30SpBiq4LijLsrTPi/JKuOP4X8zmQg+pLfAtMwLzizYIKYyjwaOqMkKFvTk4oj+skqf2x4nm
-        9MNaZt/2dXmOPhori7vEy4VWGWJeYvDxMaB/uQ/Z1cH2iUOBDUdvLNAN5x5TiLEsz19c6X1cGJOp
-        RQyxexTlgK1C39rRDmQVg3L4DNrha8masl1u5HRqYzD3TXlhFxFl8HsOU5lHwcmfyKJUpxnpQPIh
-        7uF2+MQgE4HTJJi9xNdK4YslBGQdTJdQqpI+lds8Kw4dWfXBk6Of4665wZxS3vWrtRGGmHIuU0ti
-        OjrnVjEfGFd/WIk4nNbTfbbJ8CB38+5aPMntIqdimNh+wOmyFIMtaFfQrDh3CgT7BJoXG8eHZLJf
-        g8KSqSB21L0AKOTx4tPHh/trXpZjxVEQRLogyDsq096H6TlMUsBDOIIl8p2BfelwRzQm324gBsFg
-        QEkGS+qybIw1esoZGXhK+XA8zhGL/RNdqJNRtJOHsUhYMC7pkm19z0JXJ3r4Oprj44mTicA3sJ3j
-        JHcc8LFDz/F1NP8AXqQp3puWDZorRGEKnzpcwfqqDe3G3nSteGp0U2biLzE+t2+5Gdd461VOcpLe
-        ji439KfTezLQHsePlVeNBGGif6HCG6l292O0+UT8YV3IkQGCbqiSqcwxfnrW09J2ZSXnUfXgTZ6R
-        AwpR3NaqyoJaoHS9xNf3fh7MUO+OHnsBcJaBkGSZQ9Q2uRe0fqYHvWrHOviGodHDVlB1CPvfyZaM
-        HDOdMN99+OHB+OHj9Yhok1rZBsPV0aAQsgq1BYlXOewpNfOyrPZBzUHh8XNWNy2v3cTpnV3eHlFI
-        y0QaDZbCcJYIfidCYFjUuxTttSJYqFBEqX75e9kWk3L35+aqJ+fx9PER9A78L3i8sOEv2rJ/3v1p
-        UmyGqrFsbthXcqQ9BN88iTMReHFQuRDKgFcYpbQ5nFyjop9/EJJt1QKPF8QIx+SR76bFV+fUo6KQ
-        +QzEfp0Nbobvqs3BULVCz/AabEA9T/ztX/t3BwsvZ5kWFn9BpVQ88vXBkmzg9vD3VsqXWJr8L+az
-        Y1Up1u5178uV77QctEoCAFWuGL9jGjVUAcbBHPwGvgRqNya+5UDyxJ+02i/b/Mxq1Sv+yGrx3ZyU
-        t0+/7h2ebnDkHZ5uIN/hCVwJv3TwvW7d+zz/OZM6Dv84Jtp5gs3+hfdtFwMGYsC+zZCjMsbaMzsb
-        vmqODV+DPihCNTP+7uVRRZZYxa8Hr7ZOv1igCMSatT/BJ8qsDawsYyZr4Yi4ly/1BvB8lnZnDjfD
-        40yF8gjsEOxSWu9IahVPScxW0e/c9Vb0joyF8xPeEIYtAEBs3NqJW4tXUoW+54paEOWOpXrDmj5n
-        9PPJ2x1s3GLEOXrf+bQbuccXCCd68/DwEU8MNgKMGvs/4zF1NMG3e4tCQOMGW5f3w6duMam2kK7A
-        vL/qbVYuN3SLhXbgsOCnPDgjiiBAKfOxGG8PftbPB9x/pHjQvw5einiaRf/1X+Wx9bkOgAAA
+      string: '{"indexed":{"date-parts":[[2023,10,15]],"date-time":"2023-10-15T04:56:03Z","timestamp":1697345763946},"reference-count":98,"publisher":"eLife
+        Sciences Publications, Ltd","license":[{"start":{"date-parts":[[2020,1,23]],"date-time":"2020-01-23T00:00:00Z","timestamp":1579737600000},"content-version":"vor","delay-in-days":0,"URL":"http:\/\/creativecommons.org\/licenses\/by\/4.0\/"},{"start":{"date-parts":[[2020,1,23]],"date-time":"2020-01-23T00:00:00Z","timestamp":1579737600000},"content-version":"am","delay-in-days":0,"URL":"http:\/\/creativecommons.org\/licenses\/by\/4.0\/"},{"start":{"date-parts":[[2020,1,23]],"date-time":"2020-01-23T00:00:00Z","timestamp":1579737600000},"content-version":"tdm","delay-in-days":0,"URL":"http:\/\/creativecommons.org\/licenses\/by\/4.0\/"}],"funder":[{"DOI":"10.13039\/100000001","name":"National
+        Science Foundation","doi-asserted-by":"publisher","award":["Graduate Research
+        Fellowship DGE-1324585"]},{"DOI":"10.13039\/100000002","name":"National Institutes
+        of Health","doi-asserted-by":"publisher","award":["R01 NS095251"]}],"content-domain":{"domain":[],"crossmark-restriction":false},"abstract":"<jats:p>Proprioception,
+        the sense of body position, movement, and associated forces, remains poorly
+        understood, despite its critical role in movement. Most studies of area 2,
+        a proprioceptive area of somatosensory cortex, have simply compared neurons\u2019
+        activities to the movement of the hand through space. Using motion tracking,
+        we sought to elaborate this relationship by characterizing how area 2 activity
+        relates to whole arm movements. We found that a whole-arm model, unlike classic
+        models, successfully predicted how features of neural activity changed as
+        monkeys reached to targets in two workspaces. However, when we then evaluated
+        this whole-arm model across active and passive movements, we found that many
+        neurons did not consistently represent the whole arm over both conditions.
+        These results suggest that 1) neural activity in area 2 includes representation
+        of the whole arm during reaching and 2) many of these neurons represented
+        limb state differently during active and passive movements.<\/jats:p>","DOI":"10.7554\/elife.48198","type":"journal-article","created":{"date-parts":[[2020,1,23]],"date-time":"2020-01-23T11:00:19Z","timestamp":1579777219000},"source":"Crossref","is-referenced-by-count":37,"title":"Area
+        2 of primary somatosensory cortex encodes kinematics of the whole arm","prefix":"10.7554","volume":"9","author":[{"ORCID":"http:\/\/orcid.org\/0000-0002-5934-919X","authenticated-orcid":true,"given":"Raeed
+        H","family":"Chowdhury","sequence":"first","affiliation":[{"name":"Department
+        of Biomedical Engineering, Northwestern University, Evanston, United States"},{"name":"Systems
+        Neuroscience Institute, University of Pittsburgh, Pittsburgh, United States"}]},{"ORCID":"http:\/\/orcid.org\/0000-0003-2906-115X","authenticated-orcid":true,"given":"Joshua
+        I","family":"Glaser","sequence":"additional","affiliation":[{"name":"Interdepartmental
+        Neuroscience Program, Northwestern University, Chicago, United States"},{"name":"Department
+        of Statistics, Columbia University, New York, United States"},{"name":"Zuckerman
+        Mind Brain Behavior Institute, Columbia University, New York, United States"}]},{"ORCID":"http:\/\/orcid.org\/0000-0001-8675-7140","authenticated-orcid":true,"given":"Lee
+        E","family":"Miller","sequence":"additional","affiliation":[{"name":"Department
+        of Biomedical Engineering, Northwestern University, Evanston, United States"},{"name":"Department
+        of Physiology, Northwestern University, Chicago, United States"},{"name":"Department
+        of Physical Medicine and Rehabilitation, Northwestern University, Chicago,
+        United States"},{"name":"Shirley Ryan AbilityLab, Chicago, United States"}]}],"member":"4374","published-online":{"date-parts":[[2020,1,23]]},"reference":[{"key":"bib1","doi-asserted-by":"publisher","first-page":"280","DOI":"10.1115\/1.3138494","article-title":"Determination
+        of muscle orientations and moment arms","volume":"106","author":"An","year":"1984","journal-title":"Journal
+        of Biomechanical Engineering"},{"key":"bib2","doi-asserted-by":"publisher","DOI":"10.7554\/eLife.32904","article-title":"Proprioceptive
+        and cutaneous sensations in humans elicited by intracortical microstimulation","volume":"7","author":"Armenta
+        Salas","year":"2018","journal-title":"eLife"},{"key":"bib3","doi-asserted-by":"publisher","first-page":"1745","DOI":"10.1073\/pnas.0709212105","article-title":"Variable
+        gearing in pennate muscles","volume":"105","author":"Azizi","year":"2008","journal-title":"PNAS"},{"key":"bib4","doi-asserted-by":"publisher","first-page":"450","DOI":"10.1126\/science.7291985","article-title":"An
+        efference copy which is modified by reafferent input","volume":"214","author":"Bell","year":"1981","journal-title":"Science"},{"key":"bib5","doi-asserted-by":"publisher","article-title":"The
+        reach cage environment for wireless neural recordings during structured goal-directed
+        behavior of unrestrained monkeys","volume-title":"bioRxiv","author":"Berger","year":"2018","DOI":"10.1101\/305334"},{"key":"bib6","doi-asserted-by":"publisher","first-page":"715","DOI":"10.1152\/jn.1996.76.2.715","article-title":"Representation
+        of passive hindlimb postures in cat spinocerebellar activity","volume":"76","author":"Bosco","year":"1996","journal-title":"Journal
+        of Neurophysiology"},{"key":"bib7","doi-asserted-by":"publisher","first-page":"2931","DOI":"10.1152\/jn.2000.83.5.2931","article-title":"Reference
+        frames for spinal proprioception: limb endpoint based or joint-level based?","volume":"83","author":"Bosco","year":"2000","journal-title":"Journal
+        of Neurophysiology"},{"key":"bib8","first-page":"209","article-title":"R-squared
+        measures for count data regression models with applications to health-care
+        utilization","volume":"14","author":"Cameron","year":"1996","journal-title":"Journal
+        of Business & Economic Statistics"},{"key":"bib9","doi-asserted-by":"publisher","first-page":"329","DOI":"10.1016\/S0304-4076(96)01818-0","article-title":"An
+        R-squared measure of goodness of fit for some common nonlinear regression
+        models","volume":"77","author":"Cameron","year":"1997","journal-title":"Journal
+        of Econometrics"},{"key":"bib10","doi-asserted-by":"publisher","first-page":"2039","DOI":"10.1523\/JNEUROSCI.10-07-02039.1990","article-title":"Making
+        arm movements within different parts of space: dynamic aspects in the primate
+        motor cortex","volume":"10","author":"Caminiti","year":"1990","journal-title":"The
+        Journal of Neuroscience"},{"key":"bib11","doi-asserted-by":"publisher","first-page":"1182","DOI":"10.1523\/JNEUROSCI.11-05-01182.1991","article-title":"Making
+        arm movements within different parts of space: the premotor and motor cortical
+        representation of a coordinate system for reaching to visual targets","volume":"11","author":"Caminiti","year":"1991","journal-title":"The
+        Journal of Neuroscience"},{"key":"bib12","doi-asserted-by":"publisher","first-page":"327","DOI":"10.1088\/1741-2560\/3\/4\/010","article-title":"Computational
+        model of a primate arm: from hand position to joint angles, joint torques
+        and muscle forces","volume":"3","author":"Chan","year":"2006","journal-title":"Journal
+        of Neural Engineering"},{"key":"bib13","doi-asserted-by":"publisher","first-page":"63","DOI":"10.1016\/0006-8993(84)91011-4","article-title":"Discharge
+        properties of area 5 neurones during arm movements triggered by sensory stimuli
+        in the monkey","volume":"309","author":"Chapman","year":"1984","journal-title":"Brain
+        Research"},{"key":"bib14","doi-asserted-by":"publisher","first-page":"234","DOI":"10.1152\/jn.00695.2016","article-title":"Musculoskeletal
+        geometry accounts for apparent extrinsic representation of paw position in
+        dorsal spinocerebellar tract","volume":"118","author":"Chowdhury","year":"2017","journal-title":"Journal
+        of Neurophysiology"},{"key":"bib15","article-title":"KinectTracking","volume-title":"GitHub","author":"Chowdhury","year":"2020","unstructured":"Chowdhury
+        RH. 2020a. KinectTracking. GitHub. 052b0f1. https:\/\/github.com\/limblab\/KinectTracking."},{"key":"bib16","article-title":"S1
+        kinematic encoding analysis","volume-title":"GitHub","author":"Chowdhury","year":"2020","unstructured":"Chowdhury
+        RH. 2020b. S1 kinematic encoding analysis. GitHub. e6363cf. https:\/\/github.com\/raeedcho\/s1-kinematics."},{"key":"bib17","article-title":"monkeyArmModel","volume-title":"GitHub","author":"Chowdhury","year":"2020","unstructured":"Chowdhury
+        RH. 2020c. monkeyArmModel. GitHub. d766701. https:\/\/github.com\/limblab\/monkeyArmModel."},{"key":"bib18","doi-asserted-by":"publisher","first-page":"387","DOI":"10.1016\/j.neuron.2010.09.015","article-title":"Cortical
+        preparatory activity: representation of\u00a0Movement or First Cog in a Dynamical
+        Machine?","volume":"68","author":"Churchland","year":"2010","journal-title":"Neuron"},{"key":"bib19","doi-asserted-by":"publisher","first-page":"557","DOI":"10.1016\/S0140-6736(12)61816-9","article-title":"High-performance
+        neuroprosthetic control by an individual with tetraplegia","volume":"381","author":"Collinger","year":"2013","journal-title":"The
+        Lancet"},{"key":"bib20","doi-asserted-by":"publisher","first-page":"138","DOI":"10.1038\/nn.3883","article-title":"A
+        learning-based approach to artificial sensory feedback leads to optimal integration","volume":"18","author":"Dadarlat","year":"2015","journal-title":"Nature
+        Neuroscience"},{"key":"bib21","doi-asserted-by":"publisher","DOI":"10.1038\/s41467-018-05959-y","article-title":"Single
+        reach plans in dorsal premotor cortex during a two-target task","volume":"9","author":"Dekleva","year":"2018","journal-title":"Nature
+        Communications"},{"key":"bib22","doi-asserted-by":"publisher","first-page":"224","DOI":"10.1017\/S0140525X07001641","article-title":"Somatosensory
+        processing subserving perception and action: dissociations, interactions,
+        and integration","volume":"30","author":"Dijkerman","year":"2007","journal-title":"Behavioral
+        and Brain Sciences"},{"key":"bib23","doi-asserted-by":"publisher","DOI":"10.1038\/ncomms13239","article-title":"Reorganization
+        between preparatory and movement population responses in motor cortex","volume":"7","author":"Elsayed","year":"2016","journal-title":"Nature
+        Communications"},{"key":"bib24","article-title":"Get CI and p-values for cross
+        validated performance measures","volume-title":"Cross Validated","author":"Ernst","year":"2017","unstructured":"Ernst
+        D. 2017. Get CI and p-values for cross validated performance measures. Cross
+        Validated. https:\/\/stats.stackexchange.com\/q\/305807 [Accessed December
+        1, 2017]."},{"key":"bib25","doi-asserted-by":"publisher","first-page":"368","DOI":"10.1038\/nature10987","article-title":"Restoration
+        of grasp following paralysis through brain-controlled stimulation of muscles","volume":"485","author":"Ethier","year":"2012","journal-title":"Nature"},{"key":"bib26","doi-asserted-by":"publisher","first-page":"14","DOI":"10.1152\/jn.1968.31.1.14","article-title":"Relation
+        of pyramidal tract activity to force exerted during voluntary movement","volume":"31","author":"Evarts","year":"1968","journal-title":"Journal
+        of Neurophysiology"},{"key":"bib27","doi-asserted-by":"publisher","first-page":"1","DOI":"10.1093\/cercor\/1.1.1","article-title":"Distributed
+        hierarchical processing in the primate cerebral cortex","volume":"1","author":"Felleman","year":"1991","journal-title":"Cerebral
+        Cortex"},{"key":"bib28","doi-asserted-by":"crossref","first-page":"437","volume-title":"Progress
+        in Brain Research: Afferent Control of Posture and Locomotion","author":"Fetz","year":"1989","DOI":"10.1016\/S0079-6123(08)62241-4"},{"key":"bib29","doi-asserted-by":"publisher","first-page":"679","DOI":"10.1017\/S0140525X00072599","article-title":"Are
+        movement parameters recognizably coded in activity of single neurons?","volume":"15","author":"Fetz","year":"1992","journal-title":"Behavioral
+        and Brain Sciences"},{"key":"bib30","doi-asserted-by":"publisher","DOI":"10.1126\/scitranslmed.aaf8083","article-title":"Intracortical
+        microstimulation of human somatosensory cortex","volume":"8","author":"Flesher","year":"2016","journal-title":"Science
+        Translational Medicine"},{"key":"bib31","doi-asserted-by":"publisher","first-page":"164","DOI":"10.1152\/jn.00494.2009","article-title":"Where
+        is your arm? variations in proprioception across space and tasks","volume":"103","author":"Fuentes","year":"2010","journal-title":"Journal
+        of Neurophysiology"},{"key":"bib32","doi-asserted-by":"publisher","first-page":"978","DOI":"10.1016\/j.neuron.2017.05.025","article-title":"Neural
+        manifolds for the control of movement","volume":"94","author":"Gallego","year":"2017","journal-title":"Neuron"},{"key":"bib33","doi-asserted-by":"publisher","first-page":"1527","DOI":"10.1523\/JNEUROSCI.02-11-01527.1982","article-title":"On
+        the relations between the direction of two-dimensional arm movements and cell
+        discharge in primate motor cortex","volume":"2","author":"Georgopoulos","year":"1982","journal-title":"The
+        Journal of Neuroscience"},{"key":"bib34","doi-asserted-by":"publisher","first-page":"1416","DOI":"10.1126\/science.3749885","article-title":"Neuronal
+        population coding of movement direction","volume":"233","author":"Georgopoulos","year":"1986","journal-title":"Science"},{"key":"bib35","doi-asserted-by":"publisher","first-page":"273","DOI":"10.1139\/y95-038","article-title":"Proprioceptive
+        control of interjoint coordination","volume":"73","author":"Ghez","year":"1995","journal-title":"Canadian
+        Journal of Physiology and Pharmacology"},{"key":"bib36","doi-asserted-by":"publisher","first-page":"347","DOI":"10.1152\/jn.1995.73.1.347","article-title":"Impairments
+        of reaching movements in patients without proprioception. I. spatial errors","volume":"73","author":"Gordon","year":"1995","journal-title":"Journal
+        of Neurophysiology"},{"key":"bib37","doi-asserted-by":"publisher","first-page":"2164","DOI":"10.1152\/jn.01147.2003","article-title":"Movement
+        reduces the dynamic response of muscle spindle afferents and motoneuron synaptic
+        potentials in rat","volume":"91","author":"Haftel","year":"2004","journal-title":"Journal
+        of Neurophysiology"},{"key":"bib38","doi-asserted-by":"publisher","first-page":"1349","DOI":"10.1152\/jn.00019.2012","article-title":"Energy
+        margins in dynamic object manipulation","volume":"108","author":"Hasson","year":"2012","journal-title":"Journal
+        of Neurophysiology"},{"key":"bib39","doi-asserted-by":"publisher","first-page":"199","DOI":"10.1113\/jphysiol.1976.sp011364","article-title":"Inputs
+        from low threshold muscle and cutaneous afferents of hand and forearm to Areas
+        3a and 3b of baboon''s cerebral cortex","volume":"257","author":"Heath","year":"1976","journal-title":"The
+        Journal of Physiology"},{"key":"bib40","doi-asserted-by":"publisher","first-page":"253","DOI":"10.1016\/S0167-9473(03)00062-8","article-title":"Pseudo
+        R-squared measures for Poisson regression models with over- or underdispersion","volume":"44","author":"Heinzl","year":"2003","journal-title":"Computational
+        Statistics & Data Analysis"},{"key":"bib41","doi-asserted-by":"publisher","first-page":"574","DOI":"10.1113\/jphysiol.1959.sp006308","article-title":"Receptive
+        fields of single neurones in the cat''s striate cortex","volume":"148","author":"Hubel","year":"1959","journal-title":"The
+        Journal of Physiology"},{"key":"bib42","doi-asserted-by":"publisher","first-page":"106","DOI":"10.1113\/jphysiol.1962.sp006837","article-title":"Receptive
+        fields, binocular interaction and functional architecture in the cat''s visual
+        cortex","volume":"160","author":"Hubel","year":"1962","journal-title":"The
+        Journal of Physiology"},{"key":"bib43","doi-asserted-by":"publisher","first-page":"539","DOI":"10.1113\/jphysiol.1978.sp012518","article-title":"Receptive
+        field integration and submodality convergence in the hand area of the post-central
+        gyrus of the alert monkey","volume":"283","author":"Hyv\u00e4rinen","year":"1978","journal-title":"The
+        Journal of Physiology"},{"key":"bib44","doi-asserted-by":"publisher","first-page":"1216","DOI":"10.1152\/jn.1983.49.5.1216","article-title":"Somatosensory
+        cortex activity related to position and force","volume":"49","author":"Jennings","year":"1983","journal-title":"Journal
+        of Neurophysiology"},{"key":"bib45","doi-asserted-by":"publisher","first-page":"521","DOI":"10.1126\/science.107591","article-title":"Multiple
+        representations of the body within the primary somatosensory cortex of primates","volume":"204","author":"Kaas","year":"1979","journal-title":"Science"},{"key":"bib46","doi-asserted-by":"publisher","first-page":"2136","DOI":"10.1126\/science.285.5436.2136","article-title":"Muscle
+        and movement representations in the primary motor cortex","volume":"285","author":"Kakei","year":"1999","journal-title":"Science"},{"key":"bib47","doi-asserted-by":"publisher","DOI":"10.1038\/ncomms8759","article-title":"Single-trial
+        dynamics of motor cortex and their applications to brain-machine interfaces","volume":"6","author":"Kao","year":"2015","journal-title":"Nature
+        Communications"},{"key":"bib48","doi-asserted-by":"publisher","first-page":"440","DOI":"10.1038\/nn.3643","article-title":"Cortical
+        activity in the null space: permitting preparation without movement","volume":"17","author":"Kaufman","year":"2014","journal-title":"Nature
+        Neuroscience"},{"key":"bib49","first-page":"1097","volume-title":"Advances
+        in Neural Information Processing Systems","author":"Krizhevsky","year":"2012"},{"key":"bib50","doi-asserted-by":"publisher","first-page":"168","DOI":"10.1016\/j.neuron.2012.10.041","article-title":"Preference
+        distributions of primary motor cortex neurons reflect control solutions optimized
+        for limb biomechanics","volume":"77","author":"Lillicrap","year":"2013","journal-title":"Neuron"},{"key":"bib51","doi-asserted-by":"publisher","first-page":"578","DOI":"10.1152\/jn.1985.54.3.578","article-title":"Activity
+        of spindle afferents from cat anterior thigh muscles. III. effects of external
+        stimuli","volume":"54","author":"Loeb","year":"1985","journal-title":"Journal
+        of Neurophysiology"},{"key":"bib52","first-page":"7521","article-title":"Designing
+        stimulation patterns for an afferent BMI: representation of kinetics in somatosensory
+        cortex","author":"London","year":"2011","unstructured":"London BM, Ruiz-Torres
+        R, Slutzky MW, Miller LE. 2011. Designing stimulation patterns for an afferent
+        BMI: representation of kinetics in somatosensory cortex. Engineering in Medicine
+        and Biology Society, EMBC, 2011 Annual International Conference of the IEEE."},{"key":"bib53","doi-asserted-by":"publisher","first-page":"1505","DOI":"10.1152\/jn.00372.2012","article-title":"Responses
+        of somatosensory area 2 neurons to actively and passively generated limb movements","volume":"109","author":"London","year":"2013","journal-title":"Journal
+        of Neurophysiology"},{"key":"bib54","doi-asserted-by":"publisher","DOI":"10.3389\/fnsys.2019.00013","article-title":"Neural
+        networks for modeling neural spiking in S1 cortex","volume":"13","author":"Lucas","year":"2019","journal-title":"Frontiers
+        in Systems Neuroscience"},{"key":"bib55","doi-asserted-by":"publisher","first-page":"1493","DOI":"10.1016\/j.neuron.2017.02.049","article-title":"Somatosensory
+        cortex plays an essential role in forelimb motor adaptation in mice","volume":"93","author":"Mathis","year":"2017","journal-title":"Neuron"},{"key":"bib56","doi-asserted-by":"publisher","first-page":"1671","DOI":"10.1152\/jn.00475.2018","article-title":"Highlights
+        from the 28th annual meeting of the society for the neural control of movement","volume":"120","author":"Mazurek","year":"2018","journal-title":"Journal
+        of Neurophysiology"},{"key":"bib57","volume-title":"Quantitative Methods for
+        Analyzing Travel Behavior of Individuals: Some Recent Developments","author":"McFadden","year":"1977"},{"key":"bib58","doi-asserted-by":"publisher","first-page":"57","DOI":"10.1016\/0166-4328(82)90081-X","article-title":"Contribution
+        of striate inputs to the visuospatial functions of parieto-preoccipital cortex
+        in monkeys","volume":"6","author":"Mishkin","year":"1982","journal-title":"Behavioural
+        Brain Research"},{"key":"bib59","doi-asserted-by":"publisher","first-page":"2676","DOI":"10.1152\/jn.1999.82.5.2676","article-title":"Motor
+        cortical representation of speed and direction during reaching","volume":"82","author":"Moran","year":"1999","journal-title":"Journal
+        of Neurophysiology"},{"key":"bib60","doi-asserted-by":"publisher","first-page":"1786","DOI":"10.1152\/jn.00150.2006","article-title":"Direct
+        comparison of the Task-Dependent discharge of M1 in hand space and muscle
+        space","volume":"97","author":"Morrow","year":"2007","journal-title":"Journal
+        of Neurophysiology"},{"key":"bib61","doi-asserted-by":"publisher","first-page":"871","DOI":"10.1152\/jn.1975.38.4.871","article-title":"Posterior
+        parietal association cortex of the monkey: command functions for operations
+        within extrapersonal space","volume":"38","author":"Mountcastle","year":"1975","journal-title":"Journal
+        of Neurophysiology"},{"key":"bib62","doi-asserted-by":"publisher","first-page":"106","DOI":"10.1016\/0304-3940(88)90257-1","article-title":"Do
+        neurons in the motor cortex encode movement direction? an alternative hypothesis","volume":"91","author":"Mussa-Ivaldi","year":"1988","journal-title":"Neuroscience
+        Letters"},{"key":"bib63","doi-asserted-by":"crossref","first-page":"239","DOI":"10.1023\/A:1024068626366","article-title":"Inference
+        for the generalization error","volume":"52","author":"Nadeau","year":"2003","journal-title":"Machine
+        Learning"},{"key":"bib64","doi-asserted-by":"publisher","first-page":"2077","DOI":"10.1152\/jn.00719.2012","article-title":"Sensorimotor
+        adaptation changes the neural coding of somatosensory stimuli","volume":"109","author":"Nasir","year":"2013","journal-title":"Journal
+        of Neurophysiology"},{"key":"bib65","doi-asserted-by":"publisher","first-page":"402","DOI":"10.1016\/0006-8993(87)90815-8","article-title":"Activity
+        of monkey primary somatosensory cortical neurons changes prior to active movement","volume":"406","author":"Nelson","year":"1987","journal-title":"Brain
+        Research"},{"key":"bib66","doi-asserted-by":"publisher","first-page":"666","DOI":"10.1152\/jn.00331.2012","article-title":"Movement
+        representation in the primary motor cortex and its contribution to generalizable
+        EMG predictions","volume":"109","author":"Oby","year":"2013","journal-title":"Journal
+        of Neurophysiology"},{"key":"bib67","doi-asserted-by":"publisher","DOI":"10.7554\/eLife.13141","article-title":"Distributed
+        task-specific processing of somatosensory feedback for voluntary motor control","volume":"5","author":"Omrani","year":"2016","journal-title":"eLife"},{"key":"bib68","doi-asserted-by":"publisher","first-page":"718","DOI":"10.1002\/cne.24453","article-title":"Cortical
+        connections of area 2 and posterior parietal area 5 in macaque monkeys","volume":"527","author":"Padberg","year":"2019","journal-title":"Journal
+        of Comparative Neurology"},{"key":"bib69","doi-asserted-by":"publisher","first-page":"964","DOI":"10.1016\/j.neuron.2018.09.030","article-title":"A
+        neural population mechanism for rapid learning","volume":"100","author":"Perich","year":"2018","journal-title":"Neuron"},{"key":"bib70","doi-asserted-by":"publisher","first-page":"419","DOI":"10.1113\/jphysiol.1971.sp009579","article-title":"Projection
+        from low-threshold muscle afferents of hand and forearm to area 3a of baboon''s
+        cortex","volume":"217","author":"Phillips","year":"1971","journal-title":"The
+        Journal of Physiology"},{"key":"bib71","doi-asserted-by":"publisher","first-page":"445","DOI":"10.1002\/cne.902410405","article-title":"The
+        somatotopic organization of area 2 in macaque monkeys","volume":"241","author":"Pons","year":"1985","journal-title":"The
+        Journal of Comparative Neurology"},{"key":"bib72","doi-asserted-by":"publisher","first-page":"1090","DOI":"10.1152\/jn.1976.39.5.1090","article-title":"Discharges
+        of single hindlimb afferents in the freely moving cat","volume":"39","author":"Prochazka","year":"1976","journal-title":"Journal
+        of Neurophysiology"},{"key":"bib73","doi-asserted-by":"publisher","first-page":"229","volume-title":"Muscle
+        Receptors and Movement","author":"Prochazka","year":"1981","DOI":"10.1007\/978-1-349-06022-1_24"},{"key":"bib74","doi-asserted-by":"publisher","first-page":"1","DOI":"10.1113\/jphysiol.1985.sp015843","article-title":"The
+        initial burst of impulses in responses of toad muscle spindles during stretch","volume":"368","author":"Proske","year":"1985","journal-title":"The
+        Journal of Physiology"},{"key":"bib75","doi-asserted-by":"publisher","first-page":"2280","DOI":"10.1152\/jn.1994.72.5.2280","article-title":"Proprioceptive
+        activity in primate primary somatosensory cortex during active arm reaching
+        movements","volume":"72","author":"Prud''homme","year":"1994","journal-title":"Journal
+        of Neurophysiology"},{"key":"bib76","doi-asserted-by":"publisher","first-page":"479","DOI":"10.1113\/jphysiol.1984.sp015077","article-title":"Elastic
+        properties of the cat soleus tendon and their functional importance","volume":"347","author":"Rack","year":"1984","journal-title":"The
+        Journal of Physiology"},{"key":"bib77","doi-asserted-by":"publisher","first-page":"2255","DOI":"10.1152\/jn.01083.2015","article-title":"A
+        chronic neural interface to the macaque dorsal column nuclei","volume":"115","author":"Richardson","year":"2016","journal-title":"Journal
+        of Neurophysiology"},{"key":"bib78","doi-asserted-by":"publisher","first-page":"387","DOI":"10.1038\/32891","article-title":"Somatosensory
+        discrimination based on cortical microstimulation","volume":"392","author":"Romo","year":"1998","journal-title":"Nature"},{"key":"bib79","doi-asserted-by":"publisher","first-page":"953","DOI":"10.1016\/j.neuron.2018.01.004","article-title":"Motor
+        cortex embeds Muscle-like commands in an untangled population response","volume":"97","author":"Russo","year":"2018","journal-title":"Neuron"},{"key":"bib80","doi-asserted-by":"publisher","first-page":"2136","DOI":"10.1152\/jn.1993.70.5.2136","article-title":"Loss
+        of proprioception produces deficits in interjoint coordination","volume":"70","author":"Sainburg","year":"1993","journal-title":"Journal
+        of Neurophysiology"},{"key":"bib81","doi-asserted-by":"publisher","first-page":"820","DOI":"10.1152\/jn.1995.73.2.820","article-title":"Control
+        of limb dynamics in normal subjects and patients without proprioception","volume":"73","author":"Sainburg","year":"1995","journal-title":"Journal
+        of Neurophysiology"},{"key":"bib82","doi-asserted-by":"publisher","first-page":"979","DOI":"10.1073\/pnas.81.3.979","article-title":"Motor
+        deficits in patients with large-fiber sensory neuropathy","volume":"81","author":"Sanes","year":"1984","journal-title":"PNAS"},{"key":"bib83","doi-asserted-by":"publisher","first-page":"2563","DOI":"10.1152\/jn.1995.73.6.2563","article-title":"Changes
+        in motor cortex activity during reaching movements with similar hand paths
+        but different arm postures","volume":"73","author":"Scott","year":"1995","journal-title":"Journal
+        of Neurophysiology"},{"key":"bib84","doi-asserted-by":"publisher","first-page":"291","DOI":"10.1007\/s12264-012-1223-9","article-title":"Dorsal
+        and ventral streams across sensory modalities","volume":"28","author":"Sedda","year":"2012","journal-title":"Neuroscience
+        Bulletin"},{"key":"bib85","doi-asserted-by":"publisher","first-page":"1834","DOI":"10.1093\/cercor\/bhr257","article-title":"Topographic
+        maps within brodmann''s Area 5 of macaque monkeys","volume":"22","author":"Seelke","year":"2012","journal-title":"Cerebral
+        Cortex"},{"key":"bib86","doi-asserted-by":"publisher","first-page":"3208","DOI":"10.1523\/JNEUROSCI.14-05-03208.1994","article-title":"Adaptive
+        representation of dynamics during learning of a motor task","volume":"14","author":"Shadmehr","year":"1994","journal-title":"The
+        Journal of Neuroscience"},{"key":"bib87","article-title":"What can spatiotemporal
+        characteristics of movements in RAMIS tell Us?","volume-title":"arXiv","author":"Sharon","year":"2017","unstructured":"Sharon
+        Y, Nisky I. 2017. What can spatiotemporal characteristics of movements in
+        RAMIS tell Us?. arXiv. https:\/\/arxiv.org\/abs\/1710.05818."},{"key":"bib88","doi-asserted-by":"publisher","first-page":"3271","DOI":"10.1152\/jn.00436.2017","article-title":"Methodological
+        considerations for a chronic neural interface with the cuneate nucleus of
+        macaques","volume":"118","author":"Suresh","year":"2017","journal-title":"Journal
+        of Neurophysiology"},{"key":"bib89","doi-asserted-by":"publisher","first-page":"1025","DOI":"10.1038\/nn.4042","article-title":"A
+        neural network that finds a naturalistic solution for the production of muscle
+        activity","volume":"18","author":"Sussillo","year":"2015","journal-title":"Nature
+        Neuroscience"},{"key":"bib90","doi-asserted-by":"publisher","first-page":"18279","DOI":"10.1073\/pnas.1221113110","article-title":"Restoring
+        the sense of touch with a prosthetic hand through a brain interface","volume":"110","author":"Tabot","year":"2013","journal-title":"PNAS"},{"key":"bib91","volume-title":"Progress
+        in Motor Control: Theories and Translations","author":"Tomlinson","year":"2016"},{"key":"bib92","doi-asserted-by":"publisher","first-page":"1074","DOI":"10.1152\/jn.00697.2004","article-title":"A
+        point process framework for relating neural spiking activity to spiking history,
+        neural ensemble, and extrinsic covariate effects","volume":"93","author":"Truccolo","year":"2005","journal-title":"Journal
+        of Neurophysiology"},{"key":"bib93","doi-asserted-by":"publisher","first-page":"240","DOI":"10.1109\/TNSRE.2006.875575","article-title":"Decoding
+        sensory feedback from firing rates of afferent ensembles recorded in cat dorsal
+        root ganglia in normal locomotion","volume":"14","author":"Weber","year":"2006","journal-title":"IEEE
+        Transactions on Neural Systems and Rehabilitation Engineering"},{"key":"bib94","doi-asserted-by":"publisher","first-page":"501","DOI":"10.1109\/TNSRE.2011.2163145","article-title":"Limb-state
+        information encoded by peripheral and central somatosensory neurons: implications
+        for an afferent interface","volume":"19","author":"Weber","year":"2011","journal-title":"IEEE
+        Transactions on Neural Systems and Rehabilitation Engineering"},{"key":"bib95","doi-asserted-by":"publisher","first-page":"1880","DOI":"10.1126\/science.7569931","article-title":"An
+        internal model for sensorimotor integration","volume":"269","author":"Wolpert","year":"1995","journal-title":"Science"},{"key":"bib96","doi-asserted-by":"publisher","DOI":"10.1371\/journal.pone.0163948","article-title":"Representation
+        of afferent signals from forearm muscle and cutaneous nerves in the primary
+        somatosensory cortex of the macaque monkey","volume":"11","author":"Yamada","year":"2016","journal-title":"PLOS
+        ONE"},{"key":"bib97","doi-asserted-by":"publisher","DOI":"10.1088\/1741-2552\/aaf606","article-title":"Closed-loop
+        cortical control of virtual reach and posture using cartesian and joint velocity
+        commands","volume":"16","author":"Young","year":"2019","journal-title":"Journal
+        of Neural Engineering"},{"key":"bib98","doi-asserted-by":"publisher","DOI":"10.1088\/1741-2560\/10\/5\/056013","article-title":"Multi-electrode
+        stimulation in somatosensory cortex increases probability of detection","volume":"10","author":"Zaaimi","year":"2013","journal-title":"Journal
+        of Neural Engineering"}],"container-title":"eLife","original-title":[],"language":"en","link":[{"URL":"https:\/\/cdn.elifesciences.org\/articles\/48198\/elife-48198-v1.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"text-mining"},{"URL":"https:\/\/cdn.elifesciences.org\/articles\/48198\/elife-48198-v1.xml","content-type":"application\/xml","content-version":"vor","intended-application":"text-mining"},{"URL":"https:\/\/elifesciences.org\/articles\/48198","content-type":"unspecified","content-version":"vor","intended-application":"similarity-checking"}],"deposited":{"date-parts":[[2023,10,12]],"date-time":"2023-10-12T00:55:15Z","timestamp":1697072115000},"score":1,"resource":{"primary":{"URL":"https:\/\/elifesciences.org\/articles\/48198"}},"subtitle":[],"short-title":[],"issued":{"date-parts":[[2020,1,23]]},"references-count":98,"alternative-id":["10.7554\/eLife.48198"],"URL":"http:\/\/dx.doi.org\/10.7554\/eLife.48198","relation":{"is-supplemented-by":[{"id-type":"doi","id":"10.5061\/dryad.nk98sf7q7","asserted-by":"subject"}]},"ISSN":["2050-084X"],"subject":["General
+        Immunology and Microbiology","General Biochemistry, Genetics and Molecular
+        Biology","General Medicine","General Neuroscience"],"published":{"date-parts":[[2020,1,23]]}}'
     headers:
       access-control-allow-headers:
       - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
@@ -234,15 +320,16 @@ interactions:
       content-encoding:
       - gzip
       content-length:
-      - '8775'
+      - '8764'
       content-type:
       - application/json
       date:
-      - Tue, 25 Apr 2023 19:11:47 GMT
+      - Mon, 16 Oct 2023 18:46:14 GMT
       link:
       - <http://dx.doi.org/10.7554/elife.48198>; rel="canonical", <https://cdn.elifesciences.org/articles/48198/elife-48198-v1.pdf>;
         version="vor"; type="application/pdf"; rel="item", <https://cdn.elifesciences.org/articles/48198/elife-48198-v1.xml>;
-        version="vor"; type="application/xml"; rel="item", <http://creativecommons.org/licenses/by/4.0/>;
+        version="vor"; type="application/xml"; rel="item", <https://elifesciences.org/articles/48198>;
+        version="vor"; rel="item", <http://creativecommons.org/licenses/by/4.0/>;
         version="vor"; rel="license", <http://creativecommons.org/licenses/by/4.0/>;
         version="am"; rel="license", <http://creativecommons.org/licenses/by/4.0/>;
         version="tdm"; rel="license", <http://orcid.org/0000-0002-5934-919X>; title="Raeed

--- a/dandi/cli/tests/data/update_dandiset_from_doi/jneurosci.vcr.yaml
+++ b/dandi/cli/tests/data/update_dandiset_from_doi/jneurosci.vcr.yaml
@@ -7,7 +7,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - dandi/0.53.0+17.gc2f268f.dirty requests/2.28.2 CPython/3.11.3
+      - dandi/0.56.2+5.ga0199fce.dirty requests/2.31.0 CPython/3.11.6
       accept:
       - application/json
     method: GET
@@ -21,7 +21,7 @@ interactions:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 7bd8e4c96e90392c-IAD
+      - 8172769bea134411-EWR
       Connection:
       - keep-alive
       Content-Length:
@@ -29,19 +29,19 @@ interactions:
       Content-Type:
       - text/html;charset=utf-8
       Date:
-      - Tue, 25 Apr 2023 19:11:46 GMT
+      - Mon, 16 Oct 2023 18:46:13 GMT
       NEL:
       - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=3x5Z931M7kHWhO%2B3WEpWg1WklQRqy6lj7gg%2BH5OOk2yAgjvHK5Riih1Md2tHeMCmAZB4yHg9nCo9QZkdkTfFiTd5Vhv4F8wAkwJf0ssLYdW1bz8FmbACkFnRH2vBjgfnirHmb%2BQ%3D"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=jJHhOWVxcb4zZbOf08gvxE%2Bc5RdyO367GByUT865PLuk%2B6mkZFYWEBJZYSw%2FMfUigVHxO5fgpVZtsXtvJgG9GdgWaxAgnvf8nzokqt5FEi1iwyln1mzspas%3D"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       alt-svc:
-      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
+      - h3=":443"; ma=86400
       expires:
-      - Tue, 25 Apr 2023 19:32:12 GMT
+      - Mon, 16 Oct 2023 19:27:25 GMT
       location:
       - https://api.crossref.org/v1/works/10.1523%2FJNEUROSCI.6157-08.2009/transform
       permissions-policy:
@@ -59,67 +59,56 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - dandi/0.53.0+17.gc2f268f.dirty requests/2.28.2 CPython/3.11.3
+      - dandi/0.56.2+5.ga0199fce.dirty requests/2.31.0 CPython/3.11.6
       accept:
       - application/json
     method: GET
     uri: https://api.crossref.org/v1/works/10.1523%2FJNEUROSCI.6157-08.2009/transform
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAA/61aa3PbuBX9Kxh9qT0j0nyJItWdzniTbTYPZ7dxNts2znQgEpIQkwRLkLbVTP57
-        zwWph2U5a6RN4oklgveNew4eX0ayysWdyEezL6Oct8KpedPq0ezjx8ALwnE09pNPn8b9o1aWYjQb
-        0QPHixw/ee/7M8+bReE/R+MRPdUtL+vRzI8TP/EncRSm6eTreNSIhWhElQknU13VjmZRMB7V3byQ
-        eiUaiLxUmRTtmi1Uw96KrlEanzEeYqXWHWkNfXwoZCYqjY8fv4ygq2mPme1742A8eWi17zle4HiT
-        9zDZ/Du0OognYZB45g+szlTViqp1bkSjpaog40Y1eCUXBV87snJyvoZKP4nGo9/evcHzVdvWenZ1
-        dnWWNYK38kZkqixVpV3VLK/OBuv11dl87VSZo/nVWeR6V2ejr5926nJVclkZx4bfPtJTxESXvLl2
-        GtjbyKw1Ji14ocXXXTBzp25kdTQsXjpOKCwYzecQwTMMG/3wmbd6Vv/lnZAVop+JEjawQvCmktWS
-        tSuhmjWr4bFmnF2LNWtUIZisWIfCaRC6Kh8GsrlY8RupGl4wfMsqJBK/liJb8UrqUjO1YNlKIQrb
-        oSQID0u4Yd5ZdSVHuNhPuhaZ5EWxHmNIK5pS5BIOsRveSD4vhBG2NbNUSIpmiAxEtSJni0aV+/Yg
-        GHzMdJetGNfGWHEHDS2nMJKoRtzyJjcFKDhGZeQXhXBj8Qk3IYcBRSdOxwyiyQ2BQGgohB8a1mQr
-        WEZCSMUQgEw1DUqm7W1GRdRdrxfPRGECrun9rTcUiBzuU9Wxkl/jO5e9h0Au+yCS8Bp1QKnSbZev
-        GW8EObZQRaFu9Yyd+KesVQw6W3a7kuTQPb0mYDAfjzNetx2EGamDs1tT6kZlQuvDNJ0ERrwouqwP
-        0krdsv0AaWNRIwYr+wDlcmH6QMtMWW48QXxamak51zBsyatlITnLZJN1snXZ78KYDnH5noC91O7C
-        VixVI9sVYgTboDnHLNn3Sot/d9RVNFuKSjSmUOYoaMwAlneNkYHKEWhT/Qst19fGX46Yrf+D4Vxr
-        tCrz5pBd8vpGonfBQZP0LitEB/+zrCvnmO/s5O15dmrE3MB0eqdGYcu8K9nJh19P+9SW/DOqZiHN
-        bBpCI/WQ3VtxJL1IoVxIQVJNfzIv8WpIw1WHhheaXBxMk03C4YyZTdR3dxOTGkMrlrIvVgoNTcCs
-        6Mwsv0XXw5Rf99ILpYWjb2VLswru1TBEwBoauUnQuH/SJwM6SeKfHiZkLlpMcvjMq6GVoDLLrmil
-        bkXNLtD41E1v/5+3FWg6VtlPYT5XXXtYghi36MjX4YFmt4hiBimmHueqXRltSJAZ/OHXMZtDDI0q
-        qOzRgWXFq7Y37KE+NGKks13XAmHSmMzGx0FZ7/rQWDAaZSz6ZGNSwDUTYdU1vVsO6l8MlaYp891y
-        SUGA5naY8Jh/zdB/h6mzM5xJU/UAG9matrozVZY1Zhh5QY2pqzFhKUMHnRhN9+XeSwdT90BZKZcr
-        dA4gViMRMEGq+UbituH3tpMvsu3MnEGTFreAfOH+cHU2IA8Q9fkvLwFFvuf6kyDEg2qgAG7sT6aO
-        l7iEXgTWCDQGfkbQECaHU98oiCQYuD1OYjawd8gGvBSCiQ3401kYzqKHbCBKozSMg4EN1HxJL6ZJ
-        7DtpMo0wWsOOjL58RuAMkmPoirNlO7kDnB8Yjz+NSXxb0PgPvKC2OUDP86HVOxem1bOLHswo1Oeb
-        atgbxj5sIXBIzDtE+UfTPV/03RN2IHsLebeLKr66UUXXO0+x5F27Ap0hJrUEUSF6A/2qVXi24KUs
-        1vjmpfm4mab4YiEB+fT2YiGhqCchH8EpdlJei+qz3BfyXK35fSk8z2UPREdEIVOlQOckXhimZPiO
-        3KiqkJX4A3azjb9xDpRl4Kxe5IdeCJHpJEVO/xWkbui7lFCXuGWupIP2LprWJA4v7Rjqfol6YXJ1
-        VlV+gJIkv5+kILBR4MeYAy4mQSVaKv3Y9ULX86Knqwst1PkJ1PnR1HcCSHVix8Kt6H/RE06frmhi
-        Ez9venWmPS8IfMfz8JP6iRM+XVdsocv0q1dvf/rt3S+Xz17ic4pFxpSSZuHc1L440Hrne6URP11Z
-        Yl3qnBDUi6axhZb0u+q9URU5hTVR6no208v3bPVdekkaOrGXeCdpegpxUexMLBRadYxeIaQ4UZgk
-        J54Hhf4kdCxqxLfpIIdVaZa+sakXC43Hm0i2w7quAlvsMkMm8eRn1V2zV8/Yec5BwV+9ASY14AXn
-        L0BX03RCfG2DbYCzfYYyrDII/AZIu7cYGLPzgbriPVppPBixJfQGNbEg27BzLZcVLVoME9ksCZr9
-        te6YiVyzje3PwYV624WE1+w5jL94+X7MnvFy3sh8Kcbs4vzU3Q/3dDLxr85K2RJjwuI+moKxIMH4
-        8XyLeFs100lAPAkqQny0aze+TTM9KKXQi7+jwfk2LfVBO0AwA/yzCeXxjrpXuobHOAOn80Hzvjl/
-        YvBEx6NhLiqZxg7U09kwunOsG3kpblVzbVh2Sdw5E/UKTC/DMqIGGaqw4FljOYPJ0XN9U/mmJEGd
-        2M9iPpd8tw2wz9hMADeMbXQB3s2XHRHfNQYbD4xVG2K8serVdjPNInY2ALErw3hiisICZn0bjNhX
-        lFgqCmzAwQ9QfcPuI2oxjYLEAhaC74CFJI2dOJiGJ15IsBCnNrAQ2MCCn0Ihr6ghorunHiZVYKHK
-        hlR6CZgDEC9ykjT5+9UZGBl6pBX+BDb98LBNTaPJgHg2wZw8BLVf+Z2slGYv2O9YrmLGPjNolpz2
-        C3mgyrzhsjL7fy2WHarFCxmWxqrJZWU2/U7OM56LUmZjdon5/VyKpTods59yFrmuhXVWTZSYWxAE
-        cWKhYPrQ/Us0tc+y5Ow1o2Uc/vtN5Jz9g72WJQCWXbATImwG28/zG242c/D7AL+PgPzQBhGDfsO2
-        B36Ej7Ymdzu8ZueIU1/Fo357a2+3b2n2Adf4rh66McNCEiN7RH+/arqKXSLkXcHevGaXK1Vcq3rB
-        fnwE0Z8eJ6sOea+fUB+behaqjvfIR4EsmX4byNIeyDCMgCw9AmRv+8TBXJUPfEw1c9mqRUOoY3az
-        W3FncgMUU7SvbbZBy/Uy5wXfbKSqYsGzls4OcqmzRtI+mimDo/C2vyExusxWSlRz3pX3AC79PwFc
-        +N1wEEwn7gQMiJZ5FvgT2oDCQcaCEHhgzbdC6+2GQxgK4sixwIbQasPhEGKnsQXEhsdh4fFlyWXX
-        tqi7d5f31yPo4I+cef0h4R9C5kfTyInjqXfiT0/DJPQnNivI0IaF+z5ti9artZaqMMWA5QLkW8Bp
-        aA0ftMc1tViEhzb7GIedKQqnjhea1b+Fxu/jql6cWK6FQ7s+TGF7sCP14189L02DOE2OtN2/Ocf6
-        YrLfFsE/rmWl7/XE4EhPvKDjyzckzWIfz6on+j4t0PwIS8F00scycj1wrql7Z6HTpi1uk+eHYWBZ
-        JZEVRz7i3MT1osBPyLnhnB6MTzTbiBMTfNVngUjKwQUG1cil3EsQneYXvFp2fa2IytxrqK7NbvXh
-        PQK9rrA+NMjpruRydSsb0V8mGK4LXJ3BM5Drh1Pq4Oxkc71gOENBk6QTdjpAHD1+1YFIWZUjYryu
-        i8EOPNSA8wI0rV072UpkdGphQpOLWmn5yEFMf5skfPQ2SfjeT2dBOvOP3SaJ8BfQa05iNCgI3vRp
-        p39zBPNlNByP0a+HQby9vXV3Z0r9VQylrrv6icH7Skq7+V7+NKZku59Qc0vlm+dP+wcTev8ezGb+
-        Dhddvty/8WJ59mFzD4QughSGdNP+gyNh/sdjvfleLD7t33Ux0c3vXESxD+sfl6G5CWGq6Av0v7y8
-        fEtaPbBiJ47MqRoEpE4QeT7pQtg/C7qo8nH0wmzxFfen18P56JjcEDd0t0Pd/UB+Oyb/BbZQJuMR
-        JQAA
+      string: '{"indexed":{"date-parts":[[2023,10,14]],"date-time":"2023-10-14T11:22:39Z","timestamp":1697282559256},"reference-count":42,"publisher":"Society
+        for Neuroscience","issue":"31","license":[{"start":{"date-parts":[[2010,2,5]],"date-time":"2010-02-05T00:00:00Z","timestamp":1265328000000},"content-version":"vor","delay-in-days":184,"URL":"https:\/\/creativecommons.org\/licenses\/by-nc-sa\/4.0\/"}],"content-domain":{"domain":[],"crossmark-restriction":false},"published-print":{"date-parts":[[2009,8,5]]},"abstract":"<jats:p>Reinforcement
+        learning theory plays a key role in understanding the behavioral and neural
+        mechanisms of choice behavior in animals and humans. Especially, intermediate
+        variables of learning models estimated from behavioral data, such as the expectation
+        of reward for each candidate choice (action value), have been used in searches
+        for the neural correlates of computational elements in learning and decision
+        making. The aims of the present study are as follows: (1) to test which computational
+        model best captures the choice learning process in animals and (2) to elucidate
+        how action values are represented in different parts of the corticobasal ganglia
+        circuit. We compared different behavioral learning algorithms to predict the
+        choice sequences generated by rats during a free-choice task and analyzed
+        associated neural activity in the nucleus accumbens (NAc) and ventral pallidum
+        (VP). The major findings of this study were as follows: (1) modified versions
+        of an action\u2013value learning model captured a variety of choice strategies
+        of rats, including win-stay\u2013lose-switch and persevering behavior, and
+        predicted rats'' choice sequences better than the best multistep Markov model;
+        and (2) information about action values and future actions was coded in both
+        the NAc and VP, but was less dominant than information about trial types,
+        selected actions, and reward outcome. The results of our model-based analysis
+        suggest that the primary role of the NAc and VP is to monitor information
+        important for updating choice behaviors. Information represented in the NAc
+        and VP might contribute to a choice mechanism that is situated elsewhere.<\/jats:p>","DOI":"10.1523\/jneurosci.6157-08.2009","type":"journal-article","created":{"date-parts":[[2009,8,5]],"date-time":"2009-08-05T17:33:40Z","timestamp":1249493620000},"page":"9861-9874","source":"Crossref","is-referenced-by-count":190,"title":"Validation
+        of Decision-Making Models and Analysis of Decision Variables in the Rat Basal
+        Ganglia","prefix":"10.1523","volume":"29","author":[{"given":"Makoto","family":"Ito","sequence":"first","affiliation":[]},{"given":"Kenji","family":"Doya","sequence":"additional","affiliation":[]}],"member":"393","published-online":{"date-parts":[[2009,8,5]]},"reference":[{"key":"2023041303393959000_29.31.9861.1","doi-asserted-by":"publisher","DOI":"10.1038\/nn1209"},{"key":"2023041303393959000_29.31.9861.2","doi-asserted-by":"publisher","DOI":"10.1016\/j.neunet.2006.03.004"},{"key":"2023041303393959000_29.31.9861.3","doi-asserted-by":"publisher","DOI":"10.1186\/1471-2202-6-9"},{"key":"2023041303393959000_29.31.9861.4","doi-asserted-by":"publisher","DOI":"10.1186\/1471-2202-6-37"},{"key":"2023041303393959000_29.31.9861.5","doi-asserted-by":"publisher","DOI":"10.1007\/s00221-001-0918-3"},{"key":"2023041303393959000_29.31.9861.6","doi-asserted-by":"publisher","DOI":"10.1523\/JNEUROSCI.1590-07.2007"},{"key":"2023041303393959000_29.31.9861.7","doi-asserted-by":"publisher","DOI":"10.1016\/j.conb.2006.03.006"},{"key":"2023041303393959000_29.31.9861.8","doi-asserted-by":"publisher","DOI":"10.1038\/nature04766"},{"key":"2023041303393959000_29.31.9861.9","doi-asserted-by":"publisher","DOI":"10.1016\/j.neuron.2004.09.009"},{"key":"2023041303393959000_29.31.9861.10","doi-asserted-by":"publisher","DOI":"10.1016\/S0893-6080(99)00046-5"},{"key":"2023041303393959000_29.31.9861.11","doi-asserted-by":"publisher","DOI":"10.1016\/S0959-4388(00)00153-7"},{"key":"2023041303393959000_29.31.9861.12","doi-asserted-by":"publisher","DOI":"10.1523\/JNEUROSCI.1010-06.2006"},{"key":"2023041303393959000_29.31.9861.13","doi-asserted-by":"crossref","unstructured":"Houk
+        JC Adams JL Barto AG (1995) in Models of information processing in the basal
+        ganglia, A model of how the basal ganglia generate and use neural signals
+        that predict reinforcement, eds Houk JC Davis JL Beiser DG (MIT, Cambridge,
+        MA).","DOI":"10.7551\/mitpress\/4708.001.0001"},{"key":"2023041303393959000_29.31.9861.14","doi-asserted-by":"publisher","DOI":"10.1152\/jn.00310.2007"},{"key":"2023041303393959000_29.31.9861.15","doi-asserted-by":"publisher","DOI":"10.1523\/JNEUROSCI.3060-07.2007"},{"key":"2023041303393959000_29.31.9861.16","doi-asserted-by":"publisher","DOI":"10.1016\/j.neuron.2008.02.021"},{"key":"2023041303393959000_29.31.9861.17","doi-asserted-by":"crossref","first-page":"1936","DOI":"10.1523\/JNEUROSCI.16-05-01936.1996","article-title":"A
+        framework for mesencephalic dopamine systems based on predictive Hebbian learning","volume":"16","author":"Montague","year":"1996","journal-title":"J
+        Neurosci"},{"key":"2023041303393959000_29.31.9861.18","doi-asserted-by":"publisher","DOI":"10.1152\/jn.00657.2003"},{"key":"2023041303393959000_29.31.9861.19","doi-asserted-by":"publisher","DOI":"10.1152\/jn.00658.2003"},{"key":"2023041303393959000_29.31.9861.20","doi-asserted-by":"publisher","DOI":"10.1126\/science.1094285"},{"key":"2023041303393959000_29.31.9861.21","doi-asserted-by":"publisher","DOI":"10.1016\/S0896-6273(03)00169-7"},{"key":"2023041303393959000_29.31.9861.22","doi-asserted-by":"publisher","DOI":"10.1196\/annals.1390.022"},{"key":"2023041303393959000_29.31.9861.23","doi-asserted-by":"publisher","DOI":"10.1088\/0954-898X\/7\/1\/006"},{"key":"2023041303393959000_29.31.9861.24","doi-asserted-by":"publisher","DOI":"10.1523\/JNEUROSCI.3745-06.2007"},{"key":"2023041303393959000_29.31.9861.25","unstructured":"Paxinos
+        G Watson C (1998) The rat brain in stereotaxic coordinates (Academic, San
+        Diego), Ed 4.."},{"key":"2023041303393959000_29.31.9861.26","doi-asserted-by":"publisher","DOI":"10.1038\/22268"},{"key":"2023041303393959000_29.31.9861.27","unstructured":"Samejima
+        K Doya K Ueda Y Kimura M (2004) in Advances in neural information processing
+        systems, Estimating internal variables and parameters of a learning agent
+        by a particle filter, eds Thrun S Saul LK Sholkopf B (MIT, Cambridge, MA)."},{"key":"2023041303393959000_29.31.9861.28","doi-asserted-by":"publisher","DOI":"10.1126\/science.1115270"},{"key":"2023041303393959000_29.31.9861.29","doi-asserted-by":"crossref","first-page":"1876","DOI":"10.1523\/JNEUROSCI.19-05-01876.1999","article-title":"Neural
+        encoding in orbitofrontal cortex and basolateral amygdala during olfactory
+        discrimination learning","volume":"19","author":"Schoenbaum","year":"1999","journal-title":"J
+        Neurosci"},{"key":"2023041303393959000_29.31.9861.30","doi-asserted-by":"publisher","DOI":"10.1126\/science.275.5306.1593"},{"key":"2023041303393959000_29.31.9861.31","doi-asserted-by":"publisher","DOI":"10.1523\/JNEUROSCI.2369-07.2007"},{"key":"2023041303393959000_29.31.9861.32","doi-asserted-by":"publisher","DOI":"10.1016\/S0896-6273(03)00264-2"},{"key":"2023041303393959000_29.31.9861.33","doi-asserted-by":"publisher","DOI":"10.1126\/science.1094765"},{"key":"2023041303393959000_29.31.9861.34","doi-asserted-by":"crossref","unstructured":"Sutton
+        RS Barto AG (1998) Reinforcement learning (MIT, Cambridge, MA).","DOI":"10.1016\/S1474-6670(17)38315-5"},{"key":"2023041303393959000_29.31.9861.35","doi-asserted-by":"publisher","DOI":"10.1113\/jphysiol.2007.140236"},{"key":"2023041303393959000_29.31.9861.36","doi-asserted-by":"publisher","DOI":"10.1038\/nn1279"},{"key":"2023041303393959000_29.31.9861.37","doi-asserted-by":"publisher","DOI":"10.1523\/JNEUROSCI.1437-03.2004"},{"key":"2023041303393959000_29.31.9861.38","doi-asserted-by":"publisher","DOI":"10.1152\/jn.00068.2006"},{"key":"2023041303393959000_29.31.9861.39","doi-asserted-by":"crossref","first-page":"279","DOI":"10.1007\/BF00992698","article-title":"Q-learning","volume":"8","author":"Watkins","year":"1992","journal-title":"Mach
+        Learn"},{"key":"2023041303393959000_29.31.9861.40","doi-asserted-by":"publisher","DOI":"10.1111\/j.1460-9568.2004.03747.x"},{"key":"2023041303393959000_29.31.9861.41","doi-asserted-by":"publisher","DOI":"10.1152\/jn.01332.2004"},{"key":"2023041303393959000_29.31.9861.42","doi-asserted-by":"publisher","DOI":"10.1111\/j.1460-9568.2005.04218.x"}],"container-title":"The
+        Journal of Neuroscience","original-title":[],"language":"en","link":[{"URL":"https:\/\/syndication.highwire.org\/content\/doi\/10.1523\/JNEUROSCI.6157-08.2009","content-type":"unspecified","content-version":"vor","intended-application":"similarity-checking"}],"deposited":{"date-parts":[[2023,4,13]],"date-time":"2023-04-13T19:29:13Z","timestamp":1681414153000},"score":1,"resource":{"primary":{"URL":"https:\/\/www.jneurosci.org\/lookup\/doi\/10.1523\/JNEUROSCI.6157-08.2009"}},"subtitle":[],"short-title":[],"issued":{"date-parts":[[2009,8,5]]},"references-count":42,"journal-issue":{"issue":"31","published-online":{"date-parts":[[2009,8,5]]},"published-print":{"date-parts":[[2009,8,5]]}},"alternative-id":["10.1523\/JNEUROSCI.6157-08.2009"],"URL":"http:\/\/dx.doi.org\/10.1523\/JNEUROSCI.6157-08.2009","relation":{},"ISSN":["0270-6474","1529-2401"],"subject":["General
+        Neuroscience"],"container-title-short":"J. Neurosci.","published":{"date-parts":[[2009,8,5]]}}'
     headers:
       access-control-allow-headers:
       - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
@@ -133,11 +122,11 @@ interactions:
       content-encoding:
       - gzip
       content-length:
-      - '2967'
+      - '2974'
       content-type:
       - application/json
       date:
-      - Tue, 25 Apr 2023 19:11:46 GMT
+      - Mon, 16 Oct 2023 18:46:13 GMT
       link:
       - <http://dx.doi.org/10.1523/jneurosci.6157-08.2009>; rel="canonical", <https://syndication.highwire.org/content/doi/10.1523/JNEUROSCI.6157-08.2009>;
         version="vor"; rel="item", <https://creativecommons.org/licenses/by-nc-sa/4.0/>;

--- a/dandi/cli/tests/data/update_dandiset_from_doi/nature.vcr.yaml
+++ b/dandi/cli/tests/data/update_dandiset_from_doi/nature.vcr.yaml
@@ -7,7 +7,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - dandi/0.53.0+17.gc2f268f.dirty requests/2.28.2 CPython/3.11.3
+      - dandi/0.56.2+5.ga0199fce.dirty requests/2.31.0 CPython/3.11.6
       accept:
       - application/json
     method: GET
@@ -21,7 +21,7 @@ interactions:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 7bd8e4d52b9a7fdc-IAD
+      - 817276a5ba8c43ed-EWR
       Connection:
       - keep-alive
       Content-Length:
@@ -29,19 +29,19 @@ interactions:
       Content-Type:
       - text/html;charset=utf-8
       Date:
-      - Tue, 25 Apr 2023 19:11:48 GMT
+      - Mon, 16 Oct 2023 18:46:14 GMT
       NEL:
       - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=g57RxkcPlTXeGvDYW3InUXNmiqoPJyXIlbjCZ%2FIdXOIXOt1hxI7ZubtdYz8bwERZsrc4YUqX5Wv5UWuQt4lL6I296qFTKp%2BUiaK5pSCxqcicJo8WNqtWOjzPi3tgxaA9rXtzGJ0%3D"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=3%2BhI7P8ArzKiVCpx8e0K6RQ3HTAengJaftxhPQgCP8POs6mSIgCe%2B9acLsRO8rhvgsF6yKEakDTDq2UEcUrcGWI6DTSCtrk4J5Gd8JdoNwB%2FWLoHAIblDbM%3D"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       alt-svc:
-      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
+      - h3=":443"; ma=86400
       expires:
-      - Tue, 25 Apr 2023 19:31:35 GMT
+      - Mon, 16 Oct 2023 19:01:13 GMT
       location:
       - https://api.crossref.org/v1/works/10.1038%2Fs41467-023-37704-5/transform
       permissions-policy:
@@ -59,195 +59,329 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - dandi/0.53.0+17.gc2f268f.dirty requests/2.28.2 CPython/3.11.3
+      - dandi/0.56.2+5.ga0199fce.dirty requests/2.31.0 CPython/3.11.6
       accept:
       - application/json
     method: GET
     uri: https://api.crossref.org/v1/works/10.1038%2Fs41467-023-37704-5/transform
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAA/9Vde4/bOJL/KkT/EcwAtqKXZblvsYD7kXcn2XYm2ZnpxYK22bbSsuTVoxNnb777
-        VRUpWZRpOcrs4XCL2Zm2TMlksVj1q6f+fRYlS/FVLM/O/3225IUYbnlW5Gfnv//u2q438AeTf/xj
-        IL8poo04Oz/D60PbH9qTD7Z/7o7PXe+3s8EZfpsXfLM9O3eC0LEd3/e98dj+Y3CWiXuRiWQhhou0
-        TIqz8zAYnG3LeRzla5HBI2fbLEpWImOzRYTjGE+W7KLMo0TkObsRy4izN28u4VeiPC9xEg78HUcL
-        keTw6fd/n8EvZ8XRNYRH1xB+sO1z+udwDfbEcW36H6xhkSaFSIrho8jyKE3gGcVyA7csRcx3wygZ
-        LvkOftIenP1y+wa+XRfFNj+/e3r3dJEJXkSPYpFuNmmSW2m2unuq5p7fPZ3v7p76ln32x+D/ZBWP
-        afYfXQVM8b4ElspoW67evcTNsi3Hs73J3VOHJuKMPPjNhNMi3s6esf9mFy/fwb+voscI58XSe3YR
-        pXG6ihY8Zi+T+4znRVYuijITON00GvI8F1khlsP5Dp6y56bBGf/CM+Dn38+ciee7YXj2D6StcSqO
-        N3H2U/m0jgqx5nHMngGfAqWRRN2/dvTJth2M9k/+xZpZ7Ergjm6A/ri+F4LHxZo9YS/KDU/YTGSP
-        QM0cqPD25Qv8N/08rT4voqIsBN71VpRZTZerKE8zIHVO52VWZOlDD+rc2s7bmeM6E2cCFPrHnjmW
-        6YZHCbGh+ut3OGvJg5WrY2oBE5zhDVma5xuePQwzYLgsWhDBzu95nAtgNj6Hi3wBDH32l8+8yM9h
-        GbH461Rd/svd08ZVOWL719kW1g1rW6SrJMLnsaXYimSZM/gT6MQXizKDM8AysYVfhfkSnZA2aRbV
-        H79ExTqiG0TyGGVpgmS3kOhLtowyQVNlCxHHOYNxywjnPwciL9k8gzXD41cwIof/LgSwPeMs47B2
-        /B34UaD7Du7blkU+YHAbA74tYdZ0iUU5w52OFmXMsxgGbrZpVnDY9/s0YzyOYGnJihVrEWXwA/k2
-        xUPEirQ5WXhaDNuK5M0t9iGFZz8ClaMVLn6dfmHbdAvPx3UMY/EoYraGxeFz90/kmZA/B8uCpzcn
-        OWBfkIYLZKAlu8/SDXwCDsq3sUjkBgD/fGU/3c4uf8ZV49OH9xGoCrYBRkWqcbZJH/EXG9NmKLVh
-        bV/S4XadFkhkHi+icgNU4Cv4ymKfBMtxAcWaFwwezxJk6kROtyjVZIE6sH1wU3xXurYzwa2ISQRp
-        Gw3TwJGNGQwYUKP+ApiQNIpaAc5YSF54K75KKtzjYd/PRu14zkCOLeQZhD1EDongM9tm6WfJPrkk
-        m6Iql8+IOVAHV8LlqcRDBfyUA9eA0IVx+6eyRYzHNMe5KRIAcdZRDPRJN8I0chNlGbAQTrPiPg73
-        fpETXMDaMqAejcYNBB7OC5QPpjnmwBdwUi32LKIlDuCkLVLiIA4Xdvh7GUwa7iuT6F+loLXQKaHF
-        wx5VHEd0EHyxlj9tsXclMXYZF7DwcrUCxsWziPNeRNmijNRRSBbrFGVKg3ebp9pwJtRK9kejEiPb
-        v4Jw24ti2wvvnua+4wfjIapJhCL+EEVysduiSP6clhksc0gHNUa5SSquAwl16V/HP7fdc39k0r+B
-        OwpGUv+WW/nkFDTnTulXUq/LrxaIbalVafr2GKav5O0/a0H7T3Xn4CyH6S9wEpf4HSAsAkfDGmqh
-        5K/glo1zAiGLoxVTZLXUrCi/lw+LUpBQNMkD+BXYIBADezLDpcc0Lokijo8apixgV0n/r+AgIcp4
-        LUBOsNcWfHsPzBfj2mdRgesQwFkJreQ+ynK8xO/voziS2vf8d1Le724vX1416ZVmi2gpyYW6dgj/
-        d4cjLwiG4ch21CSAY0BPohak4UozDepZ3USLNQfB+Uqb1/MUFaQ2M75cRvIkGqYHTLERmzkBWXcy
-        PttDW/jdBBSn6OKoJjwmkj0InASx6z8vb52T+pyoBk9e4URDf6KdAscNgI0kqLY4j/3QGzX3yxsF
-        jQ07m83Y6whR7U5wWo7t4HrKpAZfS9zMaDNggGdm1oDdpiWHUz5gL+DDFQx6ADCT0NdP2Cu+4xmH
-        CwP20WK3JFkK0v1w9pe7BMVQXgnqK+C1dAvSj4NaBjkDLEea2KqNApjsgMEKSR944chjP+EEf8bd
-        q05zxefqHsJnOkXdfhR1wuBQriQcaYEWTtCk5sh1mtR8dQWoToD61Qg6OiSoHDUAPmRXh3RDyAfE
-        qOmFgrMSf5oqROkOGAVBB+APwJYR4LmVPOkW4kn4OQZzHDBYlCQigD8i4shIRHmLgYZePxp6JCQa
-        NHSAKz9bi3JuwUFwgE0t255ofOk2CXnzil0IUXxr0tF1D+lIgwbsxkJKCtA4MSg3oOy6ANNmWS5Q
-        NaabLSrHFnpUPAiWDc9Ai4GKA7V5D1q1ko6JAESTPVjssswyi4wTi3nugMHaJCk9f2KJEVLTdY3U
-        bNxpIKnfj6RjW6PoyPXunr56e/3L7bvZ5Uv4PLQdlIlj+G4y0Y48MeCeR2fsAy/nYk9aNb5FWhpE
-        HDo7gqJrLFkBL2C+LAJerQFHUoKejVDn3GfA8bsKPQKH5rRlZNyAtLKYMxqwsa0OesB+wkkZidq8
-        y0DVUc/D7hzy6cz27GDoj1z3J9v+GdTMKBz+XSOobWsylL0RZbES8ya30pAWSdWwgZSjfJV++xYl
-        6QC0JLtGKXATfSs3cL5JmMI6L1MwALKVhmb3m4CHfxtzAuYgITYaX19OHWXQ0J3RdpsuAJ+U+Z56
-        9FhYCggHp5INyMywZqNoaNxmoHvQU0C0RCxgH3vsjYbwMB+kw8hyLE8jeYuJ2eU61cjtHJIbhhD/
-        PmGzNc+2A/ae6Kzz8kDScEDkrEwFhD5kewgpfGurEUkLzGsESnDSxZo/akyNXO1J4rokKWzHSNz2
-        nQYCj3viAp3ACC4vngEv+57ruDozayrszRsgrUg06eCbaCuAdG8s+Af+E8m/ERE8h4MOn66RgQfs
-        gmeJAJPl0mJT4vDFW16CdEa6X1h0DxqZBvu8ovQ2zZVUUebpkL200Fwp0g25RGpDvjoTc6Ql3ADf
-        bdKlMphh579uYYfI0r8VcAxg3YAt1N54JHB84960bjRsTdhvaya22y3Lw6ELshyHoSzX4XbY3Kzb
-        T2xWcEJg2oaFBsShxoHgAZMT90IT8M8iMsrA1N3CEiJpoiL98RAQKfkG0DIAjR1Dcx8sVjARwQg7
-        OE4kpbZRsVgPNHxC1x9FnC6iYtcW/uGA4XLlbkxAHNB+hD+iACb9NsM/sRdgaLigV325F7Z+ck7q
-        VYMSaJIdkEsZxyKjTfkFN+UWDOQH+vbiyNnQPTh4TPCI5OUcnU/odEmMyvYleiPzRRZt64PyrxI0
-        dlRID4t0AEQHahnUg19tjO+NaF/MCuLEvhC1+myMF3zXxnjB//ONgZ25vr+HR9GZ030fcGCjyudn
-        3BpPwXrfH/+JrelpczqBH3buDYBRD/AoDDsFRl+x10kE8n1zdgKOqmG0A6hZXpdL+JgWERqi0vg8
-        VC7vCR7R9gza8EldlQ4ywWL4cfLRwh7UtlZe8DlY/ofyCtQ6rk7BpmA0+XHA6vQ0TwM3OGkJTIY2
-        DjtB/Bcf2EXMo+wU6WkQkfnDAZiaosMlAtsT3eMtCit3I/mNddOgBL0hHqMlQVByC6ovUlTypNYr
-        pyE5aSuzFh3cTXWC+w8/VKRk5WHARJ+CYduQLnLbAnds/4lt62kRh+MWIHPvnv40e3n58mfHnoRD
-        xw48qfLCc/cv4fj8fPryavji5ft3zl89y7Yu3/2XO/SbexmelHEGFKDp/CctIXeJlnIW5eiFPTQ3
-        8LwwDn8/wnmoEJou4aS6b+30Mevvxd4mYaD+w7E6THbYofsbN5n2pKdJ7TiBq+/KBI7SQmTAhXdP
-        5+uVY+tQ2eumOcB77yTNL3ByRUEX4Ay9x7hsjlE4ighwncYmmQUbJTIxx/0iQOx4aMEFrqKfM3bJ
-        0PDMLonmrSYS9rSffa/lf2xLo/HQASyLw1AajTVyjr8HyxrckT+CZU2UbNoZR5wXKKlkOFJa4Qmj
-        kNycZBAFZNoyZoxauXJZAmKS7Gz2WZ6SMT2NanfiHAoZsP1TsKhbRp97kvTAQgaHW4v0YNkBIQAX
-        TRV3616j6rQCV+cqytsO92TiXyXsioGsTQHhuAMGq1N+N5v8wLbZ6XZCRPQ0ox1funiPMrjnjwCJ
-        Tiy35c90J00KP78BWdvUtGp4i7o4BkxoCx2aypt5FeVZua1CN8itJrksVS3j98DELF0s4jJv3JEL
-        4GfUp0jdBa+UMn6lS+bFOkrg/2DmtbjanYCMQVIoIeOPPLkHkx/i654Gs+O1tad004WTYAha3EM3
-        XWgHI5A12hZojg0j2jGoyCbaGbAjPqTbNBYVdQ0WshIdTfnS3jUJb87ZFKHLPMIQeMOuVsaEjMwu
-        AZzSduZFudwp0iaM3PperTe9SZfRLO8x7UVPe9mhcNJx1x3ayZajx5wcVzPIbl+xZ1kK5FwW2oEI
-        DjejGkfiRjqUNO3ZEjjvWzGQBvHyKkHk2BGqd2QPg9hcFF+EUJsIW55Xe07aIl2mWQ4bXyMd/LXq
-        mlgpE07xgsk76KLv1RtVZ0p6X4MfdRC6fQ1s3z08VJ8tmZcA8szxLTu0bF9THGEz3Ht2xaYwNn1s
-        bqNj8BbKUQMZ6/rAkwf6EzT3dbKCyVQJUgoAqZ3IGWWVxTs8Be5VrUES/ogpMcrZzWFjlng/mM1F
-        SQqGo8XG8h2gqk19WkIf9LKvQJI/CigIZnb4HT0rbm87eTzptNXcAKG/h8TWvN2eBjSnQOVYaO5u
-        x4AzaRBpYqU63oHaWLD7OP0CkiPalHHEZDbCEfZtnQrJCC1AaojceIg/caWVNTyekKvbMSPQE7qB
-        onwaFa9B4eviRDdj/95yWMMvG8S6dFj/HWPWYpqsBOwYadpLZEm6wB8iYstrDCGKr9EcZLFYpRSa
-        xgQfNG7iuP7cBjKNxIqG4YuSRBSNGMH7LF1QaDZm0wVfUqwbrK/ZVAYLaLGSkPCnQ1DeMYv0o08y
-        UbWntepMDAr3s4WCEpl1BHLekoHt/a4Emmh4A5MC0b3j2sYYRLwaNqBIwnS15p8RXf6GGGjAPpZp
-        ssLwwYDdpGkmlPsHTVexLjhFfkEzXPIypzS3+7isomXN1Bbg5nUDi9Y8jrhUxELxNxpWoAhgIcDQ
-        E6VXXXtMe2AWy3iDidw9DdHbS2fkdwoKZ+j4w8+Yv2qpYNcRmHNzwX4rVzw7GR2To4iCF6hYYZ7r
-        9NtAxmk+RSJBx8CMHMcXgPlXGebMydTHJKVkLlFdqyQz0ZpS+vgDaE2O6F4lusg4WkvC7NMW57u9
-        EXYgl+pMOR2SAvwhunWE1U7Jmr7BYs/Wdwm2CY5FYtm2P7FxYzQPzUR3F7yvwIu2MyZ/m45xlDR/
-        D1fRUV/FKHPdHkhpV/g8xakjIfduufvvtYf3FN6udzklPExQuMOyK5DpkOK0u11m1d0mkvc0acdh
-        aKY4es1QFLUc/1py0801oPaIUtObQshwGNQwOg3XB7ByulAhkiXbtnaB2B0YPEXHP5iylDk6P3CF
-        au4GI5cbaA+rGTAggEqKsG0SRN2c3kX6nqbvuOXZOQjSu5ZvyUEN1ey2eP55mi6zaLk66ZqsByq+
-        B11cLhegtR9SsrqmcOVTms3TXU4ZE/j5eRqncxVsbm/aZZW+msosWDPDG0L2LhC98t+MA6fDqPoe
-        UN7T1PX8cWdoBdNPw6GNwyzlbtwrAu+0IjDgxpYiqGFkt0645dto2fDqtNPSuuWLlOAgW3AhVTZV
-        2OW4PCXK+5qxtnTAHCe0O4R/aJilXGF7QmtMfvWcfYJjzxe6J9jgPFPDCGU+B/q+iCg54kqatu+B
-        RAhKZ+T+eYJ54fmafxkgtf9msY9NB1kj36d2oS1JxS6R7kD1h5SiWXsPRJv4wOa0usrtbjvjDq/a
-        CfJ7fW3PULeL9p5K1x55euaP5kj7lf0GIkHLrzQ50mjQgP1KMmK55NlyQHjyimcxkIVChJcUInzC
-        ZpuoWJOIeQZXAG8OQTxvgJD3oEILWYWCpKVaBoA2+YPys82jyvXTcF4C/e8J8+zzDA/jHc4EjNGw
-        iqqHQYcrrdud6fW1SF1DbmvuO6MwGNrOZOiMg5YTbTQ+lS9sIH8zX/gFEBNQYl7wJQmSG8ohxsC2
-        zIObzucpgp03RP92KuxzlDl15jrGY2NxtHSAynqw0E1U6D8Haw2TfapU2DFoVMyQrtAMaVQz4Y+n
-        wvYM2I7CdrIb0NwLbLjONfTiBZqb7HIGdNotW7lYBrEiRxFDz8hFljzkJM7JI3+ZpV9AspBaBPJ/
-        wKidyBai9ilX1FyWBBPFroExa8rB3AYMZiwpNwplIohZVhynXN+Y6UTzNXpeOLl7ep+sy41yT9mh
-        Ht/WYqIfr0GkFoCAU4BspzxU+5HEdoQBZ4t1JLao4Yiab0GoEojOorQiHwjoLZov6XJ3kJitU1mG
-        qi30fFJZWrlpSmMMgCqvidknZbzNROKelqfvt9y5aOjbXuAMJ65n/zTxf57YbhgOtcBd2z31nOdz
-        nmXR2YmkwWqcRBfvwapUgpm04SUa5wkfSOLDt1GBlL+kJAMAzKuMLyUIp+xL+RFrC1TWxkGZFiq+
-        R1VYsPfHYqFWVW3WdAocpNCSzmwkDF6UcSy9XUC0yo/odiQOtu81bZfZAl3sK3za3pK83MyjnCME
-        Rsiwg/WvhUJoH0DtrNNYyt7ahwVWeaPsigqBxAqtQJGQNG0I1SZgk3VhsAAQz2t0aa2xVJISLEGF
-        LlWlnpQQlDsAUt6SwWglXpup8cfKtNyh57lYUGUiTk9b0QnClke7bbFMrMBSoxomiwYwZlfsI0/0
-        OKjBRv9Y1byQS3u6WsWCQIU02WfKqSTYcpcDoyYEDYzVllV0QuEETGfFeJ/magRJQtypPFuSOZcR
-        lbJt2IZ/EwRLjNYMBu5gxZVvNuyy37/DnvF6GpEjN+yE2SDTVfhUt+Q9TRVevJJxZk2KG1L4VDD6
-        whQrAuuRIyacmSLVL0EEEIQ2RYbMlSNHQkCEDKtNrTbLmC2uO9FRvQKtlH71bOn5/aF0Pq+nzTma
-        tAAKgvFFIqyJ7YGF4OupA55e/PABjwt7nqUtnGLYnXrgQCaSfdrlOW3ADZU6JJXwNlKtPkW8Ojkt
-        0wbDdoouKKaxrgEWplK97KA7O1K72UTSnual2/adVCR17PFI06V+4J0kp9lu/8+Qc/5d5IRZDphb
-        eUXcwOu21E+R0+9pLrq2wVxUHOqMbNfW4YkeHzrGoQYk/adI2hT138WiGO+BlSmaOkEHpP4emvY0
-        BaWZbaYpnB6/VZ6nC+QX6Fid84JrFDUwqRpG+RTXyjA2I7Wj1WMKqyHMw0xo8X3EJYHqVfaKL3Ha
-        jzNsX5svaPtOsYY0sbxJ0FHOMa0BnaboDPCjCfzAdOYAGKOvhKRvCBZiCwDk4vcqwHlRfsvvStsW
-        DgY5n4PCQ2rLPgdptgIs9w27PIjFGv7MN/mRXCPsgyEU4tOrN2DBitTjUXd9abfu8nuaiGLk+CPN
-        Yzoejfy7p+JNdC+s6st9SKZJ7jfP2LMoX6z18IBr0FxqmHJSAIZIi3Q4jeeg/CkzBYl+UWJ9ALkw
-        XmDVEwKPG0qZvj3oW9JuaXCs9t5itA4GIE4ulBC1WYvRSBNFeyfF+gZ/BfCub4+6eHfGpmBx8INo
-        i4F764H7vMG3EdbxXpGL4taEkzd8m0s5kCafVZsMJGWkGJksE/FVfci3fCFyI6fi+qpU2dGJWugT
-        vNo3fKinZ1buDMCYCH9Dy7bliCNZmi9egVG80kWDIY6CY0jcUkjklUChu6OICVx4ozhuOOc5HHhK
-        B1Hms+m4UwoNBWcNW3JOUAzT7qu+RZt0KeLaxYGxcT3dCcPqTkdGg/lGE+X7WobjIyztB5r/SM9T
-        e/8re8UXqVbWa+qOQINI1v5aR2unaCdUicMgCeqSkmW6iRLsUCHb67SrJciHecJmPGBryiMbV1yt
-        BLA54/g0U/c08ITvBa0SOm/s3D1VP2xtU4AUVKblagaelvsNRve0XLUEhwGf0SBldssSLdnGZqZc
-        +Td8hZEQciEdEyQYqpXZCGBWg02NgKTRdun9m3TG3r29ZmOQuTRroqYZllWDTXTsaYQJPr+fhI7u
-        jauaefDlo7X/3kzDNzdw8Hiy0OJ9riHWLUeRLqM4E3U/qXooTLXGWFrnnjxPF5EUF3qRGnUR+1pQ
-        giX6ObFWd52qjlFmBqZUpSmsisislkbKzRzersebKN3TNgvclstzMpYtZeDkBENAiRPbdUfUYKYV
-        idJ9Es8BNWJGhQaBDcEQOYq8Es9NVf5GLgUZgQ4krmBXnaOEncU4rKaVBbkE5sXOiepsA+KAx1CF
-        IKxW2cCerHY6Eu3Y32ZqqtDTXguM6dpOEAx9zw1lVwXPcYd68oYOKF7+rYqAnp3IZNIDpcDJnOdf
-        ouRBxLJJzfM0+cZj8W0f8nudxnPakKsqyIeZpHGcghIsVK5ftIyqj1WUu6osr511xPGNCvW2iaL8
-        QLVjrll+jlgkGFdpBqd7A3RWoI96G3/dub/YosW2bE+HI/oBmLHXAuj+yLNvWnjF1KdlP5K4XilJ
-        EOBFVPXWUw5nQCLGivHa3DMrRJnk6zhk9bmV1edZYtLRn+Voou/IbO4dd8v/tibf4ltqgBCJR1HZ
-        BYcQ7LrROS/fbTawnh1bZtR/jrMNkqSZn4jqSvHb9/gRfQBZE9dVfDVxfcfohG95Ye3AmQxd16LN
-        M5Cjp1HWrqprNFCyJ45mRPh6QvnlFRpPj2J3CgnIUXSiEQpcpsra1dPLL0kNDfOtWET3eJBVgy9T
-        am4V/+RVJnlDwi7hfqrAkG52FRP1Mae8qrsLwg6ccDQiOuprnLn+IWnr+H04tEdO0IrfB5oRMb1g
-        M5CFQg/hm/pF0Cgy0DAr6CrCkDzG466lufsMlxihXkNX+wsM68m8LAqIXHIAGXCeZeT0Ml1Lxw8l
-        yqlTnpfzzypIUslXkKRRpdGq9F25N5RRpDWxUQH9AI0Kt0pPdMcd1sXxTehpx01G3rjzNI1BtTm+
-        pSLNex+axupvX7FZeg+SIBKahjNFp+uBKGKI4EjSRPUPAygnZAjwNYWtH9N5uqQIoSQTkPELqMgH
-        kQ0BHmOiYq3IVKZiq8tngdgjFu2SinbIArgfSaFEzWhkd8SvT3VtCgyOnTDoqKi7Ya+jPI6SU6ST
-        owaNirpnoKGH9zGmky8ZYKlhHN0j2N3CdQyzncsGmwwk8zqVSVWyRAsZt6acBLsRqoRFukUvGiOU
-        VqdgpqsdpQ594Q/tMjtZsSLT4T5iyw1qMeNKLw+supuO9R0mOva03ny/LVD0CmjOba8jLjdl7ym5
-        5JT/7L1KQdnXpsxk0LkpEFq9KGV3tjI/pvL1Imh09+Jiqm4Y3rjDVXaqCHrUN2lT03eVXydKiipN
-        xfb0IqomDW9v2K9p22lmYGQatEcVWvjyw1oroG12ba1THUy9GUiu7vVc7bp5SSV0rQQVzz2dn3Jw
-        o4m6ve01t0vaemE4Ar1nqQLCvbjQ8taugMgrnoBayqPNWitKMdUdaoMHJGN/LbF8CI0HrROJqTXe
-        QWIa9tTGnsB7b+VCqkSQtwp2wJ7dx9hPW2bqf8XkCllQCPa4PBYgN9QDz2VXQ1mkSJKomcmy3Xc9
-        aSd9BghYKsQi09+OFByeENhB724+YWc7n8AOvKGDxS2taLOGXv5GMfxT2FDG+dESnIE9mwAseSdj
-        INnDmseFcju/lf0d68ZHKIJk95FGE5JGzE82Rs7rjKJGsSfsF2DKXKXXCL4hASaFl4Zj2hrUxV4B
-        VWdO35tMOjDkqQ3pmwlqxJEyKcceOmM39IatqrvmTrx+zWQ33065D0MIhrw+8DNdNbxMKqUrStIi
-        3SLdQVNyZRph9sueurRFCkuq3i/HCK1nJTn7rCS/QzE0bzLRuG8n2bGxu+RkNBnCtoc/TSY/hza1
-        qj47FqO6nlZOzVNuJt33ifGobCUwfP0Wif9OtlR/LcS91BryHQSHNbXnVR9+LHLhW7g/F19LKprb
-        pNkWcORGNk1SxboA42VKWV51Sn23xRa+xKtzWUOE3umK/ONxhxfK/ADTTvStZwwNdpM0SYEqgQbT
-        fVdLH5hesesHWGKqmUymhAw1jKTLVY10MJpBWlk1lNXKmtdHdmFvY7rYaiqsDJxw3JF4cdTACXpa
-        mZ7Xyg1oCWt/bIPKRQNHL8x1W3kXn9J4LrL87EQunRqmci4uME59v1is0X13SZKCHM8IF3UkqBmF
-        yg+tNavPywVKjvuymd1Jpic6D9pauq0rsXWnV2UQeJ5vf0fl2zHh3NPCDCY65IFTc/cU5EYwnowD
-        156MJ06od/XW1OQMwMrZiSgAwpm9J266EkPZ8HTJMAdgJTG4oeSe6t2odVeB1uMmWsYYoZZIBR1d
-        eDWnSud8t1jj+Z9Vug6Wpfydtt/h7NduNFGzb1scz1jMvG90MCFnp6PBR8duNZz9mEarQuNlk8aT
-        o1TLkFYewCxFFpTeZaDfMovwk+YTUfR+BGiHDH80MUDROq/Qo3ulCw/lDrUxw6iy0F1/ZIlO7XfM
-        HRr0bZrjIJwx0RxAKZy6qge4GrXnYi2gdQ3QGuAXFo6cYuZ6IGq/AfsUFSkwcyazYy7XfCPly5SK
-        xZ+wjyJ75OJBEDa54dstkrBhP+EG1XCiJVPMzumibFZb7U1UsAVuYb3MG2PiAa63g+/r4aYt6GmS
-        BgdJHK1UaNvyLTnomH/f2DDHYCt1tQf8uH8LidbgSdXpy8r8jg7Axm5y++T8w3RnjHhV+R1BICNe
-        P9xRJehpqYZ+uz5ci9+u1PdmP8D7KXvDgVcTvY7QFE2pxtV1sc8zDkwuXbFA/22E9ZwXsjnzTSpd
-        s1NTkWydD6I6JYslawUfFFtjkCtbR4kxhovVK74S6WbjpSt+O+5pSgrHtid+S77oOQeLeWTtRx1p
-        OPcr+1Xvd2ZUk1iH9usBnL4AMyXJH6iShU1l4suRFu115seemGi8xyDEG2H0KvPgkhJqLOwiV62z
-        S1M2bjFRtq9N6AR2Z7MzGV4ILLelLD3N1zKtyaNZ6ibR0STjE43G11qKwb5+5ZDI1ATIkIhEHay/
-        I/M+oPaJdmWgOIETdnT8OIH0xj1NRNebhK7jhoDwXInpWqivNUCvttfY+Za9Sb/xRO8TZEhXkqOQ
-        q1EbKgB4e4CsG609+UHnDimkpRMKZYZEIa20RnpBVRZRvhPBEhnC3pOehIeDEEVbY0f6kukJpl3o
-        bR7qbO/4ILd5kgDFHiVOtNwJcb89QqkejnTccqLfNJgNhn048OAaXbTnWFe4wteJ4aaoYPlQZtlo
-        b3uZwnRxHzWFiG5xWJzWysY2k9Z0v4m0fSOWrTbeFRBMk7mC3q7VKq/Xy2Cvruv2TKfAd7uN0xPQ
-        b/BVIvG4gcTkrFV2+bnhTUUDrZlco4FcwyCSSZJVI+lMCMAyILVyKYn2TVeOukcC6gJX1ST7XQj9
-        u/0j474hTa+VeXbYxhU7T+CwE21cj7b8MJyAdsuPg6osRH9cblWzFd/3dB1WG7XS6se7Whob+rji
-        clV001PZUz/Ux3Xc02AV3miiFxA1k9qrL81pgO/Y6xQD88mDrggMIf56IDrIsYqgKPMHApWydi6W
-        DXHASkrXscp+f8KmcYyRZwwup8kwW++KNRZrdKF4UBK86ahRL6ZBVwI2LQJZgC5E6oE53zWOoTqZ
-        9XGs0uERHBEVOqL9x9Lhx2ZbtpHac9xNrpUWTEIdA2lu21cXVHT0KfqcrDjPlno1l9FxoA9XbxrA
-        jZjH+6LFl0VaWVrXCZCIEPmwhXKq9ony1aN1GWmjlx0QOMk1l9icXn9bp2E1Cg8q5TH6gdqDsdlq
-        PZ5HdVHO5/XLY25E8Q34bnjBlwDnVLbPYbEtyvVLyrwDYXABy4jFOagMfEEM3PJM1QpIAX21y6t3
-        bDZ4x+QaAsmKyl8m5o+w1YBpfT0NxLFjKgsit63rSKffPnHH1woDja02DTJ132oTYDS+gFRmoul5
-        UZXPA5Pt4Agmw8rxVKsuPIitCnlRM1zFYvs0HN8bMFic8u65bncGutlLHfa0A7siWO7QDe3ReKi7
-        9DSCXqClvJ7zuRYMNpnb1TgyqRVebra2xqKoDXnrao+yyjRTvZHU+zuAloDiNik19aValQSTcaqk
-        NOqACsPUVuArbYuu8vpxV2ZjdyArNBuGx8/ldYSduOa83EjxA2xC3q1axDfa1GBP47fiC7uqeQkF
-        UcVyNwJzn4FW+1yC9nnIEi90x6Zp942/GR6ObzPPAcd3ZGS8YrNog5Hf4tRhq8YNGq8fnFaZ2nX1
-        B7sXYjnniwcg1jqayxS3Dd/t0wKOvzhDxjaRqyq80+KIsBXZ7Kr76GCI0wbTQZnRYh0VPIvKZm7V
-        DKSCcLfnANd2Kchbxx7Ytl2/7plSFfKCo6pZNt8YvU+kwg6pAt+CCw8sGEjh26/RI9u/lV57Zy7I
-        67unduCMtCadDTtu/71p0T1NmVYeSsuSCeVLLbWwzEiLIVziC9vp9b4aXxliudU4pfFatL7UfB16
-        eFxFZev24arAtvVGbrbkBT9qkIwwaqAiNZ0tkr7bHAl7miPo+hr5ru7CNrr41Khjr+hgz0DWgI2x
-        WJ86yvVA6UX9bZ2WKqH4PU8i6aTC6k+eF0y+45denp3gL1cgykzlppNOvUYUxXi1xurQAhz+e/R4
-        zkA2TYCPAm9yyuN39M2iYd/yOA2V1HWJUYaBGhvz1xzd76Qlsj5n1/ju1FMAlwYNqNPPDaBPwUtV
-        LfspiuOIb2Tnuyny85zeupRT9+qMbwQZAbK5nXKi1mmYxN2ULvyYHqG/Sk1TL9W9rNCxQ11+O0Ct
-        +b4zfPuzesU7YFMd1SgJi6+gRoUPD5XOm/1Tf4e7Y4whKUZHuwCY6YFeBP3L7Zsz+cZrKeu+fPli
-        SXQIUmZz91S9uDw3vebc2i5Rb1MtVlIM1SvPQenGajZ3T/URCA3phdawr7h56OlAPDJs3ANfYmXX
-        cEPJr8Rpf2aOh/PDp989XReb+P92Zv9b1MujTRSD4C52QwBQiweaK75TXlCu+4++en6Er54fTYyv
-        ng+c8US+eh70KQDtcwffN169PP7fZ6BbN2Do4Z9/ai//wF8o5w2+zkEeFE1Gj/K87F5i813oefXy
-        +jDYH0Z6BD5B/UGY7jvftu648APwC5Tzl9BrDof4TvjfpaA8gxnuKSDBxVdLwxe6UdHk4wrUw0/D
-        L7yczd7ic13bdzB3zsNnqwIHvC67GMbsPaaGL6Qrd4rJQgnYqPC06nsQ6MAmG8yNA9MVrxbV8Js0
-        FtIVfyGTyxu3XVb3wLUbWUCULyLgwwQ3+lBeDWmnpNRSIqtJ1RMbJpUKrR1k1iOPSwmO2BRYK2bK
-        hsJXIWbEfAkn/gVIImAHMJYf87mI4dLt/hK2Et/iD6vRU8l6L2BZKa2rukd9wapv/sCjX08iBN2C
-        r/PGCe8n4daT4AtsyadNYrq/9J+ZRLgnRGMOXj0HUr3/VJy7f+YzvMzeVZf/M3NB34hU1Dkqz1i6
-        3ChwIwoZjYSzAQIkt0x7dl2sgf8Ms5FfvJCdIxuTuTx8MEwIOFCJkmFSYi7GmWrA88f/AGDNwu2N
-        jAAA
+      string: '{"indexed":{"date-parts":[[2023,10,10]],"date-time":"2023-10-10T16:23:04Z","timestamp":1696954984679},"reference-count":86,"publisher":"Springer
+        Science and Business Media LLC","issue":"1","license":[{"start":{"date-parts":[[2023,4,8]],"date-time":"2023-04-08T00:00:00Z","timestamp":1680912000000},"content-version":"tdm","delay-in-days":0,"URL":"https:\/\/creativecommons.org\/licenses\/by\/4.0"},{"start":{"date-parts":[[2023,4,8]],"date-time":"2023-04-08T00:00:00Z","timestamp":1680912000000},"content-version":"vor","delay-in-days":0,"URL":"https:\/\/creativecommons.org\/licenses\/by\/4.0"}],"funder":[{"DOI":"10.13039\/100000153","name":"NSF
+        | BIO | Division of Biological Infrastructure","doi-asserted-by":"publisher","award":["1934288"]},{"DOI":"10.13039\/100001391","name":"Whitehall
+        Foundation","doi-asserted-by":"publisher"},{"DOI":"10.13039\/100000065","name":"U.S.
+        Department of Health & Human Services | NIH | National Institute of Neurological
+        Disorders and Stroke","doi-asserted-by":"publisher","award":["R01NS121919"]}],"content-domain":{"domain":["link.springer.com"],"crossmark-restriction":false},"abstract":"<jats:title>Abstract<\/jats:title><jats:p>Spatial
+        cognition depends on an accurate representation of orientation within an environment.
+        Head direction cells in distributed brain regions receive a range of sensory
+        inputs, but visual input is particularly important for aligning their responses
+        to environmental landmarks. To investigate how population-level heading responses
+        are aligned to visual input, we recorded from retrosplenial cortex (RSC) of
+        head-fixed mice in a moving environment using two-photon calcium imaging.
+        We show that RSC neurons are tuned to the animal\u2019s relative orientation
+        in the environment, even in the absence of head movement. Next, we found that
+        RSC receives functionally distinct projections from visual and thalamic areas
+        and contains several functional classes of neurons. While some functional
+        classes mirror RSC inputs, a newly discovered class coregisters visual and
+        thalamic signals. Finally, decoding analyses reveal unique contributions to
+        heading from each class. Our results suggest an RSC circuit for anchoring
+        heading representations to environmental visual landmarks.<\/jats:p>","DOI":"10.1038\/s41467-023-37704-5","type":"journal-article","created":{"date-parts":[[2023,4,8]],"date-time":"2023-04-08T14:02:45Z","timestamp":1680962565000},"update-policy":"http:\/\/dx.doi.org\/10.1007\/springer_crossmark_policy","source":"Crossref","is-referenced-by-count":3,"title":"Coregistration
+        of heading to visual cues in retrosplenial cortex","prefix":"10.1038","volume":"14","author":[{"given":"Kevin
+        K.","family":"Sit","sequence":"first","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0002-5366-8501","authenticated-orcid":false,"given":"Michael
+        J.","family":"Goard","sequence":"additional","affiliation":[]}],"member":"297","published-online":{"date-parts":[[2023,4,8]]},"reference":[{"key":"37704_CR1","doi-asserted-by":"publisher","first-page":"849","DOI":"10.1126\/science.aal4835","volume":"356","author":"SS
+        Kim","year":"2017","unstructured":"Kim, S. S., Rouault, H., Druckmann, S.
+        & Jayaraman, V. Ring attractor dynamics in the Drosophila central brain. Science
+        356, 849\u2013853 (2017).","journal-title":"Science"},{"key":"37704_CR2","doi-asserted-by":"publisher","first-page":"186","DOI":"10.1038\/nature14446","volume":"521","author":"JD
+        Seelig","year":"2015","unstructured":"Seelig, J. D. & Jayaraman, V. Neural
+        dynamics for landmark orientation and angular path integration. Nature 521,
+        186\u2013191 (2015).","journal-title":"Nature"},{"key":"37704_CR3","doi-asserted-by":"publisher","first-page":"338","DOI":"10.1016\/j.cub.2021.11.009","volume":"32","author":"MJ
+        Beetz","year":"2022","unstructured":"Beetz, M. J. et al. Flight-induced compass
+        representation in the monarch butterfly heading network. Curr. Biol. 32, 338\u2013349.e5
+        (2022).","journal-title":"Curr. Biol."},{"key":"37704_CR4","doi-asserted-by":"publisher","first-page":"70","DOI":"10.1523\/JNEUROSCI.15-01-00070.1995","volume":"15","author":"JS
+        Taube","year":"1995","unstructured":"Taube, J. S. Head direction cells recorded
+        in the anterior thalamic nuclei of freely moving rats. J. Neurosci. 15, 70\u201386
+        (1995).","journal-title":"J. Neurosci."},{"key":"37704_CR5","doi-asserted-by":"publisher","first-page":"11","DOI":"10.1016\/S0306-4522(00)00258-X","volume":"100","author":"S
+        Leutgeb","year":"2000","unstructured":"Leutgeb, S., Ragozzino, K. E. & Mizumori,
+        S. J. Convergence of head direction and place information in the CA1 region
+        of hippocampus. Neuroscience 100, 11\u201319 (2000).","journal-title":"Neuroscience"},{"key":"37704_CR6","doi-asserted-by":"publisher","first-page":"3","DOI":"10.1037\/0735-7044.115.1.3","volume":"115","author":"J
+        Cho","year":"2001","unstructured":"Cho, J. & Sharp, P. E. Head direction,
+        place, and movement correlates for cells in the rat retrosplenial cortex.
+        Behav. Neurosci. 115, 3\u201325 (2001).","journal-title":"Behav. Neurosci."},{"key":"37704_CR7","doi-asserted-by":"publisher","first-page":"8","DOI":"10.1007\/BF00243212","volume":"101","author":"LL
+        Chen","year":"1994","unstructured":"Chen, L. L., Lin, L. H., Green, E. J.,
+        Barnes, C. A. & McNaughton, B. L. Head-direction cells in the rat posterior
+        cortex - I. anatomical distribution and behavioral modulation. Exp. Brain
+        Res. 101, 8\u201323 (1994).","journal-title":"Exp. Brain Res."},{"key":"37704_CR8","doi-asserted-by":"publisher","first-page":"9020","DOI":"10.1523\/JNEUROSCI.18-21-09020.1998","volume":"18","author":"RW
+        Stackman","year":"1998","unstructured":"Stackman, R. W. & Taube, J. S. Firing
+        properties of rat lateral mammillary single units: Head direction, head pitch,
+        and angular head velocity. J. Neurosci. 18, 9020\u20139037 (1998).","journal-title":"J.
+        Neurosci."},{"key":"37704_CR9","doi-asserted-by":"publisher","first-page":"420","DOI":"10.1523\/JNEUROSCI.10-02-00420.1990","volume":"10","author":"JS
+        Taube","year":"1990","unstructured":"Taube, J. S., Muller, R. U. & Ranck,
+        J. B. Head-direction cells recorded from the postsubiculum in freely moving
+        rats. I. Description and quantitative analysis. J. Neurosci. 10, 420\u2013435
+        (1990).","journal-title":"J. Neurosci."},{"key":"37704_CR10","doi-asserted-by":"publisher","first-page":"436","DOI":"10.1523\/JNEUROSCI.10-02-00436.1990","volume":"10","author":"JS
+        Taube","year":"1990","unstructured":"Taube, J. S., Muller, R. U. & Ranck,
+        J. B. Head-direction cells recorded from the postsubiculum in freely moving
+        rats. II. Effects of environmental manipulations. J. Neurosci. 10, 436\u2013447
+        (1990).","journal-title":"J. Neurosci."},{"key":"37704_CR11","doi-asserted-by":"publisher","first-page":"1648","DOI":"10.1523\/JNEUROSCI.15-03-01648.1995","volume":"15","author":"JJ
+        Knierim","year":"1995","unstructured":"Knierim, J. J., Kudrimoti, H. S. &
+        McNaughton, B. L. Place cells, head direction cells, and the learning of landmark
+        stability. J. Neurosci. 15, 1648\u20131659 (1995).","journal-title":"J. Neurosci."},{"key":"37704_CR12","doi-asserted-by":"publisher","first-page":"6260","DOI":"10.1523\/JNEUROSCI.15-09-06260.1995","volume":"15","author":"HT
+        Blair","year":"1995","unstructured":"Blair, H. T. & Sharp, P. E. Anticipatory
+        head direction signals in anterior thalamus: evidence for a thalamocortical
+        circuit that integrates angular head motion to compute head direction. J.
+        Neurosci. 15, 6260\u20136270 (1995).","journal-title":"J. Neurosci."},{"key":"37704_CR13","doi-asserted-by":"publisher","first-page":"87","DOI":"10.1002\/(SICI)1098-1063(1998)8:2<87::AID-HIPO1>3.0.CO;2-4","volume":"8","author":"JS
+        Taube","year":"1998","unstructured":"Taube, J. S. & Muller, R. U. Comparisons
+        of head direction cell activity in the postsubiculum and anterior thalamus
+        of freely moving rats. Hippocampus 8, 87\u2013108 (1998).","journal-title":"Hippocampus"},{"key":"37704_CR14","doi-asserted-by":"publisher","first-page":"1162","DOI":"10.1093\/cercor\/bhg102","volume":"13","author":"JS
+        Taube","year":"2003","unstructured":"Taube, J. S. & Bassett, J. P. Persistent
+        neural activity in head direction cells. Cereb. Cortex 13, 1162\u20131172
+        (2003).","journal-title":"Cereb. Cortex"},{"key":"37704_CR15","doi-asserted-by":"publisher","first-page":"4349","DOI":"10.1523\/JNEUROSCI.17-11-04349.1997","volume":"17","author":"RW
+        Stackman","year":"1997","unstructured":"Stackman, R. W. & Taube, J. S. Firing
+        properties of head direction cells in the rat anterior thalamic nucleus: dependence
+        on vestibular input. J. Neurosci. 17, 4349\u20134358 (1997).","journal-title":"J.
+        Neurosci."},{"key":"37704_CR16","doi-asserted-by":"publisher","first-page":"291","DOI":"10.1002\/hipo.1112","volume":"12","author":"RW
+        Stackman","year":"2002","unstructured":"Stackman, R. W., Clark, A. S. & Taube,
+        J. S. Hippocampal spatial representations require vestibular input. Hippocampus
+        12, 291\u2013303 (2002).","journal-title":"Hippocampus"},{"key":"37704_CR17","doi-asserted-by":"publisher","first-page":"14521","DOI":"10.1523\/JNEUROSCI.3450-09.2009","volume":"29","author":"GM
+        Muir","year":"2009","unstructured":"Muir, G. M. et al. Disruption of the head
+        direction cell signal after occlusion of the semicircular canals in the freely
+        moving chinchilla. J. Neurosci. 29, 14521\u201314533 (2009).","journal-title":"J.
+        Neurosci."},{"key":"37704_CR18","doi-asserted-by":"publisher","first-page":"1387","DOI":"10.1016\/S0896-6273(00)80657-1","volume":"21","author":"HT
+        Blair","year":"1998","unstructured":"Blair, H. T., Cho, J. & Sharp, P. E.
+        Role of the lateral mammillary nucleus in the rat head direction circuit:
+        A combined single unit recording and lesion study. Neuron 21, 1387\u20131397
+        (1998).","journal-title":"Neuron"},{"key":"37704_CR19","doi-asserted-by":"publisher","first-page":"135","DOI":"10.1037\/0735-7044.120.1.135","volume":"120","author":"RJ
+        Frohardt","year":"2006","unstructured":"Frohardt, R. J., Bassett, J. P. &
+        Taube, J. S. Path integration and lesions within the head direction cell circuit:
+        Comparison between the roles of the anterodorsal thalamus and dorsal tegmental
+        nucleus. Behav. Neurosci. 120, 135\u2013149 (2006).","journal-title":"Behav.
+        Neurosci."},{"key":"37704_CR20","doi-asserted-by":"publisher","first-page":"442","DOI":"10.1016\/j.neuron.2014.08.042","volume":"84","author":"D
+        Aronov","year":"2014","unstructured":"Aronov, D. & Tank, D. W. Engagement
+        of neural circuits underlying 2D spatial navigation in a rodent virtual reality
+        system. Neuron 84, 442\u2013456 (2014).","journal-title":"Neuron"},{"key":"37704_CR21","doi-asserted-by":"publisher","first-page":"16790","DOI":"10.1523\/JNEUROSCI.2698-13.2013","volume":"33","author":"A
+        Arleo","year":"2013","unstructured":"Arleo, A. et al. Optic flow stimuli update
+        anterodorsal thalamus head direction neuronal activity in rats. J. Neurosci.
+        33, 16790\u201316795 (2013).","journal-title":"J. Neurosci."},{"key":"37704_CR22","first-page":"E3305","volume":"115","author":"X
+        Chen","year":"2018","unstructured":"Chen, X., DeAngelis, G. C. & Angelaki,
+        D. E. Flexible egocentric and allocentric representations of heading signals
+        in parietal cortex. Proc. Natl Acad. Sci. USA 115, E3305\u2013E3312 (2018).","journal-title":"Proc.
+        Natl Acad. Sci. USA"},{"key":"37704_CR23","doi-asserted-by":"publisher","first-page":"197","DOI":"10.1016\/j.cell.2015.12.015","volume":"164","author":"L
+        Acharya","year":"2016","unstructured":"Acharya, L., Aghajan, Z. M., Vuong,
+        C., Moore, J. J. & Mehta, M. R. Causal influence of visual cues on hippocampal
+        directional selectivity. Cell 164, 197\u2013207 (2016).","journal-title":"Cell"},{"key":"37704_CR24","doi-asserted-by":"publisher","first-page":"RC154","DOI":"10.1523\/JNEUROSCI.21-14-j0001.2001","volume":"21","author":"MB
+        Zugaro","year":"2001","unstructured":"Zugaro, M. B., Berthoz, A. & Wiener,
+        S. I. Background, but not foreground, spatial cues are taken as references
+        for head direction responses by rat anterodorsal thalamus neurons. J. Neurosci.
+        21, RC154 (2001).","journal-title":"J. Neurosci."},{"key":"37704_CR25","doi-asserted-by":"publisher","first-page":"1304","DOI":"10.1152\/jn.00490.2004","volume":"93","author":"JP
+        Bassett","year":"2005","unstructured":"Bassett, J. P. et al. Passive movements
+        of the head do not abolish anticipatory firing properties of head direction
+        cells. J. Neurophysiol. 93, 1304\u20131316 (2005).","journal-title":"J. Neurophysiol."},{"key":"37704_CR26","doi-asserted-by":"publisher","first-page":"788","DOI":"10.1152\/jn.01098.2010","volume":"106","author":"ME
+        Shinder","year":"2011","unstructured":"Shinder, M. E. & Taube, J. S. Active
+        and passive movement are encoded equally by head direction cells in the anterodorsal
+        thalamus. J. Neurophysiol. 106, 788\u2013800 (2011).","journal-title":"J.
+        Neurophysiol."},{"key":"37704_CR27","doi-asserted-by":"publisher","first-page":"749","DOI":"10.1037\/0735-7044.112.4.749","volume":"112","author":"JP
+        Goodridge","year":"1998","unstructured":"Goodridge, J. P., Dudchenko, P. A.,
+        Worboys, K. A., Golob, E. J. & Taube, J. S. Cue control and head direction
+        cells. Behav. Neurosci. 112, 749\u2013761 (1998).","journal-title":"Behav.
+        Neurosci."},{"key":"37704_CR28","doi-asserted-by":"publisher","first-page":"3478","DOI":"10.1523\/JNEUROSCI.23-08-03478.2003","volume":"23","author":"MB
+        Zugaro","year":"2003","unstructured":"Zugaro, M. B., Arleo, A., Berthoz, A.
+        & Wiener, S. I. Rapid spatial reorientation and head direction cells. J. Neurosci.
+        23, 3478\u20133482 (2003).","journal-title":"J. Neurosci."},{"key":"37704_CR29","doi-asserted-by":"publisher","first-page":"10009","DOI":"10.1523\/JNEUROSCI.22-22-10009.2002","volume":"22","author":"DG
+        Wallace","year":"2002","unstructured":"Wallace, D. G., Hines, D. J., Pellis,
+        S. M. & Whishaw, I. Q. Vestibular information is required for dead reckoning
+        in the rat. J. Neurosci. 22, 10009\u201310017 (2002).","journal-title":"J.
+        Neurosci."},{"key":"37704_CR30","doi-asserted-by":"publisher","first-page":"480","DOI":"10.1002\/hipo.20533","volume":"19","author":"Y
+        Zheng","year":"2009","unstructured":"Zheng, Y., Goddard, M., Darlington, C.
+        L. & Smith, P. F. Long-term deficits on a foraging task after bilateral vestibular
+        deafferentation in rats. Hippocampus 19, 480\u2013486 (2009).","journal-title":"Hippocampus"},{"key":"37704_CR31","doi-asserted-by":"publisher","first-page":"126","DOI":"10.1038\/s41586-019-1767-1","volume":"576","author":"SS
+        Kim","year":"2019","unstructured":"Kim, S. S., Hermundstad, A. M., Romani,
+        S., Abbott, L. F. & Jayaraman, V. Generation of stable heading representations
+        in diverse visual scenes. Nature 576, 126\u2013131 (2019).","journal-title":"Nature"},{"key":"37704_CR32","doi-asserted-by":"publisher","first-page":"583","DOI":"10.1038\/360583a0","volume":"360","author":"CS
+        Royden","year":"1992","unstructured":"Royden, C. S., Banks, M. S. & Crowell,
+        J. A. The perception of heading during eye movements. Nature 360, 583\u2013585
+        (1992).","journal-title":"Nature"},{"key":"37704_CR33","doi-asserted-by":"publisher","first-page":"895","DOI":"10.3389\/fnhum.2014.00895","volume":"8","author":"VE
+        Pettorossi","year":"2014","unstructured":"Pettorossi, V. E. & Schieppati,
+        M. Neck proprioception shapes body orientation and perception of motion. Front.
+        Hum. Neurosci. 8, 895 (2014).","journal-title":"Front. Hum. Neurosci."},{"key":"37704_CR34","doi-asserted-by":"publisher","first-page":"445","DOI":"10.1016\/0361-9230(94)90288-7","volume":"33","author":"A
+        Gasbarri","year":"1994","unstructured":"Gasbarri, A., Packard, M. G., Campana,
+        E. & Pacitti, C. Anterograde and retrograde tracing of projections from the
+        ventral tegmental area to the hippocampal formation in the rat. Brain Res.
+        Bull. 33, 445\u2013452 (1994).","journal-title":"Brain Res. Bull."},{"key":"37704_CR35","doi-asserted-by":"crossref","unstructured":"Asumbisa,
+        K., Peyrache, A. & Trenholm, S. Flexible cue anchoring strategies enable stable
+        head direction coding in both sighted and blind animals. Nat. Commun. 13,
+        1\u201315 (2022).","DOI":"10.1038\/s41467-022-33204-0"},{"key":"37704_CR36","doi-asserted-by":"publisher","first-page":"1682","DOI":"10.1037\/0735-7044.119.6.1682","volume":"119","author":"SD
+        Vann","year":"2005","unstructured":"Vann, S. D. & Aggleton, J. P. Selective
+        dysgranular retrosplenial cortex lesions in rats disrupt allocentric performance
+        of the radial-arm maze task. Behav. Neurosci. 119, 1682\u20131686 (2005).","journal-title":"Behav.
+        Neurosci."},{"key":"37704_CR37","doi-asserted-by":"publisher","first-page":"5289","DOI":"10.1523\/JNEUROSCI.3380-09.2010","volume":"30","author":"BJ
+        Clark","year":"2010","unstructured":"Clark, B. J., Bassett, J. P., Wang, S.
+        S. & Taube, J. S. Impaired head direction cell representation in the anterodorsal
+        thalamus after lesions of the retrosplenial cortex. J. Neurosci. 30, 5289\u20135302
+        (2010).","journal-title":"J. Neurosci."},{"key":"37704_CR38","doi-asserted-by":"publisher","first-page":"593","DOI":"10.1002\/cne.903000412","volume":"300","author":"T
+        Van Groen","year":"1990","unstructured":"Van Groen, T. & Wyss, J. M. Connections
+        of the retrosplenial granular a cortex in the rat. J. Comp. Neurol. 300, 593\u2013606
+        (1990).","journal-title":"J. Comp. Neurol."},{"key":"37704_CR39","doi-asserted-by":"publisher","first-page":"249","DOI":"10.1002\/cne.10757","volume":"463","author":"T
+        Van Groen","year":"2003","unstructured":"Van Groen, T. & Wyss, J. M. Connections
+        of the retrosplenial granular b cortex in the rat. J. Comp. Neurol. 463, 249\u2013263
+        (2003).","journal-title":"J. Comp. Neurol."},{"key":"37704_CR40","doi-asserted-by":"publisher","first-page":"200","DOI":"10.1002\/cne.903150207","volume":"315","author":"T
+        Van Groen","year":"1992","unstructured":"Van Groen, T. & Wyss, J. M. Connections
+        of the retrosplenial dysgranular cortex in the rat. J. Comp. Neurol. 315,
+        200\u2013216 (1992).","journal-title":"J. Comp. Neurol."},{"key":"37704_CR41","doi-asserted-by":"publisher","first-page":"533","DOI":"10.1002\/cne.903300409","volume":"330","author":"H
+        Shibata","year":"1993","unstructured":"Shibata, H. Efferent projections from
+        the anterior thalamic nuclei to the cingulate cortex in the rat. J. Comp.
+        Neurol. 330, 533\u2013542 (1993).","journal-title":"J. Comp. Neurol."},{"key":"37704_CR42","doi-asserted-by":"publisher","first-page":"569","DOI":"10.1038\/nn.3968","volume":"18","author":"A
+        Peyrache","year":"2015","unstructured":"Peyrache, A., Lacroix, M. M., Petersen,
+        P. C. & Buzs\u00e1ki, G. Internally organized mechanisms of the head direction
+        sense. Nat. Neurosci. 18, 569\u2013575 (2015).","journal-title":"Nat. Neurosci."},{"key":"37704_CR43","doi-asserted-by":"publisher","first-page":"e51458","DOI":"10.7554\/eLife.51458","volume":"9","author":"LF
+        Fischer","year":"2020","unstructured":"Fischer, L. F., Soto-Albors, R. M.,
+        Buck, F. & Harnett, M. T. Representation of visual landmarks in retrosplenial
+        cortex. eLife 9, e51458 (2020).","journal-title":"eLife"},{"key":"37704_CR44","doi-asserted-by":"publisher","first-page":"1143","DOI":"10.1038\/nn.4058","volume":"18","author":"AS
+        Alexander","year":"2015","unstructured":"Alexander, A. S. & Nitz, D. A. Retrosplenial
+        cortex maps the conjunction of internal and external spaces. Nat. Neurosci.
+        18, 1143\u20131151 (2015).","journal-title":"Nat. Neurosci."},{"key":"37704_CR45","doi-asserted-by":"publisher","first-page":"191","DOI":"10.3389\/fncel.2018.00191","volume":"12","author":"HJ
+        Page","year":"2018","unstructured":"Page, H. J. & Jeffery, K. J. Landmark-based
+        updating of the head direction system by retrosplenial cortex: a computational
+        model. Front. Cell. Neurosci. 12, 191 (2018).","journal-title":"Front. Cell.
+        Neurosci."},{"key":"37704_CR46","doi-asserted-by":"publisher","first-page":"173","DOI":"10.1038\/nn.4465","volume":"20","author":"PY
+        Jacob","year":"2017","unstructured":"Jacob, P. Y. et al. An independent, landmark
+        dominated head-direction signal in dysgranular retrosplenial cortex. Nat.
+        Neurosci. 20, 173\u2013175 (2017).","journal-title":"Nat. Neurosci."},{"key":"37704_CR47","doi-asserted-by":"publisher","first-page":"e43620","DOI":"10.1371\/journal.pone.0043620","volume":"7","author":"SD
+        Auger","year":"2012","unstructured":"Auger, S. D., Mullally, S. L. & Maguire,
+        E. A. Retrosplenial cortex codes for permanent landmarks. PLoS ONE 7, e43620
+        (2012).","journal-title":"PLoS ONE"},{"key":"37704_CR48","doi-asserted-by":"publisher","first-page":"eabf9815","DOI":"10.1126\/sciadv.abf9815","volume":"7","author":"LM
+        Franco","year":"2021","unstructured":"Franco, L. M. & Goard, M. J. A distributed
+        circuit for associating environmental context with motor choice in retrosplenial
+        cortex. Sci. Adv. 7, eabf9815 (2021).","journal-title":"Sci. Adv."},{"key":"37704_CR49","doi-asserted-by":"publisher","first-page":"625","DOI":"10.1097\/00001756-199902250-00033","volume":"10","author":"BG
+        Cooper","year":"1999","unstructured":"Cooper, B. G. & Mizumori, S. J. Retrosplenial
+        cortex inactivation selectivity impairs navigation in darkness. NeuroReport
+        10, 625\u2013630 (1999).","journal-title":"NeuroReport"},{"key":"37704_CR50","doi-asserted-by":"publisher","first-page":"67","DOI":"10.1016\/S0166-4328(00)00312-0","volume":"118","author":"IQ
+        Whishaw","year":"2001","unstructured":"Whishaw, I. Q., Maaswinkel, H., Gonzalez,
+        C. L. & Kolb, B. Deficits in allothetic and idiothetic spatial behavior in
+        rats with posterior cingulate cortex lesions. Behav. Brain Res. 118, 67\u201376
+        (2001).","journal-title":"Behav. Brain Res."},{"key":"37704_CR51","doi-asserted-by":"publisher","first-page":"532","DOI":"10.1016\/j.neuron.2021.10.031","volume":"110","author":"S
+        Keshavarzi","year":"2022","unstructured":"Keshavarzi, S. et al. Multisensory
+        coding of angular head velocity in the retrosplenial cortex. Neuron 110, 532\u2013543.e9
+        (2022).","journal-title":"Neuron"},{"key":"37704_CR52","doi-asserted-by":"crossref","unstructured":"Zhang,
+        N., Grieves, R. M. & Jeffery, K. J. Environment symmetry drives a multidirectional
+        code in rat retrosplenial cortex. J. Neurosci. 42, 9227\u20139241 (2022).","DOI":"10.1523\/JNEUROSCI.0619-22.2022"},{"key":"37704_CR53","doi-asserted-by":"publisher","first-page":"62","DOI":"10.1038\/nature10918","volume":"484","author":"CD
+        Harvey","year":"2012","unstructured":"Harvey, C. D., Coen, P. & Tank, D. W.
+        Choice-specific sequences in parietal cortex during a virtualnavigation decision
+        task. Nature 484, 62\u201368 (2012).","journal-title":"Nature"},{"key":"37704_CR54","doi-asserted-by":"publisher","first-page":"124","DOI":"10.1038\/s41586-018-0516-1","volume":"562","author":"AB
+        Saleem","year":"2018","unstructured":"Saleem, A. B., Diamanti, E. M., Fournier,
+        J., Harris, K. D. & Carandini, M. Coherent encoding of subjective spatial
+        position in visual cortex and hippocampus. Nature 562, 124\u2013127 (2018).","journal-title":"Nature"},{"key":"37704_CR55","doi-asserted-by":"publisher","first-page":"9537","DOI":"10.1523\/JNEUROSCI.0712-14.2014","volume":"34","author":"NJ
+        Sofroniew","year":"2014","unstructured":"Sofroniew, N. J., Cohen, J. D., Lee,
+        A. K. & Svoboda, K. Natural whisker-guided behavior by head-fixed mice in
+        tactile virtual reality. J. Neurosci. 34, 9537\u20139550 (2014).","journal-title":"J.
+        Neurosci."},{"key":"37704_CR56","first-page":"e51869","volume":"29","author":"M
+        Kislin","year":"2014","unstructured":"Kislin, M. et al. Flat-floored air-lifted
+        platform: a new method for combining behavior with microscopy or electrophysiology
+        on awake freely moving rodents. J. Vis. Exp. 29, e51869 (2014).","journal-title":"J.
+        Vis. Exp."},{"key":"37704_CR57","doi-asserted-by":"publisher","first-page":"4424","DOI":"10.1093\/cercor\/bhaa030","volume":"30","author":"A
+        Powell","year":"2020","unstructured":"Powell, A. et al. Stable encoding of
+        visual cues in the mouse retrosplenial cortex. Cereb. Cortex 30, 4424\u20134437
+        (2020).","journal-title":"Cereb. Cortex"},{"key":"37704_CR58","doi-asserted-by":"publisher","first-page":"32","DOI":"10.3389\/fnint.2014.00032","volume":"8","author":"RM
+        Yoder","year":"2014","unstructured":"Yoder, R. M. & Taube, J. S. The vestibular
+        contribution to the head direction signal and navigation. Front. Integr. Neurosci.
+        8, 32 (2014).","journal-title":"Front. Integr. Neurosci."},{"key":"37704_CR59","doi-asserted-by":"publisher","first-page":"622","DOI":"10.1523\/JNEUROSCI.3885-05.2006","volume":"26","author":"D
+        Yoganarasimha","year":"2006","unstructured":"Yoganarasimha, D., Yu, X. & Knierim,
+        J. J. Head direction cell representations maintain internal coherence during
+        conflicting proximal and distal cue rotations: comparison with hippocampal
+        place cells. J. Neurosci. 26, 622\u2013631 (2006).","journal-title":"J. Neurosci."},{"key":"37704_CR60","doi-asserted-by":"publisher","first-page":"4386","DOI":"10.1523\/JNEUROSCI.6063-11.2012","volume":"32","author":"Q
+        Wang","year":"2012","unstructured":"Wang, Q., Sporns, O. & Burkhalter, A.
+        Network analysis of corticocortical connections reveals ventral and dorsal
+        processing streams in mouse visual cortex. J. Neurosci. 32, 4386\u20134399
+        (2012).","journal-title":"J. Neurosci."},{"key":"37704_CR61","doi-asserted-by":"publisher","first-page":"1","DOI":"10.1038\/s41467-020-17283-5","volume":"11","author":"KK
+        Sit","year":"2020","unstructured":"Sit, K. K. & Goard, M. J. Distributed and
+        retinotopically asymmetric processing of coherent motion in mouse visual cortex.
+        Nat. Commun. 11, 1\u201314 (2020).","journal-title":"Nat. Commun."},{"key":"37704_CR62","doi-asserted-by":"publisher","first-page":"171","DOI":"10.1016\/S0959-4388(99)80023-3","volume":"9","author":"EA
+        Maguire","year":"1999","unstructured":"Maguire, E. A., Burgess, N. & O\u2019Keefe,
+        J. Human spatial navigation: cognitive maps, sexual dimorphism, and neural
+        substrates. Curr. Opin. Neurobiol. 9, 171\u2013177 (1999).","journal-title":"Curr.
+        Opin. Neurobiol."},{"key":"37704_CR63","doi-asserted-by":"publisher","first-page":"184","DOI":"10.1038\/nature01964","volume":"425","author":"AD
+        Ekstrom","year":"2003","unstructured":"Ekstrom, A. D. et al. Cellular networks
+        underlying human spatial navigation. Nature 425, 184\u2013187 (2003).","journal-title":"Nature"},{"key":"37704_CR64","doi-asserted-by":"publisher","first-page":"3333","DOI":"10.1523\/JNEUROSCI.4705-04.2005","volume":"25","author":"T
+        Wolbers","year":"2005","unstructured":"Wolbers, T. & B\u00fcchel, C. Dissociable
+        retrosplenial and hippocampal contributions to successful formation of survey
+        representations. J. Neurosci. 25, 3333\u20133340 (2005).","journal-title":"J.
+        Neurosci."},{"key":"37704_CR65","doi-asserted-by":"publisher","first-page":"692","DOI":"10.1177\/0956797620979185","volume":"32","author":"S
+        Yu","year":"2021","unstructured":"Yu, S. et al. Age-related changes in spatial
+        navigation are evident by midlife and differ by sex. Psychol. Sci. 32, 692\u2013704
+        (2021).","journal-title":"Psychol. Sci."},{"key":"37704_CR66","doi-asserted-by":"publisher","first-page":"237","DOI":"10.1016\/j.neuron.2019.10.016","volume":"105","author":"J
+        Voigts","year":"2020","unstructured":"Voigts, J. & Harnett, M. T. Somatic
+        and dendritic encoding of spatial variables in retrosplenial cortex differs
+        during 2D navigation. Neuron 105, 237\u2013245.e4 (2020).","journal-title":"Neuron"},{"key":"37704_CR67","doi-asserted-by":"publisher","first-page":"110134","DOI":"10.1016\/j.celrep.2021.110134","volume":"37","author":"E
+        Hennestad","year":"2021","unstructured":"Hennestad, E., Witoelar, A., Chambers,
+        A. R. & Vervaeke, K. Mapping vestibular and visual contributions to angular
+        head velocity tuning in the cortex. Cell Rep. 37, 110134 (2021).","journal-title":"Cell
+        Rep."},{"key":"37704_CR68","doi-asserted-by":"publisher","first-page":"643","DOI":"10.1037\/0735-7044.110.4.643","volume":"110","author":"HT
+        Blair","year":"1996","unstructured":"Blair, H. T. & Sharp, P. E. Visual and
+        vestibular influences on head-direction cells in the anterior thalamus of
+        the rat. Behav. Neurosci. 110, 643\u2013660 (1996).","journal-title":"Behav.
+        Neurosci."},{"key":"37704_CR69","doi-asserted-by":"publisher","first-page":"8404","DOI":"10.1126\/sciadv.abg8404","volume":"8","author":"PA
+        LaChance","year":"2022","unstructured":"LaChance, P. A., Graham, J., Shapiro,
+        B. L., Morris, A. J. & Taube, J. S. Landmark-modulated directional coding
+        in postrhinal cortex. Sci. Adv. 8, 8404 (2022).","journal-title":"Sci. Adv."},{"key":"37704_CR70","doi-asserted-by":"publisher","first-page":"e1009434","DOI":"10.1371\/journal.pcbi.1009434","volume":"17","author":"Y
+        Yan","year":"2021","unstructured":"Yan, Y., Burgess, N. & Bicanski, A. A model
+        of head direction and landmark coding in complex environments. PLoS Comput.17,
+        e1009434 (2021).","journal-title":"PLoS Comput."},{"key":"37704_CR71","doi-asserted-by":"publisher","first-page":"11601","DOI":"10.1523\/JNEUROSCI.0516-16.2016","volume":"36","author":"A
+        Bicanski","year":"2016","unstructured":"Bicanski, A. & Burgess, N. Environmental
+        anchoring of head direction in a computational model of retrosplenial cortex.
+        J. Neurosci. 36, 11601\u201311618 (2016).","journal-title":"J. Neurosci."},{"key":"37704_CR72","doi-asserted-by":"publisher","first-page":"239821281772185","DOI":"10.1177\/2398212817721859","volume":"1","author":"YR
+        Lozano","year":"2017","unstructured":"Lozano, Y. R. et al. Retrosplenial and
+        postsubicular head direction cells compared during visual landmark discrimination.
+        Brain Neurosci. Adv. 1, 239821281772185 (2017).","journal-title":"Brain Neurosci.
+        Adv."},{"key":"37704_CR73","doi-asserted-by":"publisher","first-page":"181","DOI":"10.1146\/annurev.neuro.29.051605.112854","volume":"30","author":"JS
+        Taube","year":"2007","unstructured":"Taube, J. S. The head direction signal:
+        origins and sensory-motor integration. Annu. Rev. Neurosci. 30, 181\u2013207
+        (2007).","journal-title":"Annu. Rev. Neurosci."},{"key":"37704_CR74","doi-asserted-by":"publisher","first-page":"136","DOI":"10.1016\/j.conb.2019.12.002","volume":"60","author":"DE
+        Angelaki","year":"2020","unstructured":"Angelaki, D. E. & Laurens, J. The
+        head direction cell network: attractor dynamics, integration within the navigation
+        system, and three-dimensional properties. Curr. Opin. Neurobiol. 60, 136\u2013144
+        (2020).","journal-title":"Curr. Opin. Neurobiol."},{"key":"37704_CR75","doi-asserted-by":"publisher","first-page":"9315","DOI":"10.1523\/JNEUROSCI.17-23-09315.1997","volume":"17","author":"JP
+        Goodridge","year":"1997","unstructured":"Goodridge, J. P. & Taube, J. S. Interaction
+        between the postsubiculum and anterior thalamus in the generation of head
+        direction cell activity. J. Neurosci. 17, 9315\u20139330 (1997).","journal-title":"J.
+        Neurosci."},{"key":"37704_CR76","doi-asserted-by":"publisher","first-page":"e35949","DOI":"10.7554\/eLife.35949","volume":"7","author":"O
+        Kornienko","year":"2018","unstructured":"Kornienko, O., Latuske, P., Bassler,
+        M., Kohler, L. & Allen, K. Non-rhythmic head-direction cells in the parahippocampal
+        region are not constrained by attractor network dynamics. eLife 7, e35949
+        (2018).","journal-title":"eLife"},{"key":"37704_CR77","doi-asserted-by":"crossref","first-page":"1","DOI":"10.7554\/eLife.59816","volume":"9","author":"JB
+        Van Wijngaarden","year":"2020","unstructured":"Van Wijngaarden, J. B., Babl,
+        S. S. & Ito, H. T. Entorhinal-retrosplenial circuits for allocentricegocentric
+        transformation of boundary coding. eLife 9, 1\u201325 (2020).","journal-title":"eLife"},{"key":"37704_CR78","doi-asserted-by":"crossref","unstructured":"Bubb,
+        E. J., Metzler-Baddeley, C. & Aggleton, J. P. The Cingulum Bundle: Anatomy,
+        Function, and Dysfunction (2018).","DOI":"10.1016\/j.neubiorev.2018.05.008"},{"key":"37704_CR79","doi-asserted-by":"publisher","first-page":"719","DOI":"10.1038\/nature21692","volume":"543","author":"D
+        Aronov","year":"2017","unstructured":"Aronov, D., Nevers, R. & Tank, D. W.
+        Mapping of a non-spatial dimension by the hippocampalentorhinal circuit. Nature
+        543, 719\u2013722 (2017).","journal-title":"Nature"},{"key":"37704_CR80","doi-asserted-by":"publisher","first-page":"1","DOI":"10.1038\/s41467-022-28057-6","volume":"13","author":"B
+        Shahbaba","year":"2022","unstructured":"Shahbaba, B. et al. Hippocampal ensembles
+        represent sequential relationships among an extended sequence of nonspatial
+        events. Nat. Commun. 13, 1\u201317 (2022).","journal-title":"Nat. Commun."},{"key":"37704_CR81","doi-asserted-by":"crossref","unstructured":"Eichenbaum,
+        H. Time Cells in the Hippocampus: A New Dimension for Mapping Memories (2014).","DOI":"10.1038\/nrn3827"},{"key":"37704_CR82","doi-asserted-by":"publisher","first-page":"1","DOI":"10.1038\/ncomms16032","volume":"8","author":"J
+        Simonnet","year":"2017","unstructured":"Simonnet, J. et al. Activity dependent
+        feedback inhibition may maintain head direction signals in mouse presubiculum.
+        Nat. Commun. 8, 1\u201314 (2017).","journal-title":"Nat. Commun."},{"key":"37704_CR83","doi-asserted-by":"publisher","unstructured":"Pachitariu,
+        M. et al. Suite2p: beyond 10,000 neurons with standard two-photon microscopy.
+        Preprint at bioRxiv https:\/\/doi.org\/10.1101\/061507 (2016).","DOI":"10.1101\/061507"},{"key":"37704_CR84","doi-asserted-by":"publisher","first-page":"22","DOI":"10.1016\/j.conb.2018.11.005","volume":"55","author":"C
+        Stringer","year":"2019","unstructured":"Stringer, C. & Pachitariu, M. Computational
+        processing of neural recordings from calcium imaging data. Curr. Opin. Neurobiol.
+        55, 22\u201331 (2019).","journal-title":"Curr. Opin. Neurobiol."},{"key":"37704_CR85","doi-asserted-by":"publisher","first-page":"e1005423","DOI":"10.1371\/journal.pcbi.1005423","volume":"13","author":"J
+        Friedrich","year":"2017","unstructured":"Friedrich, J., Zhou, P. & Paninski,
+        L. Fast online deconvolution of calcium imaging data. PLoS Comput. Biol. 13,
+        e1005423 (2017). arXiv: 1609.00639.","journal-title":"PLoS Comput. Biol."},{"key":"37704_CR86","doi-asserted-by":"publisher","first-page":"19","DOI":"10.3389\/fncir.2020.00019","volume":"14","author":"G
+        Etter","year":"2020","unstructured":"Etter, G., Manseau, F. & Williams, S.
+        A probabilistic framework for decoding behavior from in vivo calcium imaging
+        data. Front. Neural Circuits 14, 19 (2020).","journal-title":"Front. Neural
+        Circuits"}],"container-title":"Nature Communications","original-title":[],"language":"en","link":[{"URL":"https:\/\/www.nature.com\/articles\/s41467-023-37704-5.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"text-mining"},{"URL":"https:\/\/www.nature.com\/articles\/s41467-023-37704-5","content-type":"text\/html","content-version":"vor","intended-application":"text-mining"},{"URL":"https:\/\/www.nature.com\/articles\/s41467-023-37704-5.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"similarity-checking"}],"deposited":{"date-parts":[[2023,4,8]],"date-time":"2023-04-08T15:02:59Z","timestamp":1680966179000},"score":1,"resource":{"primary":{"URL":"https:\/\/www.nature.com\/articles\/s41467-023-37704-5"}},"subtitle":[],"short-title":[],"issued":{"date-parts":[[2023,4,8]]},"references-count":86,"journal-issue":{"issue":"1","published-online":{"date-parts":[[2023,12]]}},"alternative-id":["37704"],"URL":"http:\/\/dx.doi.org\/10.1038\/s41467-023-37704-5","relation":{},"ISSN":["2041-1723"],"subject":["General
+        Physics and Astronomy","General Biochemistry, Genetics and Molecular Biology","General
+        Chemistry","Multidisciplinary"],"container-title-short":"Nat Commun","published":{"date-parts":[[2023,4,8]]},"assertion":[{"value":"22
+        April 2022","order":1,"name":"received","label":"Received","group":{"name":"ArticleHistory","label":"Article
+        History"}},{"value":"28 March 2023","order":2,"name":"accepted","label":"Accepted","group":{"name":"ArticleHistory","label":"Article
+        History"}},{"value":"8 April 2023","order":3,"name":"first_online","label":"First
+        Online","group":{"name":"ArticleHistory","label":"Article History"}},{"value":"The
+        authors declare no competing interests.","order":1,"name":"Ethics","group":{"name":"EthicsHeading","label":"Competing
+        interests"}}],"article-number":"1992"}'
     headers:
       access-control-allow-headers:
       - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
@@ -261,11 +395,11 @@ interactions:
       content-encoding:
       - gzip
       content-length:
-      - '10263'
+      - '10269'
       content-type:
       - application/json
       date:
-      - Tue, 25 Apr 2023 19:11:48 GMT
+      - Mon, 16 Oct 2023 18:46:14 GMT
       link:
       - <http://dx.doi.org/10.1038/s41467-023-37704-5>; rel="canonical", <https://www.nature.com/articles/s41467-023-37704-5.pdf>;
         version="vor"; type="application/pdf"; rel="item", <https://www.nature.com/articles/s41467-023-37704-5>;

--- a/dandi/cli/tests/data/update_dandiset_from_doi/neuron.vcr.yaml
+++ b/dandi/cli/tests/data/update_dandiset_from_doi/neuron.vcr.yaml
@@ -7,7 +7,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - dandi/0.53.0+17.gc2f268f.dirty requests/2.28.2 CPython/3.11.3
+      - dandi/0.56.2+5.ga0199fce.dirty requests/2.31.0 CPython/3.11.6
       accept:
       - application/json
     method: GET
@@ -21,7 +21,7 @@ interactions:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 7bd8e4cd2b67586c-IAD
+      - 8172769f4bf141e9-EWR
       Connection:
       - keep-alive
       Content-Length:
@@ -29,19 +29,19 @@ interactions:
       Content-Type:
       - text/html;charset=utf-8
       Date:
-      - Tue, 25 Apr 2023 19:11:46 GMT
+      - Mon, 16 Oct 2023 18:46:13 GMT
       NEL:
       - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=4ujOeD%2Bo27RrsYGsqq8qitn9T1NwBi8IfxVk4DAS5CAFKL6CV9ZoAxgbtPmce6wpqIfu5oMDV3FwIyND3wja%2FDo1sbKCNlQo136o2tZMK1MyKjokgXXPyo6yp1UnZsXuHNViCsc%3D"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=oMaESedfgox6sztDGRLRnf4k%2FlMOpQdL8gWy8qgcvw%2B%2Fo8sKFzOPd%2Bshy4pKl4SVfIEmcJDf0YExoEqk0ZkIX9CCWpDo131GZjHrKYlTVs%2FIiDjIM%2FChY8E%3D"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       alt-svc:
-      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
+      - h3=":443"; ma=86400
       expires:
-      - Tue, 25 Apr 2023 19:32:12 GMT
+      - Mon, 16 Oct 2023 19:27:25 GMT
       link:
       - <https://dul.usage.elsevier.com/doi/>; rel=dul
       - <https://dul.usage.elsevier.com/doi/>; rel=dul
@@ -62,169 +62,222 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - dandi/0.53.0+17.gc2f268f.dirty requests/2.28.2 CPython/3.11.3
+      - dandi/0.56.2+5.ga0199fce.dirty requests/2.31.0 CPython/3.11.6
       accept:
       - application/json
     method: GET
     uri: https://api.crossref.org/v1/works/10.1016%2Fj.neuron.2019.10.012/transform
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAA/+1dbXPbtrL+Kxx9amdMme8iPXPnjpOmSXqSNGOn7b0nznQgEpKQUCQPX2wrnf73
-        uwuAFEFBVuC43+45bitTNAgsFrvPvvKvGSsyek+z2cVfs4y01K5I3Tazi48fPcfzz4Iz1//06Ux8
-        1bItnV3M8AvbCWzX/+A6F3584Ub/np3N8NumJdtqBhdi1489L4niOPz7bFbTFa1pkVI7LbuihRuc
-        xdms6pY5aza0hjFf5A29ZbS2nv0OQ7Gm6fBJLnzOWUqLBn77+NcMhq9b7UydM/fM1UzUsR0Xfj44
-        zgX/mU40XCxiP4od/B9MNC2LlhatfUvrhpUFjNFmW/iTjOZkZ7PCzsgOHumczX67egPfbtq2ai5u
-        zm/O7+7u5lQuYp6W25tz+Mub866htVzBzbk7d27OZ3+fPbQQWMZZrFmIyxcSH11I5DpOFDjHF3Jb
-        1ocL8Rf+eClHVlJWtLBJmtKm0a8IprvqgI9qvks//foa986Zu77jJ3CTmJXjwfMLwhf07vUrnEzJ
-        bNLAeC3N7OUOru9Z4mxG7kgNbPlx9vZVGEQL5IW3r4Bx/CSCj7+5ifXuGn6N3PGvQZg48Ou7aydx
-        wtiffUJq9w+9/nk8rBsGYRzG4hb9nOPE38/5mm3LorF+Bg6GvUGifvMK/NB1nQSe9Gm/M1m5Jazg
-        PCA/fZylNM+R5PC34x2AX5uU4fnJWE3Tll/Doeqyabak/mLXwAc1S/msLtq6o3/vj1dmVzUrjh6b
-        T7D+0fIdN7o5/zwvaFeXxdxz3ASuzR0XN6/dVUiIz2VXFyS3YRyW5nSGE6EwslaGuMmZ65550SFL
-        u4nturYXfXDDiyC5cMLDsxnA4fSDULB0RdZcJvix7QbJnIZwe1eJ55XAkbsxE2f3c9ibeVmvcS/l
-        snqa/plu/5R/ApSF1aQ48HOkJkgqLn/sQWThvvZiy3dwhm2Ot1+VXcuKtVWurFesqsoUJk1y6wo+
-        57Sx2tK67pZpiTSCy9ewKWnbwT5Zt4xY7YZab2DmNX5Fq7bDPa7gmex+vw9w6bbMO04u18Hlkq7d
-        lOKQrdktxWP9E7llGXy1IluWIwk+wKRyyldG/9PhCuDiitVNiwOsVixngnsvPnLO7wd6ubvpHGcV
-        1evdeLhn3dcGv6DuF6aOSbKM4UAk1wwMu72l2yWX7Yt4NlIBfPZf6O4Uv/25ZEtXe8TS/UbxddmS
-        M0IPmfSAlfmhgoH9uevNnQDFg+Rcu9/L53Am6zLHvYRzBGIOJGTWwd5bFcrPBg+sRYp7RtudtdzB
-        R4vetzWxyXa3zkhOrAY2sdzsqrLdwK9bllopq9OOtcomhtFoE2eXBXwokNo7SmpxJgL4rT9fw+xg
-        AVxrfCPVPM0Ke2ZrOLNZ/A9hVQ0rxGcQbDkrvsjlwwIz+Kes6T0jypS/0lualcqUE82Ul6y8rO/Z
-        rcm0/el+urqdAqpet6S9sIj19vLDm8tncNLKfFneW6uyFkTPSQ3rAF5s4G+b8Qb47ngxz5Ahm/Fa
-        HN1afpkj/xMHHzu3rstVezc3WVdgxMSBH6lM7Mc3503ghglgLje2Hd937J2GMj+VdVPm6jY3oFna
-        ktOisEAH0Lrf7DXcaG3LJRxaYGkQViCk2LLGq1xB3bd2U9GUrYCTl3QDQqbEcVdAKQs4pIIxqEJa
-        fvZGpG0K1H2n+OQdkvQdzgkUnBFVQyOq+n4yoeri5nzjOGES+jo2G4vuLU03pGDNtgESWnRbCqE3
-        kAVYcbUCrQxy1MI71yDjV2Wel3eoHnAnkHBwloC8MAAoB4Y7AB9RC5B8yYrSAsqPqRkoguJZTbKR
-        mHBh0g/w6fNyW82t95sdPCeHD80u3cAHE+JGRsR1I89VqAsXbs4BPCWLKEoSH9Q3wNNFoqHzz6Rp
-        rXVeLoFEyAJ5zlUIp05B27uy/tKgVEbeXSN32iCZbHg6HcTWHWs3FhDbgqtIcLxL4UxXPfR1V9B8
-        TMxEy5gwOswJadm1RrRbmB13N1RJFwLpPhcwmJOEMLSjE+Z/bEhrZRSO85YViDWAj1a10Mw7JNcK
-        ySrpp9KVU4vVNV1zMVmIZWasAc6tgXP/23oNMm5XkAoeaWXwAXSZ0Af0PmUtHwa044YtufK3YOcI
-        avURwTkCP0pwWNND3MuFQSWZ14TusRnPgh2hSgQHCL9hVTn3vCCONVQfo7wGqFVZd+SW2jUHfKiP
-        0nJdMC4GQP0hLAdzFpUSrVhTZkBOQERlvePErIBqBbCrIkJDhW4q8NrL0VBDvWFuXWNCs4QjuprR
-        ZhjpA/DSMy6oVnW5tV4DRMio9WvXftPcEpOnu47Zlk1lOI4N/wpBLy78H2L/xwRYa2FrYQNAKM7w
-        SwJ6C4/IZrSbL1687MWxEOpCjCh7Ey9OE8BNYh1rC3Je0caIn10z8OsGi0PcUMCoC18nQsbMXFPg
-        xt2gkO7IF8rxE2fqCmFiy5DnuyWgQ0QIyNSSlwEsAOpgwiDmnF1TsETpLbcK9jI4GFPvOalrhW3c
-        J4UG3Fb9dsp5vqehHEFjzXOdKNJQ7yXZbokqWMHSBJDwlQKWqsC2vyushq1hPTkyE+CrvW3QSXFa
-        kGWOtCwzAAn0y0QYhIE3IVnX2M9JBtxJUxWAL/TUg/kbUc03oloUHR7Gz3MU3HCEhLnlwI+rIx/K
-        mA1DMx/UV70GyfjKPbNeeWecMK984KEU7aman1RkygmuzdiKW5PIl/kOeDFjyJecfcFKK/MdPNDO
-        GTAy5dhMHnn5SAtYFRgZTjDSADTpCi2hWzpAugGd0Rw4uUU7MIdt25KvlE+xKG9p3u4GK7Hpqgrt
-        JjwDqH4pTAi2vSIA3Nh6q6KRyHZdRZg831CqbKhOiAx47hnO0ew8mFkgvuPrtnYY21kATIHNDTU7
-        +47eAU6oUKUAKGiAyTeIDkBMlDWQhJNSYg6CiBmND0nqzUiFjc/BlFT8mOyxRHwEvJWFEYnMzInY
-        PUohtoVbxPBOOHcCHZK4BEZrgaEBQHDbCxgQuRI5K6NNWrMltd6WdU5bDjHgvw2Xuegcs/dAj8Ca
-        gSlUsMvR7J5eJRDstBWGE3+NEzeimaGV4DhHiSa9m/gED4afO06gIdsVXQvLK7V/LoUQhf8+uzkH
-        TewnAX5G5usPIkyrTBlnOY560w0sgqMwkMPbakOlMGhovrJJBp8Z12+9IpvcZ0shPQgJZFyUIgpM
-        cCKV/DUMulE2wDu2AZIIRltgZmxcPffUPQg9/+b8l3cvfrv69fr56zl6ZCP7M9prc2kXaQ02rWUx
-        PcZoPV26IMrXUio+BK9clWsbsDluSa1AK62ZplgNxjjBzGQIksXDchFO/GLueItvg1tAEXoP2Cqj
-        2UhkjokS+WOicEdvUyqnWeuveoT0Sw4Oqw5Ev9+9e3dhXYIw325L6U9akVTgQTEyLK9njoZtAXGj
-        ElcOyHRJ37Kin2HkHgyyAp62Ndpnz8zOiJ2jeNCJHE8n0OGc11QcBBTtd5QWvZprKkQhLZoAeEYw
-        UoIWCJdII4+F4vwRSqOnUobwx7oqwUJXKPU0sI+7bjQ24KsRXrXfs7YD27/e2ZcZwC5Y1uU91zuj
-        SeZg4ewmEzSZhxlod73A1exS4SaRjnV/LmuMxUkDBYOiqqSCE4nBabASrT7C0VhZJ7ZHRHQUcaV4
-        OH5iy2/amUeaM54ZMHcXga+jzDwIfF3s49K6ZZxRuW233gmkgc4gHt7imhAsmwoPM15Q3MiEz8K6
-        xXkJ7zH3Gk+olajU2oIcSzdNS5kKTaKnJZsh6p1K99GpTyLf18nDvSRfdXijYCNrwkbLncJqae+K
-        wHltl/mEWEGkUqsm61L1sRwxlk3PvRnijdxEPW8a6BDYDt52DDq8RsYhqUALvZQcoX4JujI2svPE
-        Cdx728RNLWKyMfo45b1xH6TpP4EtPENwHKhu4ANsEQGwgB8dG36g24oHZ4DdykyGpAUnPsiERxgw
-        dB7mP0d7TI0xh2cGXcOJyeUGMDYpCuD6W5s/wXYWHhrXju+Gvk5JX4nTCuhFeABx4PHBU9YNxkRL
-        VSeVTqpfwgzmoPhuHyukzCBoFDtHhVQQxjrkeSW13V5WSftFoJOBQVhxqBA5mwx6cOIcVBHLCeLp
-        mcZcaCVmiN0Pgpk2uuKE8KunNzN5MgBbdtKvx4NPQIBGOPBBy4HNOARGwHo3CrZwiLwPt4yJmCg+
-        0peUNfmEiDrP/3fHTXxDL3zkBxoeBHgR+Xr+444eMlBzH0CVLuRD/88orWIHnLTXAzmllWpuKyQD
-        HFNnlHQnj+3jUYVv5pWPJ27SA60ZOrYb40NORZzqER2l4SicQg0ecLhhA2scB565j/KIZeknE7pN
-        ozhPrA19Q3A/ptkiDIObc/qGrejcCf1Ih2F//3A5xIP3rkZx/qZOCYWQmPBTER7e0FNKPZPlFu5p
-        lZQRbTiOz9aIQGYY31to4cJundJC+t4TQAu6wM/rAtZ2S7e0aA+860r+EgFC4dlcE55aaOGx5cki
-        iMAY/LEQa8Lm3Wm89CoAmxBS9eJqPd4vYS2WSGZ4UWRlCiLAVLSZmQCuUGMjdeHB4L1vkpDMTbRO
-        758Yz7IVrmxp9kvTftATGCEogXWsJVAYTMo1E8ZoDiQoaKZw6KCUlSMbKmkML2ENGGI+aUBdm3sV
-        fUPTIHkYu/KB546v07W6MGQDoqu1CDqQKgyQdUXan9UjfjIlbv6yq1rFHOfG+vcDVt8Q0bsTXhqg
-        h+ss5jLT75Ac683Iwa+ACYL2ZV2iK7poh/hU70HsNaZy6FzF2/aKdKsJotCmG34/ojCE9osJtF8g
-        tP9czV3PmUdz8fWUUi9ymqJY4sclX9lNK9yNY18zD7vDz5YUCllU1PCKknbkoXeTSCeMLrdz6xeZ
-        TMVIW++MCGKYmyJypSb5VAVNSzStF/MEqOLq86nQcyfm0PtfOVwobhlcQpmvAE6FDJhJpNjEWuD0
-        6LQo3wy6LxKdExZG9bUO2OuKoJHT9qbw3hCmOdd1BIBmi4ofJQolIhNbwkoicvfuNqzBlJ2GFk2f
-        3z9imjGxfiEZ2FCzk574R8PMwAyUH6Q34tjXTuLFduCFix+SxY/xInFDWxeNfwPK2MZcsiHXYwiB
-        5cNXGR3ialL0TELycLVHUmgI9a7DIe1bov3Z0TyxX8hqpaSMAgvqFFovnvYJjqRmRllPgRmGXywm
-        OXoTEB+6fmQD5Doi09+WGc2F43QDyqvl8XD00GxIgxKdpipdx0gAQx0HrOgHKtlqTNXP1ZSQk3Ld
-        mCHNELw+U8u3XScAbsRMrSgKbB25fhVUqMuc9oJ87CPkCbQAmQbXtGJDTtx+0YTB6nrKYNp0LZ5g
-        YUlR98xU+wWG7vppWFzGMWJPBzWfj/Io5NLV7K1b1nRc/sGT7zmFxtQ7Zker8YxfVH/f0xrQrmNo
-        6vg6ZfjuxfNf/yR/OsBGOnTAcVTGtpjWIzIG8g5dUkPKxN403BIQ+pn14q1F8nUJ53OjGC6eEs//
-        F8nYaQD1eCUZmBksiauP9HjC73UQ6eHOu70jsEZXDFXydR7OxVGV4L9InTffFJB+vBo0s0QCJzmZ
-        3+DYDt52LEhxNfEOPOA0vxjnlo1qJLh39GxEVpHWhkmmvTk4Oxqb+FeX1QxN7dk/Gp4IzIwZiuWQ
-        7iRj2l+48AAxq3m1ZOV8f9dROw+EEMjvDEOGRSvDjgA4BIDYs6aIx9aUB21FyP9ADyqJYW8I1jJ9
-        OcmL79+U14+Q6WYWjafPoFsua5E+xxMj9VihrjbHcpJY0ZbaZEhacWcg3JKV1T6ncl+3cmG9uGUZ
-        R2E8qRugB9AzLfNyvevTqKwhe22SiOrGinJ4Q623tK4nnmmdjpB69HHZz4GZyeTpJCFWTcWRqJpa
-        LDxbH/2WdXqCMmr2kofu/YPU00ZWPzQWzy8DkbBeS2w8plsYBSrd6lIt9dNmLhqHRAIzuyoKNc6a
-        a8d3IjsIPe8Hx/sRPRSu/T9a9DGpDOsRf82tAzSzZHR3p5BNys5JVY6nkqdr13SpMNVTZsqFZgaV
-        F/Ci1UOGCqKFzSuXHd9b2NoU2CvAEhxhDagULIACQ0TlEVgGE8i5IhElNpgWrtUUk4MIIvQwieKo
-        AgY4su0Ksxo7M0NpWrkopV7dcNOIu6QdnXJ43lfaDaljgM5SkIPrCzBJ4WAhQcYGweRIIjmxxK0X
-        fKQuu0atP1ASqt6crqcRQuuaO5XMSGZmJ4Xaqg0uBADongoK2UONItvnVvQgH9FHmXFw0oyqGRuW
-        H8Q4EsW1/KZcl5hhwdQ4h/Y0Gour0Az9J66+zKDZwfAi1uFxxtKS6tf7XQsiuugLBJr+KErBLS0o
-        tAX0Tg2ZbNJnpQxhSaFyuYdJHnFeKCAte7wgnyDckh1o4C0B/v3cwZlFFxQGDODgryi/TLIub3kp
-        jRSsqudfZd7uC1E3RlstwIs++RbQIXYC2t5oqwwTqEJVBSvBE9dzgkgbj3oDqA0JKauOhWEmgB+W
-        H/Xef1QhxxW1j4q6R5QtXXOPX85DWAolfV8lpeo00SVWPSJ8EpoZLUeDnX4caF3fvxVNB4cbLH2w
-        WzGVoARu4qh5cH9O0jomxnBGWtLQtjkTxCZVlYNoEJob6DjOyD8qQ9+S9Au9ZSnrVGbUqR/jaGho
-        Zp0ksU6IVhUOu5i7WlsYq+Ux4jl2jtQME8z68ve+tieF7wUkF+n/2L6DFWDZc2IdNPHYS1WF196m
-        L0E/pRv6DRiQx134AR4DdTMni9nZVbCO78fJzfmqALNLxpIdUWZzLNiALEWlx102Yzhqp72lO1qf
-        ll8843uc8G3EPmbWmnvQckH2DemWso7HP1LH876EUQZ35OYwlglmnGgMkKOfjq8ED2UPm6X+wSwO
-        PKT8JhR8FD3v8kQqzijFVfCWoYg/efqed3U9Nzd5Q+OYlT4tyIuTU4FfLBOpdujGznpLgXu+R8If
-        SJNhOw/4HdEM0JaqdQVqgelb9rVr6Jdvypt9bP+Jp4lnBV6irVce+XnXtcwVGGUXS/7qM9Rp80C6
-        K7qJMj8nqybjHX78tp04MZ828ToyM7UC90hrjnix0NlXcOhEkf1woFDbY2hcyGuwPekoOKzGhaU1
-        ynNbkKQIdGtZo8Shck1aEThWRLkiwn7NMyVQGj4UbHmKZhxmVliizw3ajx3xsbVhVJ6izTnrID+7
-        b3pgj5oeWGiCtiInG7AAAYMD9Cg69HJR4lzXINqUolpQFIxHu7ZkWvGcKA6B9wQeSU+zqXEeR2SY
-        izaN/qnoItRFVJ8x0adN4tZ9cynZQsrmxULIq2PSgLlPLwY7V0IMjG3iEeeglwd4JModIxe9X3CU
-        To+dxVCjDpEhhbsndK9XrG0Vwh/LBPhOlBIZRoISR8V5E+++k9hObDt429xNYn0JwiqXwHji2x/J
-        Vpm6ddgOoTf2hsplYes1kzxp7JPA8Xcr3UCi/8ck2Vel+W3OMjX9In5yn39khgmjIHgwd9UJF6Ht
-        BMeyqD+MeHXs4y9XKxs9NSiweeQbvTzYTHLLvTzj8Ms4Wim4GUT8PuNQwVuHNVqeggje06KAKX5V
-        HIxPHiWPzEy/5ED19fG7I6nUQ+Sug8sD8OylicTiAC6xQmsI5h0c/uNhYFUSUMBkYLHM/rn4nra5
-        BnKObJI5PaW8YUMqwA//nCkTXlHeF+Kk7Hpkt5zI0K6IH8wmJceqyvaVF3PrsmvLvo4dMc+QTyr3
-        dk0LWo/QzX9OSTfVsxQkJ+mn844+wikSmZoT2jDF0OwnWfyIVmlyLExR0HQoOJCJIQcRiRLTS++P
-        i4wrkNq5mi6iDXMN8a1RqIuXBJlZ7IZJt8eqMLxInx+HVcgNOoERTAAqy7H+5AzwGIheCZhBR1mY
-        I7N7ID59BdMhhQoPnth8MDOsvFBbBzwPglAnQy+t3hNub3SO9LwsKwG/hpjzSFP1klPX/EhhJEel
-        Wbtp0g3Ls5OS6fFkWxhaXZGnumsn2j0II9d23bl0/B+SUZwiWykZAM2zwZYm0pPG24cO/UXPMMEy
-        3fD8bp7zRqTrA6goGsmOnG3Vvl3sWF4p+ukaJlWqwkoXo/i+FhGOadb3IokfoqsThZHtesfoiroP
-        OwYIj/i2KgupBftUcGQ73np2KCMeGnQ1oyy4Yxk8EwoCeN8uu3r9zxJxYWbABovjjWIKGUqMAX7q
-        /CYfeGWwSK1s6BoM+0E5coNqH7pe8xZeY6wEVCzrDStU0TC0oRyTMQ5Ok/FYZpiZtbows1YXocbN
-        tPyMxirQzEt0DhXsnrN0f3B/tAk2dyj71luakFjvOpFAXHYvY4Atv9B9XamuMY4bhirJyooVGyX+
-        om3l9KwWefe9iWnGeIapmPEEdGBLyGxbg5EPn31syakh37u+qnNUD4Xwi6KTF/gs79KywRBiS5ag
-        LJqtKEkA7puAMYU+G7YlX0eFjK4IckzJ8xMjS4qBzbc4vDnsWBhWSJ0q9RGtwbQ9tn+qM1/2xBuZ
-        1xOfxRCohVXnOytnKzrtyC0jq9mu6d3Dil29mJBRdZA/TbewhRlW07QNgn9FduB78Q9xhG0rA8/W
-        qYOfKIgqzDTaZ9fbEnu0pPkyLvfs2wrvnZxKMpjoFasqieMoj7/qQGE+Hcb7rgSvhZli9ZxownoL
-        0KtVQRpgN3+R+LFIpD60BTDrRYY3R715jqXiKD4HlGM8YWCShuOotKpLteBM29/2PYBIgHakzcGq
-        S0k2t8CKmlu/XV8aUc00EfH/qYZUMzM+E08bD9yPDegDMIirT9CXAFZY3D205dQBOVas4exhr30Z
-        3tvjESXRuOyqvm8ontWig0dgg5Q07bZLqgYFEyUuf/25yyc52U8l9MzsMjdePOD+8BbuPPRCUBfi
-        tuOurqFpgnTLKqkNE6Sr8uGoB/uDJd7eQkl/uv5C1mu1Eu6J6mpjMxNNdDE5rCB1k8CZ+1gZqW1z
-        8vPQaZ7XX8FY0qs6CSareKNidK22RQ90ZbPf36Xb0BYIT9gCCa8tDk+3OFbT+mugDQZUavKZpoB2
-        GeaGUZHZjy0e6/KuYKTgjWa7aWav66hWVAummFpx/DRt+WIz7D/t26ocuCBJtBG/gUilasqnex/a
-        BRjybC1KaZtuycQLNoQmOOO12pfYD1A0020sIIpKrViFFnekaFRwsXgiH2Ns2MF48tYCDvfTgs4T
-        EJkRgNhjOS/poX9RQi7Z7PIIxIqjU4R4KOYjIsmciwyPnBnGD4OHHRiu7YS248BtGGXT1mYPxQbc
-        u5P3GL+qy8893Za7oWEHUOuAgc44ATOeUU6t9a7umrMhG1MyYbfFBMFtl7es4qGjti7XNeHtEpei
-        5LJpu+xYcaB7YjNiXb7Id/lBYsPEQGBDTRJ6ge03m/7LA8dc0b+nAY2EI8HiidHVJ1a2+FqJvpU1
-        vsREtLEeE23CwYAKJwltuqP82PTz2NT3NjXgJ6zroZnlRnNP35X8Eg8ur+xA0knajKildHA3oJl/
-        kmgPlTk/jtMMI1XuIk4epJyXuLbL21ac6G5rj6KNumDuELRkDQLislhT7i8SYXZ0eZK6b9gsYBwP
-        vavIRbHxP5BJLxmdn+T7qGlmPly5nqbrGPlcoYMIW1tH2HpMaz1cyeSPyQFFHxJZg7XAO9pXcBHf
-        yeGO2uTj6zr2rjiFWOrrbz7QumZ5fpL9+n4XfeLSFTq35tZr/h6evi3P+8cAQEMzwvM0teSHxpgW
-        3HwAmNfs4ziYgLPPvSRV3710UnVvTwOFhy9yU22u/Rv3ntrmch3dcZMl8tifvJRNwJSjJvoucANq
-        1CL+welqSyU3LC+bucWpCByA7z4DY/yZyCXlhrjRu2YQyWsaDV+RDOY8bJVlW3C1f03Oa4zRbvvC
-        MmUV5WoUheRGmslkzMwQL1GYcJ8h3Zc2OZ62mpjvOOxBW27FehrMvpAvr5Bxeu4FLeushG0aXqyE
-        2EW0vtP6Sce8qLJi030hG1Kr5oguFDHuqW0qEBPDFLowmshDoB6WCnteGOkst6HdtEVku+mhCRRZ
-        YRl/syW5SDHkYezpO9V0IQspIW1sZMJuaXYYoVDU9G/yFa57bH40nvPoApvEMP8tDAOdKBwXQ/lz
-        7BSrfWnYNb3fe5tGmVTAgkNZkvStiwxQgI+kKUXbF7UBicJyvyOe2aoM90+VJCWG4QpX+0LQodKZ
-        7ruTaavWUTxVhNV3DDu18KAihvz5+0DTHVofS0YabNiF0pg02AIanQubXbtBI3rwXcEOibdPfD1I
-        FVDbuv3OilTt6Xa0eRkzfV9HYviOk2keMeZlA51Ce+EEAboX5sE81qZo/wq6tGGt8vKdyZl88+G9
-        PL/K5SGKUfR1ONjNhL91UvGlynRZ5fyq2Wu/lx3bjvuyg4rQBhj33V7M5aDpG1Ci6MGkC/dhA2Vc
-        FDAu+Hw4V7vPjZTvdG2xLBRflFqsRQi3K8CM6VNaj9stf0xh9pMbLYmZ0RLrel6pee5YuOPrKPlO
-        Fhpvyi3F16NiRxiunrm7YUiy4+7ncl86O82XVBtY/QEKpfyGjvbGKDAxsz/CRNt9QpYzhfwtyJHu
-        2L4YXmOqqgdRozo0OQAVW5fdejO1UsBUlunmiqW89/qMSaf21flj2g9UR7hHFjIlhg0SgvBBU9gP
-        3OCBbl+ahpYpqUS7OYQmcNr+0/GXxKHykyUq8tXgwkCRfXv1LfvU3l9/qJ2OnzydWcTsDI5krOE8
-        x/FdO/Hj4Ick/NHx3DjQvqHx+rCB47SeoQW12/HsALYVry7+2r+OVKYGiJdXd3k6qQ4LFRf0/5KM
-        Ka4+bYDne1645hg2Tni4axHmvNoOZqBg1yLdyb3ev4509NarzdFuotYPnuMIxnj19cceNqPzIFUC
-        ahdDSwbe9LcY553t28soWlhJ8/lfzPRXSX2yh7k5k5pZI8H0VQv7eh4Hxg20b73C140Jy4Mbz72J
-        TTmddc16gIX7XEauWAivedh7oi8sukVEyZq+quQZacj4PdHiEf1rufcNcDWtZnyF6P8mvIXZN0BI
-        XfnOp7MZIi+ceT3VWWczEQnaj/MRbs8BGXSyTxTeg++Rh2/+mv129Qaubdq2ai5uzm/OScXmNG/o
-        LaP1PC23N+cyzR++EgS/OX//+vXFtRMnUeQtfDfxnTgOvf/GMS5TdHb9F2LCm/P7Lbqw5J/b7a7C
-        p+u+4p2ZYeoXQC205xA3YcNce1T1Lv/Uxg0EPYS89w9OHXQClz7ayU+/fMz0YUvAyOUAPJtd/DXL
-        8LXZFcG+5RcfP3oggs/g/84nvA+/wrcKckbxXBQ0rvPBcy8c9yIM/w1PxG/xtZnV7MKN4LC4XuiG
-        IIz+Pps1gIzgL92zGfAk8BfgcXgcmNdbMN3x45SKuej1sAEkohJTvjMWiFgxhon+EyrO/sbHdcsR
-        1zXA7O2YDVnTdEcW7Jy5nz79jdPsHS92WnagWS9cZ7E/G3wEHEB+4CGiqlvmrNkAyWFh+CdHx4cH
-        kByzSXmphs1gLh9nh0uBqe7pwsmS3c9BfM3Len1z/qC4m+EScrnpf8HzXl9fv8On4ENsfAqODnRC
-        wIXXX/LykHywbnhE9fCE25yY43M+rPpBegqBy2cDx/2W5JxqL+TWwjCAo/FKPxpe4rE5blsj5hZn
-        B4MBW8LEnLCCl5/BfryrsmtlM98xurqSZg3AzutRf5vrHk01vFMDStaDHg1yWvLpgof2M7uUk/rA
-        r49nMpBHDiAZZzrAL+KyZoD9UfjmDVfnmosed/2TnqOOu6IrC9SZhd8hNQZqj2naC5LxbOSY+4dI
-        qfMnF0mjp8hirA94eTwA19qJhRO2+l23XhfpfDxktQOdsWmV8fprf3/6+/8AOov5qIGMAAA=
+      string: '{"indexed":{"date-parts":[[2023,9,27]],"date-time":"2023-09-27T21:31:39Z","timestamp":1695850299681},"reference-count":107,"publisher":"Elsevier
+        BV","issue":"1","license":[{"start":{"date-parts":[[2020,1,1]],"date-time":"2020-01-01T00:00:00Z","timestamp":1577836800000},"content-version":"tdm","delay-in-days":0,"URL":"https:\/\/www.elsevier.com\/tdm\/userlicense\/1.0\/"},{"start":{"date-parts":[[2021,1,8]],"date-time":"2021-01-08T00:00:00Z","timestamp":1610064000000},"content-version":"vor","delay-in-days":373,"URL":"http:\/\/www.elsevier.com\/open-access\/userlicense\/1.0\/"}],"funder":[{"DOI":"10.13039\/100000002","name":"NIH","doi-asserted-by":"publisher","award":["MH54671","MH107396","U19
+        NS107616","U19 NS104590","NS090583"]},{"name":"NSF","award":["1545858"]},{"DOI":"10.13039\/100000893","name":"Simons
+        Foundation","doi-asserted-by":"publisher","award":["351109"]}],"content-domain":{"domain":["cell.com","elsevier.com","sciencedirect.com"],"crossmark-restriction":true},"published-print":{"date-parts":[[2020,1]]},"DOI":"10.1016\/j.neuron.2019.10.012","type":"journal-article","created":{"date-parts":[[2019,11,26]],"date-time":"2019-11-26T15:49:05Z","timestamp":1574783345000},"page":"138-149.e5","update-policy":"http:\/\/dx.doi.org\/10.1016\/elsevier_cm_policy","source":"Crossref","is-referenced-by-count":33,"title":"Routing
+        of Hippocampal Ripples to Subcortical Structures via the Lateral Septum","prefix":"10.1016","volume":"105","author":[{"given":"David","family":"Tingley","sequence":"first","affiliation":[]},{"given":"Gy\u00f6rgy","family":"Buzs\u00e1ki","sequence":"additional","affiliation":[]}],"member":"78","reference":[{"key":"10.1016\/j.neuron.2019.10.012_bib1","doi-asserted-by":"crossref","first-page":"522","DOI":"10.1016\/j.cell.2013.12.040","article-title":"Control
+        of stress-induced persistent anxiety by an extra-amygdala septohypothalamic
+        circuit","volume":"156","author":"Anthony","year":"2014","journal-title":"Cell"},{"key":"10.1016\/j.neuron.2019.10.012_bib2","article-title":"Lateral
+        septum neurotensin neurons link stress and anorexia","author":"Azevedo","year":"2019","journal-title":"bioArxiv"},{"key":"10.1016\/j.neuron.2019.10.012_bib3","first-page":"1","article-title":"CircStat:
+        a MATLAB toolbox for circular statistics","volume":"31","author":"Berens","year":"2009","journal-title":"J.\u00a0Stat.
+        Softw."},{"key":"10.1016\/j.neuron.2019.10.012_bib4","doi-asserted-by":"crossref","first-page":"436","DOI":"10.1038\/s41593-018-0330-y","article-title":"Dorsolateral
+        septum somatostatin interneurons gate mobility to calibrate context-specific
+        behavioral fear responses","volume":"22","author":"Besnard","year":"2019","journal-title":"Nat.
+        Neurosci."},{"key":"10.1016\/j.neuron.2019.10.012_bib5","doi-asserted-by":"crossref","first-page":"339","DOI":"10.1037\/h0059531","article-title":"Subcortical
+        mechanisms in emotional behavior: affective changes following septal forebrain
+        lesions in the albino rat","volume":"46","author":"Brady","year":"1953","journal-title":"J.\u00a0Comp.
+        Physiol. Psychol."},{"key":"10.1016\/j.neuron.2019.10.012_bib6","doi-asserted-by":"crossref","first-page":"1621","DOI":"10.1162\/089976699300016179","article-title":"Fast
+        global oscillations in networks of integrate-and-fire neurons with low firing
+        rates","volume":"11","author":"Brunel","year":"1999","journal-title":"Neural
+        Comput."},{"key":"10.1016\/j.neuron.2019.10.012_bib7","doi-asserted-by":"crossref","first-page":"415","DOI":"10.1152\/jn.01095.2002","article-title":"What
+        determines the frequency of fast network oscillations with irregular neural
+        discharges? I. Synaptic dynamics and excitation-inhibition balance","volume":"90","author":"Brunel","year":"2003","journal-title":"J.\u00a0Neurophysiol."},{"key":"10.1016\/j.neuron.2019.10.012_bib8","doi-asserted-by":"crossref","first-page":"1073","DOI":"10.1002\/hipo.22488","article-title":"Hippocampal
+        sharp wave-ripple: a cognitive biomarker for episodic memory and planning","volume":"25","author":"Buzs\u00e1ki","year":"2015","journal-title":"Hippocampus"},{"key":"10.1016\/j.neuron.2019.10.012_bib9","series-title":"The
+        Brain from Inside Out","author":"Buzs\u00e1ki","year":"2019"},{"key":"10.1016\/j.neuron.2019.10.012_bib10","doi-asserted-by":"crossref","first-page":"139","DOI":"10.1016\/0165-0173(83)90037-1","article-title":"Cellular
+        bases of hippocampal EEG in the behaving rat","volume":"287","author":"Buzs\u00e1ki","year":"1983","journal-title":"Brain
+        Res."},{"key":"10.1016\/j.neuron.2019.10.012_bib11","doi-asserted-by":"crossref","first-page":"147","DOI":"10.1038\/nn.2732","article-title":"Hippocampal
+        replay in the awake state: a potential substrate for memory consolidation
+        and retrieval","volume":"14","author":"Carr","year":"2011","journal-title":"Nat.
+        Neurosci."},{"key":"10.1016\/j.neuron.2019.10.012_bib12","doi-asserted-by":"crossref","first-page":"232","DOI":"10.1038\/nature21066","article-title":"Gamma
+        oscillations organize top-down signalling to hypothalamus and enable food
+        seeking","volume":"542","author":"Carus-Cadavieco","year":"2017","journal-title":"Nature"},{"key":"10.1016\/j.neuron.2019.10.012_bib13","doi-asserted-by":"crossref","first-page":"66","DOI":"10.1016\/j.physbeh.2013.03.016","article-title":"The
+        histaminergic H1, H2, and H3 receptors of the lateral septum differentially
+        mediate the anxiolytic-like effects of histamine on rats\u2019 defensive behaviors
+        in the elevated plus maze and novelty-induced suppression of feeding paradigm","volume":"116-117","author":"Chee","year":"2013","journal-title":"Physiol.
+        Behav."},{"key":"10.1016\/j.neuron.2019.10.012_bib14","doi-asserted-by":"crossref","first-page":"303","DOI":"10.1016\/j.neuron.2007.11.035","article-title":"New
+        experiences enhance coordinated neural activity in the hippocampus","volume":"57","author":"Cheng","year":"2008","journal-title":"Neuron"},{"key":"10.1016\/j.neuron.2019.10.012_bib15","doi-asserted-by":"crossref","first-page":"81","DOI":"10.1016\/j.neuroimage.2019.05.048","article-title":"A
+        better way to define and describe Morlet wavelets for time-frequency analysis","volume":"199","author":"Cohen","year":"2019","journal-title":"NeuroImage"},{"key":"10.1016\/j.neuron.2019.10.012_bib16","doi-asserted-by":"crossref","first-page":"100","DOI":"10.1016\/j.neuroscience.2012.01.004","article-title":"Regional
+        c-Fos and FosB\/\u0394FosB expression associated with chronic methamphetamine
+        self-administration and methamphetamine-seeking behavior in rats","volume":"206","author":"Cornish","year":"2012","journal-title":"Neuroscience"},{"key":"10.1016\/j.neuron.2019.10.012_bib17","doi-asserted-by":"crossref","first-page":"RC20","DOI":"10.1523\/JNEUROSCI.19-16-j0001.1999","article-title":"Fast
+        network oscillations in the hippocampal CA1 region of the behaving rat","volume":"19","author":"Csicsvari","year":"1999","journal-title":"J.\u00a0Neurosci."},{"key":"10.1016\/j.neuron.2019.10.012_bib18","doi-asserted-by":"crossref","first-page":"497","DOI":"10.1016\/j.neuron.2009.07.027","article-title":"Hippocampal
+        replay of extended experience","volume":"63","author":"Davidson","year":"2009","journal-title":"Neuron"},{"key":"10.1016\/j.neuron.2019.10.012_bib19","first-page":"11","article-title":"PyNN:
+        A common interface for neuronal network simulators","volume":"2","author":"Davison","year":"2009","journal-title":"Front.
+        Neuroinform."},{"key":"10.1016\/j.neuron.2019.10.012_bib20","doi-asserted-by":"crossref","first-page":"802","DOI":"10.1038\/nature06028","article-title":"Correlation
+        between neural spike trains increases with firing rate","volume":"448","author":"de
+        la Rocha","year":"2007","journal-title":"Nature"},{"key":"10.1016\/j.neuron.2019.10.012_bib21","series-title":"The
+        Hypothalamus-Pituitary-Adrenal Axis","author":"del Rey","year":"2007"},{"key":"10.1016\/j.neuron.2019.10.012_bib22","doi-asserted-by":"crossref","first-page":"1241","DOI":"10.1038\/nn1961","article-title":"Forward
+        and reverse hippocampal place-cell sequences during ripples","volume":"10","author":"Diba","year":"2007","journal-title":"Nat.
+        Neurosci."},{"key":"10.1016\/j.neuron.2019.10.012_bib23","doi-asserted-by":"crossref","first-page":"1743","DOI":"10.1038\/nn.4430","article-title":"A
+        viral strategy for targeting and manipulating interneurons across vertebrate
+        species","volume":"19","author":"Dimidschstein","year":"2016","journal-title":"Nat.
+        Neurosci."},{"key":"10.1016\/j.neuron.2019.10.012_bib24","doi-asserted-by":"crossref","first-page":"397","DOI":"10.1038\/nature09633","article-title":"Preplay
+        of future place cell sequences by hippocampal cellular assemblies","volume":"469","author":"Dragoi","year":"2011","journal-title":"Nature"},{"key":"10.1016\/j.neuron.2019.10.012_bib25","doi-asserted-by":"crossref","first-page":"6191","DOI":"10.1523\/JNEUROSCI.19-14-06191.1999","article-title":"Interactions
+        between hippocampus and medial septum during sharp waves and theta oscillation
+        in the behaving rat","volume":"19","author":"Dragoi","year":"1999","journal-title":"J.\u00a0Neurosci."},{"key":"10.1016\/j.neuron.2019.10.012_bib26","doi-asserted-by":"crossref","first-page":"145","DOI":"10.1016\/j.neuron.2006.02.023","article-title":"Temporal
+        encoding of place sequences by hippocampal cell assemblies","volume":"50","author":"Dragoi","year":"2006","journal-title":"Neuron"},{"key":"10.1016\/j.neuron.2019.10.012_bib27","doi-asserted-by":"crossref","first-page":"581","DOI":"10.1146\/annurev-neuro-072116-031538","article-title":"Replay
+        comes of age","volume":"40","author":"Foster","year":"2017","journal-title":"Annu.
+        Rev. Neurosci."},{"key":"10.1016\/j.neuron.2019.10.012_bib28","doi-asserted-by":"crossref","first-page":"680","DOI":"10.1038\/nature04587","article-title":"Reverse
+        replay of behavioural sequences in hippocampal place cells during the awake
+        state","volume":"440","author":"Foster","year":"2006","journal-title":"Nature"},{"key":"10.1016\/j.neuron.2019.10.012_bib29","doi-asserted-by":"crossref","first-page":"4344","DOI":"10.1152\/jn.00510.2004","article-title":"Contributions
+        of intrinsic membrane dynamics to fast network oscillations with irregular
+        neuronal discharges","volume":"94","author":"Geisler","year":"2005","journal-title":"J.\u00a0Neurophysiol."},{"key":"10.1016\/j.neuron.2019.10.012_bib30","doi-asserted-by":"crossref","first-page":"1634","DOI":"10.1038\/nn.4637","article-title":"Reactivations
+        of emotional memory in the hippocampus-amygdala system during sleep","volume":"20","author":"Girardeau","year":"2017","journal-title":"Nat.
+        Neurosci."},{"key":"10.1016\/j.neuron.2019.10.012_bib31","doi-asserted-by":"crossref","first-page":"866","DOI":"10.1523\/JNEUROSCI.1950-18.2018","article-title":"Hippocampal
+        reactivation extends for several hours following novel experience","volume":"39","author":"Giri","year":"2019","journal-title":"J.\u00a0Neurosci."},{"key":"10.1016\/j.neuron.2019.10.012_bib32","doi-asserted-by":"crossref","first-page":"1","DOI":"10.7554\/eLife.05360","article-title":"VTA
+        neurons coordinate with the hippocampal reactivation of spatial experience","volume":"4","author":"Gomperts","year":"2015","journal-title":"eLife"},{"key":"10.1016\/j.neuron.2019.10.012_bib33","doi-asserted-by":"crossref","first-page":"275","DOI":"10.1016\/j.ygcen.2013.09.022","article-title":"Involvements
+        of the lateral hypothalamic area in gastric motility and its regulation by
+        the lateral septum","volume":"194","author":"Gong","year":"2013","journal-title":"Gen.
+        Comp. Endocrinol."},{"key":"10.1016\/j.neuron.2019.10.012_bib34","doi-asserted-by":"crossref","first-page":"1440","DOI":"10.1126\/science.aad1935","article-title":"Diversity
+        in neural firing dynamics supports both rigid and learned hippocampal sequences","volume":"351","author":"Grosmark","year":"2016","journal-title":"Science"},{"key":"10.1016\/j.neuron.2019.10.012_bib35","doi-asserted-by":"crossref","first-page":"695","DOI":"10.1016\/j.neuron.2010.01.034","article-title":"Hippocampal
+        replay is not a simple function of experience","volume":"65","author":"Gupta","year":"2010","journal-title":"Neuron"},{"key":"10.1016\/j.neuron.2019.10.012_bib36","doi-asserted-by":"crossref","first-page":"110","DOI":"10.1152\/jn.00107.2014","article-title":"High-frequency
+        oscillations are prominent in the extended amygdala","volume":"112","author":"Haufler","year":"2014","journal-title":"J.\u00a0Neurophysiol."},{"key":"10.1016\/j.neuron.2019.10.012_bib37","doi-asserted-by":"crossref","first-page":"571","DOI":"10.1176\/ajp.120.6.571","article-title":"Electrical
+        self-stimulation of the brain in man","volume":"120","author":"Heath","year":"1963","journal-title":"Am.
+        J. Psychiatry"},{"key":"10.1016\/j.neuron.2019.10.012_bib38","doi-asserted-by":"crossref","first-page":"1179","DOI":"10.1162\/neco.1997.9.6.1179","article-title":"The
+        neuron simulation environment","volume":"9","author":"Hines","year":"1997","journal-title":"Neural
+        Comput."},{"key":"10.1016\/j.neuron.2019.10.012_bib39","doi-asserted-by":"crossref","first-page":"792","DOI":"10.1038\/nn.2328","article-title":"Sparse
+        temporal coding of elementary tactile features during active whisker sensation","volume":"12","author":"Jadhav","year":"2009","journal-title":"Nat.
+        Neurosci."},{"key":"10.1016\/j.neuron.2019.10.012_bib40","doi-asserted-by":"crossref","first-page":"339","DOI":"10.1016\/S0928-4257(97)87915-6","article-title":"Long-term
+        potentiation and long-term depression in the lateral septum in spatial working
+        and reference memory","volume":"90","author":"Jaffard","year":"1996","journal-title":"J.\u00a0Physiol.
+        Paris"},{"key":"10.1016\/j.neuron.2019.10.012_bib41","doi-asserted-by":"crossref","first-page":"7715","DOI":"10.1523\/JNEUROSCI.5136-13.2014","article-title":"Modeling
+        inheritance of phase precession in the hippocampal formation","volume":"34","author":"Jaramillo","year":"2014","journal-title":"J.\u00a0Neurosci."},{"key":"10.1016\/j.neuron.2019.10.012_bib42","doi-asserted-by":"crossref","first-page":"9","DOI":"10.1016\/0163-1047(93)90664-4","article-title":"On
+        the role of the hippocampus in learning and memory in the rat","volume":"60","author":"Jarrard","year":"1993","journal-title":"Behav.
+        Neural Biol."},{"key":"10.1016\/j.neuron.2019.10.012_bib43","doi-asserted-by":"crossref","first-page":"100","DOI":"10.1038\/nn1825","article-title":"Coordinated
+        memory replay in the visual cortex and hippocampus during sleep","volume":"10","author":"Ji","year":"2007","journal-title":"Nat.
+        Neurosci."},{"key":"10.1016\/j.neuron.2019.10.012_bib103","doi-asserted-by":"crossref","first-page":"2379","DOI":"10.1162\/NECO_a_00661","article-title":"High-dimensional
+        cluster analysis with the masked EM algorithm","volume":"26","author":"Kadir","year":"2014","journal-title":"Neural
+        Comput."},{"key":"10.1016\/j.neuron.2019.10.012_bib44","doi-asserted-by":"crossref","first-page":"913","DOI":"10.1038\/nn.2344","article-title":"Awake
+        replay of remote experiences in the hippocampus","volume":"12","author":"Karlsson","year":"2009","journal-title":"Nat.
+        Neurosci."},{"key":"10.1016\/j.neuron.2019.10.012_bib45","doi-asserted-by":"crossref","first-page":"4090","DOI":"10.1523\/JNEUROSCI.19-10-04090.1999","article-title":"Reactivation
+        of hippocampal cell assemblies: effects of behavioral state, experience, and
+        EEG dynamics","volume":"19","author":"Kudrimoti","year":"1999","journal-title":"J.\u00a0Neurosci."},{"key":"10.1016\/j.neuron.2019.10.012_bib46","doi-asserted-by":"crossref","first-page":"e1000173","DOI":"10.1371\/journal.pbio.1000173","article-title":"Hippocampus
+        leads ventral striatum in replay of place-reward information","volume":"7","author":"Lansink","year":"2009","journal-title":"PLoS
+        Biol."},{"key":"10.1016\/j.neuron.2019.10.012_bib47","doi-asserted-by":"crossref","first-page":"203","DOI":"10.1016\/j.bbr.2007.03.014","article-title":"Morphine
+        self-administration into the lateral septum depends on dopaminergic mechanisms:
+        Evidence from pharmacology and Fos neuroimaging","volume":"180","author":"Le
+        Merrer","year":"2007","journal-title":"Behav. Brain Res."},{"key":"10.1016\/j.neuron.2019.10.012_bib48","doi-asserted-by":"crossref","first-page":"213","DOI":"10.1038\/s41586-018-0772-0","article-title":"A
+        circuit from hippocampal CA2 to lateral septum disinhibits social aggression","volume":"564","author":"Leroy","year":"2018","journal-title":"Nature"},{"key":"10.1016\/j.neuron.2019.10.012_bib49","doi-asserted-by":"crossref","first-page":"655","DOI":"10.1016\/S0306-4522(02)00101-X","article-title":"Context-specific
+        spatial representations by lateral septal cells","volume":"112","author":"Leutgeb","year":"2002","journal-title":"Neuroscience"},{"key":"10.1016\/j.neuron.2019.10.012_bib50","doi-asserted-by":"crossref","first-page":"2478","DOI":"10.1038\/s41467-019-10327-5","article-title":"NREM
+        sleep in the rodent neocortex and hippocampus reflects excitable dynamics","volume":"10","author":"Levenstein","year":"2019","journal-title":"Nat.
+        Commun."},{"key":"10.1016\/j.neuron.2019.10.012_bib51","doi-asserted-by":"crossref","first-page":"36","DOI":"10.1016\/j.brs.2014.09.003","article-title":"Cortical
+        network switching: possible role of the lateral septum and cholinergic arousal","volume":"8","author":"Li","year":"2015","journal-title":"Brain
+        Stimul."},{"key":"10.1016\/j.neuron.2019.10.012_bib52","doi-asserted-by":"crossref","first-page":"547","DOI":"10.1038\/nature11618","article-title":"Hippocampal-cortical
+        interaction during periods of subcortical silence","volume":"491","author":"Logothetis","year":"2012","journal-title":"Nature"},{"key":"10.1016\/j.neuron.2019.10.012_bib53","doi-asserted-by":"crossref","first-page":"916","DOI":"10.1016\/j.psyneuen.2012.09.018","article-title":"Oxytocin
+        mediates rodent social memory within the lateral septum and the medial amygdala
+        depending on the relevance of the social stimulus: male juvenile versus female
+        adult conspecifics","volume":"38","author":"Lukas","year":"2013","journal-title":"Psychoneuroendocrinology"},{"key":"10.1016\/j.neuron.2019.10.012_bib54","doi-asserted-by":"crossref","first-page":"353","DOI":"10.1126\/science.1204622","article-title":"Linking
+        context with reward: a functional circuit from hippocampal CA3 to ventral
+        tegmental area","volume":"333","author":"Luo","year":"2011","journal-title":"Science"},{"key":"10.1016\/j.neuron.2019.10.012_bib55","doi-asserted-by":"crossref","first-page":"1","DOI":"10.7554\/eLife.38471","article-title":"Unsupervised
+        discovery of temporal sequences in high-dimensional datasets, with applications
+        to neuroscience","volume":"8","author":"Mackevicius","year":"2019","journal-title":"eLife"},{"key":"10.1016\/j.neuron.2019.10.012_bib56","doi-asserted-by":"crossref","first-page":"987","DOI":"10.1038\/npp.2017.144","article-title":"Dorsal
+        hippocampus drives context-induced cocaine seeking via inputs to Lateral Septum","volume":"43","author":"McGlinchey","year":"2018","journal-title":"Neuropsychopharmacology"},{"key":"10.1016\/j.neuron.2019.10.012_bib104","doi-asserted-by":"crossref","first-page":"8","DOI":"10.3389\/fninf.2013.00008","article-title":"The
+        neural decoding toolbox","volume":"7","author":"Meyers","year":"2013","journal-title":"Front
+        Neuroinform"},{"key":"10.1016\/j.neuron.2019.10.012_bib57","doi-asserted-by":"crossref","first-page":"1436","DOI":"10.1016\/j.cub.2019.03.048","article-title":"Post-learning
+        hippocampal replay selectively reinforces spatial memory for highly rewarded
+        locations","volume":"29","author":"Michon","year":"2019","journal-title":"Curr.
+        Biol."},{"key":"10.1016\/j.neuron.2019.10.012_bib58","doi-asserted-by":"crossref","first-page":"1174","DOI":"10.1038\/nn.2894","article-title":"Hippocampal
+        CA1 pyramidal cells form functionally distinct sublayers","volume":"14","author":"Mizuseki","year":"2011","journal-title":"Nat.
+        Neurosci."},{"key":"10.1016\/j.neuron.2019.10.012_bib59","doi-asserted-by":"crossref","first-page":"792","DOI":"10.1038\/nn.4291","article-title":"Coordinated
+        grid and place cell replay during rest","volume":"19","author":"\u00d3lafsd\u00f3ttir","year":"2016","journal-title":"Nat.
+        Neurosci."},{"key":"10.1016\/j.neuron.2019.10.012_bib60","doi-asserted-by":"crossref","first-page":"419","DOI":"10.1037\/h0058775","article-title":"Positive
+        reinforcement produced by electrical stimulation of septal area and other
+        regions of rat brain","volume":"47","author":"Olds","year":"1954","journal-title":"J.\u00a0Comp.
+        Physiol. Psychol."},{"key":"10.1016\/j.neuron.2019.10.012_bib61","doi-asserted-by":"crossref","first-page":"975","DOI":"10.1016\/j.neuron.2016.10.028","article-title":"Interplay
+        between hippocampal sharp-wave-ripple events and vicarious trial and error
+        behaviors in decision making","volume":"92","author":"Papale","year":"2016","journal-title":"Neuron"},{"key":"10.1016\/j.neuron.2019.10.012_bib62","doi-asserted-by":"crossref","first-page":"1715","DOI":"10.1038\/npp.2017.56","article-title":"Bidirectional
+        control of anxiety-related behaviors in mice: role of inputs arising from
+        the ventral hippocampus to the lateral septum and medial prefrontal cortex","volume":"42","author":"Parfitt","year":"2017","journal-title":"Neuropsychopharmacology"},{"key":"10.1016\/j.neuron.2019.10.012_bib63","doi-asserted-by":"crossref","first-page":"2907","DOI":"10.1523\/JNEUROSCI.09-08-02907.1989","article-title":"Influences
+        of hippocampal place cell firing in the awake state on the activity of these
+        cells during subsequent sleep episodes","volume":"9","author":"Pavlides","year":"1989","journal-title":"J.\u00a0Neurosci."},{"key":"10.1016\/j.neuron.2019.10.012_bib64","doi-asserted-by":"crossref","first-page":"6446","DOI":"10.1523\/JNEUROSCI.0575-04.2004","article-title":"The
+        ventral striatum in off-line processing: ensemble reactivation during sleep
+        and modulation by hippocampal ripples","volume":"24","author":"Pennartz","year":"2004","journal-title":"J.\u00a0Neurosci."},{"key":"10.1016\/j.neuron.2019.10.012_bib65","doi-asserted-by":"crossref","first-page":"919","DOI":"10.1038\/nn.2337","article-title":"Replay
+        of rule-learning related neural patterns in the prefrontal cortex during sleep","volume":"12","author":"Peyrache","year":"2009","journal-title":"Nat.
+        Neurosci."},{"key":"10.1016\/j.neuron.2019.10.012_bib66","article-title":"The
+        content of hippocampal \u201creplay\u201d","author":"Pfeiffer","year":"2017","journal-title":"Hippocampus"},{"key":"10.1016\/j.neuron.2019.10.012_bib67","doi-asserted-by":"crossref","first-page":"180","DOI":"10.1126\/science.aaa9633","article-title":"Place
+        cells. Autoassociative dynamics in the generation of sequences of hippocampal
+        place cells","volume":"349","author":"Pfeiffer","year":"2015","journal-title":"Science"},{"key":"10.1016\/j.neuron.2019.10.012_bib68","doi-asserted-by":"crossref","first-page":"115","DOI":"10.1016\/S0165-0173(97)00009-X","article-title":"Connections
+        of the rat lateral septal complex","volume":"24","author":"Risold","year":"1997","journal-title":"Brain
+        Res. Brain Res. Rev."},{"key":"10.1016\/j.neuron.2019.10.012_bib105","doi-asserted-by":"crossref","first-page":"634","DOI":"10.1038\/nn.4268","article-title":"Spike
+        sorting for large, dense electrode arrays","volume":"19","author":"Rossant","year":"2016","journal-title":"Nat.
+        Neurosci."},{"key":"10.1016\/j.neuron.2019.10.012_bib69","doi-asserted-by":"crossref","first-page":"251","DOI":"10.1038\/nn.4457","article-title":"A
+        cortical-hippocampal-cortical loop of information processing during memory
+        consolidation","volume":"20","author":"Rothschild","year":"2017","journal-title":"Nat.
+        Neurosci."},{"key":"10.1016\/j.neuron.2019.10.012_bib70","doi-asserted-by":"crossref","first-page":"4623","DOI":"10.1523\/JNEUROSCI.4561-11.2012","article-title":"A
+        septal-hypothalamic pathway drives orexin neurons, which is necessary for
+        conditioned cocaine preference","volume":"32","author":"Sartor","year":"2012","journal-title":"J.\u00a0Neurosci."},{"key":"10.1016\/j.neuron.2019.10.012_bib106","doi-asserted-by":"crossref","first-page":"11798","DOI":"10.1523\/JNEUROSCI.0656-12.2012","article-title":"The
+        spiking component of oscillatory extracellular potentials in the rat hippocampus","volume":"32","author":"Schomburg","year":"2012","journal-title":"J.\u00a0Neurosci."},{"key":"10.1016\/j.neuron.2019.10.012_bib71","doi-asserted-by":"crossref","first-page":"470","DOI":"10.1016\/j.neuron.2014.08.051","article-title":"Theta
+        phase segregation of input-specific gamma patterns in entorhinal-hippocampal
+        networks","volume":"84","author":"Schomburg","year":"2014","journal-title":"Neuron"},{"key":"10.1016\/j.neuron.2019.10.012_bib72","doi-asserted-by":"crossref","first-page":"752","DOI":"10.1038\/bjp.2008.295","article-title":"\u03b1(1)-adrenoceptors
+        in the lateral septal area modulate food intake behaviour in rats","volume":"155","author":"Scopinho","year":"2008","journal-title":"Br.
+        J. Pharmacol."},{"key":"10.1016\/j.neuron.2019.10.012_bib73","doi-asserted-by":"crossref","first-page":"185","DOI":"10.1002\/dmr.5610030109","article-title":"Neuronal
+        regulation of hepatic glucose metabolism in mammals","volume":"3","author":"Shimazu","year":"1987","journal-title":"Diabetes
+        Metab. Rev."},{"key":"10.1016\/j.neuron.2019.10.012_bib74","doi-asserted-by":"crossref","first-page":"195","DOI":"10.1016\/j.neuron.2017.11.040","article-title":"Drd3
+        signaling in the lateral septum mediates early life stress-induced social
+        dysfunction","volume":"97","author":"Shin","year":"2018","journal-title":"Neuron"},{"key":"10.1016\/j.neuron.2019.10.012_bib75","doi-asserted-by":"crossref","first-page":"7","DOI":"10.1016\/0166-4328(86)90042-2","article-title":"Deficits
+        in spatial-memory tasks following lesions of septal dopaminergic terminals
+        in the rat","volume":"19","author":"Simon","year":"1986","journal-title":"Behav.
+        Brain Res."},{"key":"10.1016\/j.neuron.2019.10.012_bib76","doi-asserted-by":"crossref","first-page":"2065","DOI":"10.1073\/pnas.0437938100","article-title":"Communication
+        between neocortex and hippocampus during sleep in rodents","volume":"100","author":"Sirota","year":"2003","journal-title":"Proc.
+        Natl. Acad. Sci. USA"},{"key":"10.1016\/j.neuron.2019.10.012_bib77","doi-asserted-by":"crossref","first-page":"2065","DOI":"10.1073\/pnas.0437938100","article-title":"Communication
+        between neocortex and hippocampus during sleep in rodents","volume":"100","author":"Sirota","year":"2003","journal-title":"Proc.
+        Natl. Acad. Sci. USA"},{"key":"10.1016\/j.neuron.2019.10.012_bib78","doi-asserted-by":"crossref","first-page":"926","DOI":"10.1016\/j.neuron.2018.04.015","article-title":"Cocaine
+        place conditioning strengthens location-specific hippocampal coupling to the
+        nucleus accumbens","volume":"98","author":"Sjulson","year":"2018","journal-title":"Neuron"},{"key":"10.1016\/j.neuron.2019.10.012_bib79","doi-asserted-by":"crossref","first-page":"1870","DOI":"10.1126\/science.271.5257.1870","article-title":"Replay
+        of neuronal firing sequences in rat hippocampus during sleep following spatial
+        experience","volume":"271","author":"Skaggs","year":"1996","journal-title":"Science"},{"key":"10.1016\/j.neuron.2019.10.012_bib80","doi-asserted-by":"crossref","first-page":"538","DOI":"10.1152\/jn.1940.3.6.538","article-title":"Forebrain
+        and rage reactions","volume":"3","author":"Spiegel","year":"1940","journal-title":"J.\u00a0Neurophysiol."},{"key":"10.1016\/j.neuron.2019.10.012_bib81","doi-asserted-by":"crossref","first-page":"450","DOI":"10.1016\/j.neuron.2019.01.052","article-title":"Hippocampal
+        reactivation of random trajectories resembling brownian diffusion","volume":"102","author":"Stella","year":"2019","journal-title":"Neuron"},{"key":"10.1016\/j.neuron.2019.10.012_bib82","doi-asserted-by":"crossref","first-page":"303","DOI":"10.1126\/science.49928","article-title":"Hippocampo-hypothalamic
+        connections: origin in subicular cortex, not Ammon\u2019s horn","volume":"189","author":"Swanson","year":"1975","journal-title":"Science"},{"key":"10.1016\/j.neuron.2019.10.012_bib83","doi-asserted-by":"crossref","first-page":"621","DOI":"10.1002\/cne.901860408","article-title":"The
+        connections of the septal region in the rat","volume":"186","author":"Swanson","year":"1979","journal-title":"J.\u00a0Comp.
+        Neurol."},{"key":"10.1016\/j.neuron.2019.10.012_bib84","doi-asserted-by":"crossref","first-page":"548","DOI":"10.1523\/JNEUROSCI.01-05-00548.1981","article-title":"Evidence
+        for collateral projections by neurons in Ammon\u2019s horn, the dentate gyrus,
+        and the subiculum: a multiple retrograde labeling study in the rat","volume":"1","author":"Swanson","year":"1981","journal-title":"J.\u00a0Neurosci."},{"key":"10.1016\/j.neuron.2019.10.012_bib85","doi-asserted-by":"crossref","first-page":"10188","DOI":"10.1038\/ncomms10188","article-title":"An
+        excitatory ventral hippocampus to lateral septum circuit that suppresses feeding","volume":"6","author":"Sweeney","year":"2015","journal-title":"Nat.
+        Commun."},{"key":"10.1016\/j.neuron.2019.10.012_bib86","doi-asserted-by":"crossref","first-page":"11185","DOI":"10.1523\/JNEUROSCI.2042-16.2016","article-title":"An
+        inhibitory septum to lateral hypothalamus circuit that suppresses feeding","volume":"36","author":"Sweeney","year":"2016","journal-title":"J.\u00a0Neurosci."},{"key":"10.1016\/j.neuron.2019.10.012_bib87","doi-asserted-by":"crossref","first-page":"11789","DOI":"10.1523\/JNEUROSCI.2291-17.2017","article-title":"Hippocampal-prefrontal
+        reactivation during learning is stronger in awake compared with sleep states","volume":"37","author":"Tang","year":"2017","journal-title":"J.\u00a0Neurosci."},{"key":"10.1016\/j.neuron.2019.10.012_bib88","doi-asserted-by":"crossref","first-page":"R124","DOI":"10.1152\/ajpregu.00460.2015","article-title":"Role
+        of lateral septum glucagon-like peptide 1 receptors in food intake","volume":"311","author":"Terrill","year":"2016","journal-title":"Am.
+        J. Physiol. Regul. Integr. Comp. Physiol."},{"key":"10.1016\/j.neuron.2019.10.012_bib89","doi-asserted-by":"crossref","first-page":"1229","DOI":"10.1016\/j.neuron.2018.04.028","article-title":"Transformation
+        of a spatial map across the hippocampal-lateral septal circuit","volume":"98","author":"Tingley","year":"2018","journal-title":"Neuron"},{"key":"10.1016\/j.neuron.2019.10.012_bib107","article-title":"On
+        the methods for reactivation and replay analysis","author":"Tingley","year":"2019","journal-title":"Philos.
+        Trans. R. Soc. B Biol. Sci."},{"key":"10.1016\/j.neuron.2019.10.012_bib90","series-title":"The
+        Radon Transform - Theory and Implementation","author":"Toft","year":"1996"},{"key":"10.1016\/j.neuron.2019.10.012_bib91","doi-asserted-by":"crossref","first-page":"299","DOI":"10.3389\/fnins.2014.00299","article-title":"Neuroanatomy
+        and sex differences of the lordosis-inhibiting system in the lateral septum","volume":"8","author":"Tsukahara","year":"2014","journal-title":"Front.
+        Neurosci."},{"key":"10.1016\/j.neuron.2019.10.012_bib92","doi-asserted-by":"crossref","first-page":"156","DOI":"10.1159\/000122562","article-title":"Pituitary
+        adrenal function after small and large lesions in the lateral septal area
+        in food-deprived rats","volume":"16","author":"Usher","year":"1974","journal-title":"Neuroendocrinology"},{"key":"10.1016\/j.neuron.2019.10.012_bib93","doi-asserted-by":"crossref","first-page":"2554","DOI":"10.1016\/j.psyneuen.2013.06.002","article-title":"Sex-specific
+        modulation of juvenile social play by vasopressin","volume":"38","author":"Veenema","year":"2013","journal-title":"Psychoneuroendocrinology"},{"key":"10.1016\/j.neuron.2019.10.012_bib94","doi-asserted-by":"crossref","first-page":"112","DOI":"10.1016\/j.neuroimage.2010.01.073","article-title":"The
+        pairwise phase consistency: a bias-free measure of rhythmic neuronal synchronization","volume":"51","author":"Vinck","year":"2010","journal-title":"Neuroimage"},{"key":"10.1016\/j.neuron.2019.10.012_bib95","doi-asserted-by":"crossref","first-page":"875","DOI":"10.1037\/0735-7044.112.4.875","article-title":"Opposite
+        effects of lateral septal LTP and lateral septal lesions on contextual fear
+        conditioning in mice","volume":"112","author":"Vouimba","year":"1998","journal-title":"Behav.
+        Neurosci."},{"key":"10.1016\/j.neuron.2019.10.012_bib96","doi-asserted-by":"crossref","first-page":"10663","DOI":"10.1523\/JNEUROSCI.1042-16.2016","article-title":"Coordinated
+        interaction between hippocampal sharp-wave ripples and anterior cingulate
+        unit activity","volume":"36","author":"Wang","year":"2016","journal-title":"J.\u00a0Neurosci."},{"key":"10.1016\/j.neuron.2019.10.012_bib97","doi-asserted-by":"crossref","first-page":"839","DOI":"10.1016\/j.neuron.2016.03.036","article-title":"Network
+        homeostasis and state dynamics of neocortical sleep","volume":"90","author":"Watson","year":"2016","journal-title":"Neuron"},{"key":"10.1016\/j.neuron.2019.10.012_bib98","doi-asserted-by":"crossref","first-page":"593","DOI":"10.1016\/j.cub.2015.12.065","article-title":"Effective
+        modulation of male aggression through lateral septum to medial hypothalamus
+        projection","volume":"26","author":"Wong","year":"2016","journal-title":"Curr.
+        Biol."},{"key":"10.1016\/j.neuron.2019.10.012_bib99","doi-asserted-by":"crossref","first-page":"6459","DOI":"10.1523\/JNEUROSCI.3414-13.2014","article-title":"Hippocampal
+        replay captures the unique topological structure of a novel environment","volume":"34","author":"Wu","year":"2014","journal-title":"J.\u00a0Neurosci."},{"key":"10.1016\/j.neuron.2019.10.012_bib100","doi-asserted-by":"crossref","first-page":"883","DOI":"10.1016\/0031-9384(95)02184-1","article-title":"Stimulation
+        of the lateral septum attenuates immobilization-induced stress ulcers","volume":"59","author":"Yadin","year":"1996","journal-title":"Physiol.
+        Behav."},{"key":"10.1016\/j.neuron.2019.10.012_bib101","doi-asserted-by":"crossref","first-page":"30","DOI":"10.1523\/JNEUROSCI.15-01-00030.1995","article-title":"Sharp
+        wave-associated high-frequency oscillation (200\u00a0Hz) in the intact hippocampus:
+        network and intracellular mechanisms","volume":"15","author":"Ylinen","year":"1995","journal-title":"J.\u00a0Neurosci."},{"key":"10.1016\/j.neuron.2019.10.012_bib102","doi-asserted-by":"crossref","first-page":"445","DOI":"10.1038\/npp.2009.149","article-title":"Fos
+        after single and repeated self-administration of cocaine and saline in the
+        rat: emphasis on the Basal forebrain and recalibration of expression","volume":"35","author":"Zahm","year":"2010","journal-title":"Neuropsychopharmacology"}],"container-title":"Neuron","original-title":[],"language":"en","link":[{"URL":"https:\/\/api.elsevier.com\/content\/article\/PII:S0896627319308852?httpAccept=text\/xml","content-type":"text\/xml","content-version":"vor","intended-application":"text-mining"},{"URL":"https:\/\/api.elsevier.com\/content\/article\/PII:S0896627319308852?httpAccept=text\/plain","content-type":"text\/plain","content-version":"vor","intended-application":"text-mining"}],"deposited":{"date-parts":[[2021,1,10]],"date-time":"2021-01-10T21:01:55Z","timestamp":1610312515000},"score":1,"resource":{"primary":{"URL":"https:\/\/linkinghub.elsevier.com\/retrieve\/pii\/S0896627319308852"}},"subtitle":[],"short-title":[],"issued":{"date-parts":[[2020,1]]},"references-count":107,"journal-issue":{"issue":"1","published-print":{"date-parts":[[2020,1]]}},"alternative-id":["S0896627319308852"],"URL":"http:\/\/dx.doi.org\/10.1016\/j.neuron.2019.10.012","relation":{},"ISSN":["0896-6273"],"subject":["General
+        Neuroscience"],"container-title-short":"Neuron","published":{"date-parts":[[2020,1]]},"assertion":[{"value":"Elsevier","name":"publisher","label":"This
+        article is maintained by"},{"value":"Routing of Hippocampal Ripples to Subcortical
+        Structures via the Lateral Septum","name":"articletitle","label":"Article
+        Title"},{"value":"Neuron","name":"journaltitle","label":"Journal Title"},{"value":"https:\/\/doi.org\/10.1016\/j.neuron.2019.10.012","name":"articlelink","label":"CrossRef
+        DOI link to publisher maintained version"},{"value":"article","name":"content_type","label":"Content
+        Type"},{"value":"\u00a9 2019 Elsevier Inc.","name":"copyright","label":"Copyright"}]}'
     headers:
       access-control-allow-headers:
       - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
@@ -238,11 +291,11 @@ interactions:
       content-encoding:
       - gzip
       content-length:
-      - '8831'
+      - '8830'
       content-type:
       - application/json
       date:
-      - Tue, 25 Apr 2023 19:11:46 GMT
+      - Mon, 16 Oct 2023 18:46:13 GMT
       link:
       - <http://dx.doi.org/10.1016/j.neuron.2019.10.012>; rel="canonical", <https://api.elsevier.com/content/article/PII:S0896627319308852?httpAccept=text/xml>;
         version="vor"; type="text/xml"; rel="item", <https://api.elsevier.com/content/article/PII:S0896627319308852?httpAccept=text/plain>;

--- a/dandi/cli/tests/test_service_scripts.py
+++ b/dandi/cli/tests/test_service_scripts.py
@@ -5,6 +5,7 @@ import json
 import os
 from pathlib import Path
 import re
+import sys
 
 import anys
 from click.testing import CliRunner
@@ -48,6 +49,10 @@ def record_only_doi_requests(request):
         return None
 
 
+@pytest.mark.xfail(
+    sys.version_info < (3, 10),
+    reason="Some difference in VCR tape: https://github.com/dandi/dandi-cli/pull/1337",
+)
 @pytest.mark.parametrize(
     "doi,name",
     [


### PR DESCRIPTION
I believe that somehow some upgrade among

```
❯ wdiff -3 /tmp/f1 /tmp/f2

====================================================================== [-06/github/cron/20231006T060312/0c1d4a0/Tests/5197/test-]{+07/github/cron/20231007T060245/0c1d4a0/Tests/5198/test+} ======================================================================
 [-dependencies.txt:2023-10-06T06:05:18.6948668Z-] {+dependencies.txt:2023-10-07T06:04:51.1091526Z+}
======================================================================
 [-boto3-1.28.61 botocore-1.31.61-] {+boto3-1.28.62 botocore-1.31.62+}
======================================================================
 [-entrypoints-0.4-]
======================================================================
 [-numcodecs-0.11.0-] {+numcodecs-0.12.0+}
======================================================================
 [-urllib3-1.26.17-] {+urllib3-2.0.6+}
======================================================================
```

(so likely urllib3) lead to drastically different behavior which triggered VCR to try to not reuse prior tape but then subsequent dialog started to fail -- we got no json.  As you can see in the diff we observe that now we do get json (as requested) recorded although previously it was some "binary".


Closes #1332 although I am afraid that we might need to really identify the library lead to breakage and then set explicit minimal version of tests so we have consistent testing across distributions etc

PS `pre-commit` refused to commit since it kept codespell'ing the .vcr.yaml files although ignored within codespell config of `setup.cfg`. I guess codespell does not consult that `skip` config if explicit file names are given.  Might need to add those to excludes of pre-commit