### PR TITLE
Merge duplicate entries in species_map

### DIFF
--- a/dandi/metadata.py
+++ b/dandi/metadata.py
@@ -474,7 +474,7 @@ species_map = [
         "Homo sapiens - Human",
     ),
     (
-        ["norvegicus"],
+        ["rat", "norvegicus"],
         None,
         "http://purl.obolibrary.org/obo/NCBITaxon_10116",
         "Rattus norvegicus - Norway rat",
@@ -484,12 +484,6 @@ species_map = [
         None,
         "http://purl.obolibrary.org/obo/NCBITaxon_10117",
         "Rattus rattus - Black rat",
-    ),
-    (
-        ["rat"],
-        None,
-        "http://purl.obolibrary.org/obo/NCBITaxon_10116",
-        "Rattus norvegicus - Norway rat",
     ),
     (
         ["mulatta", "rhesus"],


### PR DESCRIPTION
This PR merges duplicate a duplicate entry in the current `species_map` variable in `dandi/metadata.py`. We are using this variable in the NWB GUIDE to [populate an autosuggestion dropdown](https://github.com/NeurodataWithoutBorders/nwb-guide/pull/513) for Subject.species values.