### PR TITLE
Don't use buggy version of `responses`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -87,7 +87,7 @@ test =
     pytest-cov
     pytest-mock
     pytest-rerunfailures
-    responses
+    responses != 0.24.0
     vcrpy
 tools=
     boto3


### PR DESCRIPTION
The tests have been failing for the past four days due to [an issue with the latest version of `responses`](https://github.com/getsentry/responses/issues/689).  This PR excludes the version in question from use.