### PR TITLE
Minor update to `organize` docstring

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Commands:
   instances         List known Dandi Archive instances that the CLI can...
   ls                List .nwb files and dandisets metadata.
   move              Move or rename assets in a local Dandiset and/or on...
-  organize          (Re)organize files according to the metadata.
+  organize          (Re)organize NWB files according to their metadata.
   shell-completion  Emit shell script for enabling command completion.
   upload            Upload Dandiset files to DANDI Archive.
   validate          Validate files for data standards compliance.

--- a/dandi/cli/cmd_organize.py
+++ b/dandi/cli/cmd_organize.py
@@ -74,7 +74,7 @@ def organize(
     jobs: int | None,
     devel_debug: bool = False,
 ) -> None:
-    """(Re)organize files according to the metadata.
+    """(Re)organize NWB files according to their metadata.
 
     The purpose of this command is to take advantage of metadata contained in
     .nwb files to provide datasets with consistently-named files whose names


### PR DESCRIPTION
## Description
- Updated the summary line in the docstring to specify that `dandi organize` works for NWB files (and not BIDS datasets).