### PR TITLE
Revert "Do not allow dandischema 0.10.1 - new schema not yet supporteed by dandi-archive"

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     bidsschematools ~= 0.7.0
     click >= 7.1
     click-didyoumean
-    dandischema >= 0.9.0, < 0.10.1
+    dandischema >= 0.9.0, < 0.11
     etelemetry >= 0.2.2
     fasteners
     fscacher >= 0.3.0


### PR DESCRIPTION
This reverts commit ca4c1702e46dae5ca4db2886e2700fe1f408bb31.

dandi-archive supports new schema now, we should be fine to proceed.