### PR TITLE
Add missing command to `dandi-archive` docker compose fixture

### DIFF
--- a/dandi/tests/fixtures.py
+++ b/dandi/tests/fixtures.py
@@ -407,6 +407,19 @@ def docker_compose_setup() -> Iterator[dict[str, str]]:
                     "docker-compose",
                     "run",
                     "--rm",
+                    "django",
+                    "./manage.py",
+                    "createcachetable",
+                ],
+                cwd=str(LOCAL_DOCKER_DIR),
+                env=env,
+                check=True,
+            )
+            run(
+                [
+                    "docker-compose",
+                    "run",
+                    "--rm",
                     "-e",
                     "DJANGO_SUPERUSER_PASSWORD=nsNc48DBiS",
                     "django",


### PR DESCRIPTION
dandi-archive requires this command to be run as part of system initialization in order to initialize the database to serve as a Django cache backend. It must be run in order for any endpoint with caching enabled to work properly. See the set up instructions for docker-compose: https://github.com/dandi/dandi-archive/blob/master/DEVELOPMENT.md#initial-setup

Up until this point, the only endpoint with caching enabled was `/api/stats/`, and presumably the CLI has no need to hit that in testing so this went unnoticed. However, the rate limiting introduced in https://github.com/dandi/dandi-archive/pull/1899 also makes use of the database cache backend, and thus the CLI tests are failing on that PR.