### PR TITLE
Move words ignored by codespell from `.codespellignore` to `setup.cfg`

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -1,4 +1,0 @@
-        ("fo", "foo/bar", "foo/bar"),
-        ("foo/ba", "foo/bar/baz/quux", "bar/baz/quux"),
-            filename="/bu",
-                "^File /bu: nwb_version 'NWB-2.1.0' starts with NWB- prefix,"

--- a/setup.cfg
+++ b/setup.cfg
@@ -131,7 +131,7 @@ skip = _version.py,due.py,versioneer.py,*.vcr.yaml,venv,venvs
 # Don't warn about "[l]ist" in the abbrev_prompt() docstring:
 # TE is present in the BIDS schema
 ignore-regex = (\[\w\]\w+|TE|ignore "bu" strings)
-exclude-file = .codespellignore
+ignore-words-list = ba,bu,fo
 
 [mypy]
 # TODO: Eventually uncomment these:


### PR DESCRIPTION
Having that `.codespellignore` file there bothered me.