### PR TITLE
Do not allow dandischema 0.10.1 - new schema not yet supported by dandi-archive

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     bidsschematools ~= 0.7.0
     click >= 7.1
     click-didyoumean
-    dandischema >= 0.9.0, < 0.11
+    dandischema >= 0.9.0, < 0.10.1
     etelemetry >= 0.2.2
     fasteners
     fscacher >= 0.3.0


### PR DESCRIPTION
testing started to fail
![image](https://github.com/dandi/dandi-cli/assets/39889/67d1056d-f9e6-459a-9722-628905467c43)

With current release of dandi-schema our testing starts to fail, but dandi-archive seems needing CI fixing first to also 
make upgrade possible. So as a quick resolution to avoid ill effects on users etc, I think we should restrict version

refs:
- https://github.com/dandi/dandi-archive/pull/1893
- (blocker) https://github.com/dandi/dandi-archive/issues/1894