### PR TITLE
Fix service script tests for change in autogenerated date

### DIFF
--- a/dandi/cli/tests/test_service_scripts.py
+++ b/dandi/cli/tests/test_service_scripts.py
@@ -116,9 +116,18 @@ def test_update_dandiset_from_doi(
     expected["manifestLocation"][
         0
     ] = f"{new_dandiset.api.api_url}/dandisets/{dandiset_id}/versions/draft/assets/"
-    expected["citation"] = re.sub(
+    citation = re.sub(
         r"\S+\Z",
         f"{repository}/dandiset/{dandiset_id}/draft",
         expected["citation"],
     )
+    if m := re.search(r"\(\d{4}\)", citation):
+        citation_rgx = (
+            re.escape(citation[: m.start()])
+            + r"\(\d{4}\)"
+            + re.escape(citation[m.end() :])
+        )
+        expected["citation"] = anys.AnyFullmatch(citation_rgx)
+    else:
+        expected["citation"] = citation
     assert metadata == expected


### PR DESCRIPTION
The `update-dandiset-from-doi` tests are currently failing because they test against the Dandisets' final `citation` fields (among others), which the Archive automatically populates based on the year the Dandisets were created (among other things), and so our expected output is no longer accurate as of the new year.