### PR TITLE
`dandi download dandi://…/dandiset.yaml` now downloads `dandiset.yaml`

### DIFF
--- a/dandi/download.py
+++ b/dandi/download.py
@@ -28,7 +28,13 @@ import requests
 from . import get_logger
 from .consts import RETRY_STATUSES, dandiset_metadata_file
 from .dandiapi import AssetType, BaseRemoteZarrAsset, RemoteDandiset
-from .dandiarchive import DandisetURL, ParsedDandiURL, SingleAssetURL, parse_dandi_url
+from .dandiarchive import (
+    AssetItemURL,
+    DandisetURL,
+    ParsedDandiURL,
+    SingleAssetURL,
+    parse_dandi_url,
+)
 from .dandiset import Dandiset
 from .exceptions import NotFoundError
 from .files import LocalAsset, find_dandi_files
@@ -227,7 +233,13 @@ class Downloader:
         """
 
         with self.url.navigate(strict=True) as (client, dandiset, assets):
-            if isinstance(self.url, DandisetURL) and self.get_metadata:
+            if (
+                isinstance(self.url, DandisetURL)
+                or (
+                    isinstance(self.url, AssetItemURL)
+                    and self.url.path == "dandiset.yaml"
+                )
+            ) and self.get_metadata:
                 assert dandiset is not None
                 for resp in _populate_dandiset_yaml(
                     self.output_path, dandiset, self.existing
@@ -236,6 +248,8 @@ class Downloader:
                         "path": str(self.output_prefix / dandiset_metadata_file),
                         **resp,
                     }
+                if isinstance(self.url, AssetItemURL):
+                    return
 
             # TODO: do analysis of assets for early detection of needed renames
             # etc to avoid any need for late treatment of existing and also for

--- a/dandi/tests/test_download.py
+++ b/dandi/tests/test_download.py
@@ -31,7 +31,7 @@ from ..download import (
 )
 from ..exceptions import NotFoundError
 from ..support.digests import Digester
-from ..utils import list_paths
+from ..utils import list_paths, yaml_load
 
 
 # both urls point to 000027 (lean test dataset), and both draft and "released"
@@ -180,6 +180,18 @@ def test_download_item(text_dandiset: SampleDandiset, tmp_path: Path) -> None:
     )
     assert list_paths(tmp_path, dirs=True) == [tmp_path / "coconut.txt"]
     assert (tmp_path / "coconut.txt").read_text() == "Coconut\n"
+
+
+def test_download_dandiset_yaml(text_dandiset: SampleDandiset, tmp_path: Path) -> None:
+    dandiset_id = text_dandiset.dandiset_id
+    download(
+        f"dandi://{text_dandiset.api.instance_id}/{dandiset_id}/dandiset.yaml",
+        tmp_path,
+    )
+    assert list_paths(tmp_path, dirs=True) == [tmp_path / dandiset_metadata_file]
+    with (tmp_path / dandiset_metadata_file).open(encoding="utf-8") as fp:
+        metadata = yaml_load(fp)
+    assert metadata["id"] == f"DANDI:{dandiset_id}/draft"
 
 
 def test_download_asset_id(text_dandiset: SampleDandiset, tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #1383.

Note that this feature only applies to `dandi://` URLs, as GUI and API URLs cannot refer to a specific asset by path in the first place.

Note that this re-interpretation of `dandi://` URLs only happens when downloading and not when a `dandi://…/dandiset.yaml` URL is supplied to a `move`, `delete`, `ls`, or `reextract-metadata` command (I think those are all the places that `dandi://` URLs are accepted), as it wouldn't make sense for most of those.