### PR TITLE
Add missing term in ETA calculation

### DIFF
--- a/dandi/download.py
+++ b/dandi/download.py
@@ -444,7 +444,7 @@ class PYOUTHelper:
             and self.items_summary.size != 0
         ):
             dt = time.time() - self.items_summary.t0
-            more_time = dt / r if r != 1 else 0
+            more_time = (dt / r) - dt if r != 1 else 0
             more_time_str = humanize.naturaldelta(more_time)
             if not self.it.finished:
                 more_time_str += "<"

--- a/dandi/tests/test_download.py
+++ b/dandi/tests/test_download.py
@@ -934,7 +934,7 @@ def test_pyouthelper_time_remaining_1339():
         helper.items_summary.t0 = time.time() - (100 - (10 - i))
         done = helper.agg_done(iter([100 - (10 - i)]))
         if i == 9:
-            assert done[-1] == f"ETA: a second<"
+            assert done[-1] == "ETA: a second<"
         elif i == 10:
             # once done, dont print ETA
             assert len(done) == 2


### PR DESCRIPTION
Fix https://github.com/dandi/dandi-cli/issues/1339

Add in missing -dt term so ETA counts down correctly :)

to quote @NickleDave : "I have changed but one line, yet achieved enlightenment in the path I took to change it" 
https://neuromatch.social/@nicholdav/111297136870307787
(davey nickles i hereby see your one line PR and raise you one line PR with 40 line test)
