### PR TITLE
Fix typing error

### DIFF
--- a/dandi/cli/cmd_move.py
+++ b/dandi/cli/cmd_move.py
@@ -44,7 +44,7 @@ from .base import devel_debug_option, instance_option, map_to_click_exceptions
 @devel_debug_option()
 @map_to_click_exceptions
 def move(
-    paths: tuple[str],
+    paths: tuple[str, ...],
     dandiset: str | None,
     dry_run: bool,
     existing: str,


### PR DESCRIPTION
I suspect the error in question only started being emitted when mypy 1.7.0 was released on the 10th.