### PR TITLE
Expose number of jobs to organize

### DIFF
--- a/dandi/cli/cmd_organize.py
+++ b/dandi/cli/cmd_organize.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
-
 import click
 
 from .base import dandiset_path_option, devel_debug_option, map_to_click_exceptions

--- a/dandi/cli/cmd_organize.py
+++ b/dandi/cli/cmd_organize.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Optional
+
 import click
 
 from .base import dandiset_path_option, devel_debug_option, map_to_click_exceptions
@@ -59,6 +61,13 @@ from ..consts import dandi_layout_fields, file_operation_modes
     ),
 )
 @click.argument("paths", nargs=-1, type=click.Path(exists=True))
+@click.option(
+    "--number-of-jobs",
+    "number_of_jobs",
+    type=int,
+    default=None,
+    help="The number of jobs to use during organization.",
+)
 @devel_debug_option()
 @map_to_click_exceptions
 def organize(
@@ -70,6 +79,7 @@ def organize(
     devel_debug=False,
     update_external_file_paths=False,
     media_files_mode=None,
+    number_of_jobs: Optional[int] = None,
 ):
     """(Re)organize files according to the metadata.
 
@@ -115,4 +125,5 @@ def organize(
         update_external_file_paths=update_external_file_paths,
         media_files_mode=media_files_mode,
         required_fields=required_fields,
+        number_of_jobs=number_of_jobs,
     )

--- a/dandi/cli/cmd_organize.py
+++ b/dandi/cli/cmd_organize.py
@@ -73,7 +73,7 @@ def organize(
     devel_debug=False,
     update_external_file_paths=False,
     media_files_mode=None,
-    jobs: Optional[int] = None,
+    jobs=None,
 ):
     """(Re)organize files according to the metadata.
 

--- a/dandi/cli/cmd_organize.py
+++ b/dandi/cli/cmd_organize.py
@@ -61,13 +61,7 @@ from ..consts import dandi_layout_fields, file_operation_modes
     ),
 )
 @click.argument("paths", nargs=-1, type=click.Path(exists=True))
-@click.option(
-    "--number-of-jobs",
-    "number_of_jobs",
-    type=int,
-    default=None,
-    help="The number of jobs to use during organization.",
-)
+@click.option("-J", "--jobs", type=int, help="Number of jobs during organization")
 @devel_debug_option()
 @map_to_click_exceptions
 def organize(

--- a/dandi/cli/cmd_organize.py
+++ b/dandi/cli/cmd_organize.py
@@ -73,7 +73,7 @@ def organize(
     devel_debug=False,
     update_external_file_paths=False,
     media_files_mode=None,
-    number_of_jobs: Optional[int] = None,
+    jobs: Optional[int] = None,
 ):
     """(Re)organize files according to the metadata.
 
@@ -119,5 +119,5 @@ def organize(
         update_external_file_paths=update_external_file_paths,
         media_files_mode=media_files_mode,
         required_fields=required_fields,
-        number_of_jobs=number_of_jobs,
+        jobs=jobs,
     )

--- a/dandi/organize.py
+++ b/dandi/organize.py
@@ -721,7 +721,7 @@ def organize(
     update_external_file_paths=False,
     media_files_mode=None,
     required_fields=None,
-    jobs: Optional[int] = None,
+    jobs=None,
 ):
     in_place = False  # If we deduce that we are organizing in-place
     jobs = jobs or -1

--- a/dandi/organize.py
+++ b/dandi/organize.py
@@ -721,10 +721,10 @@ def organize(
     update_external_file_paths=False,
     media_files_mode=None,
     required_fields=None,
-    number_of_jobs: Optional[int] = None,
+    jobs: Optional[int] = None,
 ):
     in_place = False  # If we deduce that we are organizing in-place
-    number_of_jobs = number_of_jobs or -1
+    jobs= jobs or -1
 
     # will come handy when dry becomes proper separate option
     def dry_print(msg):
@@ -814,12 +814,12 @@ def organize(
             meta["path"] = path
             return meta
 
-        if not devel_debug and number_of_jobs != 1:  # Do not use joblib at all if number_of_jobs=1
+        if not devel_debug and jobs != 1:  # Do not use joblib at all if number_of_jobs=1
             # Note: It is Python (pynwb) intensive, not IO, so ATM there is little
             # to no benefit from Parallel without using multiproc!  But that would
             # complicate progress bar indication... TODO
             metadata = list(
-                Parallel(n_jobs=number_of_jobs, verbose=10)(
+                Parallel(n_jobs=jobs, verbose=10)(
                     delayed(_get_metadata)(path) for path in paths
                 )
             )

--- a/dandi/organize.py
+++ b/dandi/organize.py
@@ -724,7 +724,7 @@ def organize(
     jobs: Optional[int] = None,
 ):
     in_place = False  # If we deduce that we are organizing in-place
-    jobs= jobs or -1
+    jobs = jobs or -1
 
     # will come handy when dry becomes proper separate option
     def dry_print(msg):

--- a/dandi/organize.py
+++ b/dandi/organize.py
@@ -721,8 +721,10 @@ def organize(
     update_external_file_paths=False,
     media_files_mode=None,
     required_fields=None,
+    number_of_jobs: Optional[int] = None,
 ):
     in_place = False  # If we deduce that we are organizing in-place
+    number_of_jobs = number_of_jobs or -1
 
     # will come handy when dry becomes proper separate option
     def dry_print(msg):
@@ -812,12 +814,12 @@ def organize(
             meta["path"] = path
             return meta
 
-        if not devel_debug:
+        if not devel_debug and number_of_jobs != 1:  # Do not use joblib at all if number_of_jobs=1
             # Note: It is Python (pynwb) intensive, not IO, so ATM there is little
             # to no benefit from Parallel without using multiproc!  But that would
             # complicate progress bar indication... TODO
             metadata = list(
-                Parallel(n_jobs=-1, verbose=10)(
+                Parallel(n_jobs=number_of_jobs, verbose=10)(
                     delayed(_get_metadata)(path) for path in paths
                 )
             )

--- a/dandi/tests/test_organize.py
+++ b/dandi/tests/test_organize.py
@@ -387,3 +387,23 @@ def test_organize_required_field(simple2_nwb: Path, tmp_path: Path) -> None:
         tmp_path / dandiset_metadata_file,
         tmp_path / "sub-mouse001" / "sub-mouse001_ses-session-id1.nwb",
     ]
+
+
+def test_organize_single_job(simple2_nwb: Path, tmp_path: Path) -> None:
+    (tmp_path / dandiset_metadata_file).write_text("{}\n")
+    r = CliRunner().invoke(
+        organize,
+        [
+            "-f",
+            "copy",
+            "--dandiset-path",
+            str(tmp_path),
+            "--jobs",
+            1,
+        ],
+    )
+    assert r.exit_code == 0
+    assert list_paths(tmp_path) == [
+        tmp_path / dandiset_metadata_file,
+        tmp_path / "sub-mouse001" / "sub-mouse001_ses-session-id1.nwb",
+    ]

--- a/dandi/tests/test_organize.py
+++ b/dandi/tests/test_organize.py
@@ -399,7 +399,7 @@ def test_organize_single_job(simple2_nwb: Path, tmp_path: Path) -> None:
             "--dandiset-path",
             str(tmp_path),
             "--jobs",
-            1,
+            "1",
         ],
     )
     assert r.exit_code == 0

--- a/dandi/tests/test_organize.py
+++ b/dandi/tests/test_organize.py
@@ -110,7 +110,7 @@ if not on_windows:
 
 @pytest.mark.integration
 @pytest.mark.parametrize("mode", no_move_modes)
-@pytest.mark.parametrize("jobs", (1, None))
+@pytest.mark.parametrize("jobs", (1, -1))
 def test_organize_nwb_test_data(nwb_test_data: Path, tmp_path: Path, mode: str, jobs: int) -> None:
     outdir = tmp_path / "organized"
 

--- a/dandi/tests/test_organize.py
+++ b/dandi/tests/test_organize.py
@@ -394,8 +394,6 @@ def test_organize_single_job(simple2_nwb: Path, tmp_path: Path) -> None:
     r = CliRunner().invoke(
         organize,
         [
-            "-f",
-            "copy",
             "--dandiset-path",
             str(tmp_path),
             "--jobs",

--- a/dandi/tests/test_organize.py
+++ b/dandi/tests/test_organize.py
@@ -110,7 +110,8 @@ if not on_windows:
 
 @pytest.mark.integration
 @pytest.mark.parametrize("mode", no_move_modes)
-def test_organize_nwb_test_data(nwb_test_data: Path, tmp_path: Path, mode: str) -> None:
+@pytest.mark.parametrize("jobs", (1, None))
+def test_organize_nwb_test_data(nwb_test_data: Path, tmp_path: Path, mode: str, jobs: int) -> None:
     outdir = tmp_path / "organized"
 
     relative = False
@@ -152,7 +153,7 @@ def test_organize_nwb_test_data(nwb_test_data: Path, tmp_path: Path, mode: str) 
 
     input_files = nwb_test_data / "v2.0.1"
 
-    cmd = ["-d", str(outdir), "--files-mode", mode, str(input_files)]
+    cmd = ["-d", str(outdir), "--files-mode", mode, str(input_files), "--jobs", str(jobs)]
     r = CliRunner().invoke(organize, cmd)
 
     # with @map_to_click_exceptions we loose original str of message somehow
@@ -380,24 +381,6 @@ def test_organize_required_field(simple2_nwb: Path, tmp_path: Path) -> None:
             str(tmp_path),
             "--required-field=session_id",
             str(simple2_nwb),
-        ],
-    )
-    assert r.exit_code == 0
-    assert list_paths(tmp_path) == [
-        tmp_path / dandiset_metadata_file,
-        tmp_path / "sub-mouse001" / "sub-mouse001_ses-session-id1.nwb",
-    ]
-
-
-def test_organize_single_job(simple2_nwb: Path, tmp_path: Path) -> None:
-    (tmp_path / dandiset_metadata_file).write_text("{}\n")
-    r = CliRunner().invoke(
-        organize,
-        [
-            "--dandiset-path",
-            str(tmp_path),
-            "--jobs",
-            "1",
         ],
     )
     assert r.exit_code == 0


### PR DESCRIPTION
Recent usage of the DANDI API in the NWB GUIDE revealed a sporadic `joblib` issue that results in segmentation faults - no clue what actually causes it for some users, but the best solution we have for now is to just expose job usage directly

Where should tests for this go?