### PR TITLE
Update for `zarr_checksum` 0.2.12

### DIFF
--- a/dandi/files/zarr.py
+++ b/dandi/files/zarr.py
@@ -15,6 +15,7 @@ from typing import Any
 from dandischema.digests.zarr import get_checksum
 from dandischema.models import BareAsset, DigestType
 import requests
+from zarr_checksum.tree import ZarrChecksumTree
 
 from dandi import get_logger
 from dandi.consts import (
@@ -287,10 +288,6 @@ class ZarrAsset(LocalDirectoryAsset[LocalZarrEntry]):
             ``"done"`` and an ``"asset"`` key containing the resulting
             `RemoteAsset`.
         """
-        # Importing zarr_checksum leads to importing numpy, which we want to
-        # avoid unless necessary
-        from zarr_checksum import ZarrChecksumTree
-
         # So that older clients don't get away with doing the wrong thing once
         # Zarr upload to embargoed Dandisets is implemented in the API:
         if dandiset.embargo_status is EmbargoStatus.EMBARGOED:

--- a/dandi/support/digests.py
+++ b/dandi/support/digests.py
@@ -24,6 +24,7 @@ from pathlib import Path
 
 from dandischema.digests.dandietag import DandiETag
 from fscacher import PersistentCache
+from zarr_checksum.tree import ZarrChecksumTree
 
 from .threaded_walk import threaded_walk
 from ..utils import Hasher, exclude_from_zarr
@@ -104,10 +105,6 @@ def get_zarr_checksum(path: Path, known: dict[str, str] | None = None) -> str:
     passed in the ``known`` argument, which must be a `dict` mapping
     slash-separated paths relative to the root of the Zarr to hex digests.
     """
-    # Importing zarr_checksum leads to importing numpy, which we want to avoid
-    # unless necessary
-    from zarr_checksum import ZarrChecksumTree
-
     if path.is_file():
         s = get_digest(path, "md5")
         assert isinstance(s, str)

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ install_requires =
     semantic-version
     tenacity
     zarr ~= 2.10
-    zarr_checksum
+    zarr_checksum ~= 0.2.12
 zip_safe = False
 packages = find_namespace:
 include_package_data = True
@@ -214,10 +214,6 @@ ignore_missing_imports = True
 
 [mypy-zarr.*]
 # <https://github.com/zarr-developers/zarr-python/issues/1566>
-ignore_missing_imports = True
-
-[mypy-zarr_checksum.*]
-# <https://github.com/dandi/zarr_checksum/issues/5>
 ignore_missing_imports = True
 
 [pydantic-mypy]


### PR DESCRIPTION
- We can't update to `zarr_checksum` 0.3.0 yet, as that requires Pydantic v2.

- As `zarr_checksum` gained type annotations in dandi/zarr_checksum#21, we can remove its override from the mypy config.

- Since dandi/zarr_checksum#17 was merged, it's now safe to import `zarr_checksum` at the top level of a module.

- Fixed a typing error caused by importing `ZarrChecksumTree` from the top level of `zarr_checksum` despite it not being listed in `zarr_checksum.__all__`, which triggered a typing failure due to our mypy configuration containing `implicit_reexport = False`.  (This error could only be detected after `zarr_checksum` started shipping a `py.typed` file.)