### PR TITLE
Update test utility for the email requirement for contact person

### DIFF
--- a/dandi/tests/data/dandiarchive-docker/docker-compose.yml
+++ b/dandi/tests/data/dandiarchive-docker/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       DJANGO_DANDI_API_URL: http://localhost:8000
       DJANGO_DANDI_JUPYTERHUB_URL: https://hub.dandiarchive.org
       DANDI_ALLOW_LOCALHOST_URLS: "1"
+      DJANGO_DANDI_DEV_EMAIL: "test@example.com"
     ports:
       - "8000:8000"
 
@@ -80,6 +81,7 @@ services:
       DJANGO_DANDI_API_URL: http://localhost:8000
       DJANGO_DANDI_JUPYTERHUB_URL: https://hub.dandiarchive.org
       DANDI_ALLOW_LOCALHOST_URLS: "1"
+      DJANGO_DANDI_DEV_EMAIL: "test@example.com"
 
   minio:
     image: minio/minio:RELEASE.2022-04-12T06-55-35Z

--- a/dandi/tests/fixtures.py
+++ b/dandi/tests/fixtures.py
@@ -548,6 +548,7 @@ class SampleDandisetFactory:
                     {
                         "schemaKey": "Person",
                         "name": "Tests, Dandi-Cli",
+                        "email": "nemo@example.com",
                         "roleName": ["dcite:Author", "dcite:ContactPerson"],
                     }
                 ],


### PR DESCRIPTION
This PR updates `SampleDandisetFactory` used for testing to meet the requirement imposed by [dandi-schema](https://github.com/dandi/dandi-schema) of having email for a contributor who is a contact person, https://github.com/dandi/dandi-schema/pull/235.

Additionally, it sets `DJANGO_DANDI_DEV_EMAIL` needed for running the latest [`dandiarchive/dandiarchive-api`](https://hub.docker.com/r/dandiarchive/dandiarchive-api) image in testing. 