### PR TITLE
Update zarr_checksum dependency to `~= 0.3.2`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ install_requires =
     semantic-version
     tenacity
     zarr ~= 2.10
-    zarr_checksum ~= 0.2.12
+    zarr_checksum ~= 0.3.2
 zip_safe = False
 packages = find_namespace:
 include_package_data = True


### PR DESCRIPTION
Now that https://github.com/dandi/zarr_checksum/pull/53 has been merged & released, we should be able to use the latest version of `zarr_checksum` without having to update Pydantic first (#1381).