### PR TITLE
Minor docs update for `dandi validate`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ pip-wheel-metadata/
 sandbox/
 venv/
 venvs/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Commands:
   organize          (Re)organize files according to the metadata.
   shell-completion  Emit shell script for enabling command completion.
   upload            Upload Dandiset files to DANDI Archive.
-  validate          Validate files for NWB and DANDI compliance.
+  validate          Validate files for DANDI, and BIDS and/or NWB compliance.
   validate-bids     Validate BIDS paths.
 ```
 Run `dandi --help` or `dandi <subcommand> --help` (e.g. `dandi upload --help`) to see manual pages.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Commands:
   organize          (Re)organize files according to the metadata.
   shell-completion  Emit shell script for enabling command completion.
   upload            Upload Dandiset files to DANDI Archive.
-  validate          Validate files for DANDI, and BIDS and/or NWB compliance.
+  validate          Validate files for data standards compliance.
 ```
 Run `dandi --help` or `dandi <subcommand> --help` (e.g. `dandi upload --help`) to see manual pages.
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ Commands:
   shell-completion  Emit shell script for enabling command completion.
   upload            Upload Dandiset files to DANDI Archive.
   validate          Validate files for DANDI, and BIDS and/or NWB compliance.
-  validate-bids     Validate BIDS paths.
 ```
 Run `dandi --help` or `dandi <subcommand> --help` (e.g. `dandi upload --help`) to see manual pages.
 

--- a/dandi/cli/cmd_validate.py
+++ b/dandi/cli/cmd_validate.py
@@ -98,7 +98,7 @@ def validate(
     devel_debug: bool = False,
     allow_any_path: bool = False,
 ) -> None:
-    """Validate files for DANDI, and BIDS and/or NWB compliance.
+    """Validate files for data standards compliance.
 
     Exits with non-0 exit code if any file is not compliant.
     """

--- a/dandi/cli/cmd_validate.py
+++ b/dandi/cli/cmd_validate.py
@@ -98,7 +98,7 @@ def validate(
     devel_debug: bool = False,
     allow_any_path: bool = False,
 ) -> None:
-    """Validate files for DANDI and BIDS and/or NWB compliance.
+    """Validate files for DANDI, and BIDS and/or NWB compliance.
 
     Exits with non-0 exit code if any file is not compliant.
     """

--- a/docs/source/cmdline/validate.rst
+++ b/docs/source/cmdline/validate.rst
@@ -5,7 +5,7 @@
 
     dandi [<global options>] validate [<path> ...]
 
-Validate files for DANDI, and BIDS and/or NWB compliance.
+Validate files for data standards compliance.
 
 Exits with non-zero exit code if any file is not compliant.
 

--- a/docs/source/cmdline/validate.rst
+++ b/docs/source/cmdline/validate.rst
@@ -5,7 +5,7 @@
 
     dandi [<global options>] validate [<path> ...]
 
-Validate files for NWB and DANDI compliance.
+Validate files for DANDI, and BIDS and/or NWB compliance.
 
 Exits with non-zero exit code if any file is not compliant.
 


### PR DESCRIPTION
## Description
- Add a note that `dandi validate` works to ensure BIDS compliance.

## Changes
- [x] Update gitignore
- [x] Update readme, docstring, and docs
- [x] Remove `dandi validate-bids` from readme since it is now deprecated