### PR TITLE
Properly open filehandles for `RemoteReadableAsset`s

### DIFF
--- a/dandi/misctypes.py
+++ b/dandi/misctypes.py
@@ -345,7 +345,10 @@ class RemoteReadableAsset(Readable):
         # Optional dependency:
         import fsspec
 
-        return cast(IO[bytes], fsspec.open(self.url, mode="rb"))
+        # We need to call open() on the return value of fsspec.open() because
+        # otherwise the filehandle will only be opened when used to enter a
+        # context manager.
+        return cast(IO[bytes], fsspec.open(self.url, mode="rb").open())
 
     def get_size(self) -> int:
         return self.size


### PR DESCRIPTION
@yarikoptic I am marking this for release as it is a blocker for https://github.com/dandi/dandi-infrastructure/issues/163.