### PR TITLE
Remove `_order_` attribute from `Severity` enum

### DIFF
--- a/dandi/validate_types.py
+++ b/dandi/validate_types.py
@@ -12,7 +12,6 @@ class ValidationOrigin:
 
 
 class Severity(Enum):
-    _order_ = "HINT WARNING ERROR"
     HINT = 1
     WARNING = 2
     ERROR = 3


### PR DESCRIPTION
That attribute only has a purpose when supporting both Python 2 and Python 3, which we are not doing.  CC @TheChymera.