### PR TITLE
Add DJANGO_DANDI_DEV_EMAIL env var to archive tests

### DIFF
--- a/dandi/tests/data/dandiarchive-docker/docker-compose.yml
+++ b/dandi/tests/data/dandiarchive-docker/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       DJANGO_DANDI_WEB_APP_URL: http://localhost:8085
       DJANGO_DANDI_API_URL: http://localhost:8000
       DJANGO_DANDI_JUPYTERHUB_URL: https://hub.dandiarchive.org
+      DJANGO_DANDI_DEV_EMAIL: test@example.com
       DANDI_ALLOW_LOCALHOST_URLS: "1"
     ports:
       - "8000:8000"


### PR DESCRIPTION
We've added a new env var during the [embargo re-design](https://github.com/dandi/dandi-archive/pull/1890), and integration tests to that branch as well as master (once it's merged), will fail until this PR is merged.