### PR TITLE
Slight tune up to formatting of examples etc to harmonize appearance/make shorter

### DIFF
--- a/dandi/cli/cmd_download.py
+++ b/dandi/cli/cmd_download.py
@@ -12,24 +12,26 @@ from ..download import DownloadExisting, DownloadFormat, PathType
 from ..utils import get_instance, joinurl
 
 _examples = """
-EXAMPLES:\n
-# Download only the dandiset.yaml\n
-dandi download --download dandiset.yaml DANDI:000027\n
+EXAMPLES:
 
-# Download only dandiset.yaml if there is a newer version\n
-dandi download https://identifiers.org/DANDI:000027 --existing refresh
-
-# Download only the assets\n
-dandi download --download assets DANDI:000027
-
-# Download all from a specific version\n
-dandi download DANDI:000027/0.210831.2033
-
-# Download a specific directory\n
-dandi download dandi://DANDI/000027@0.210831.2033/sub-RAT123/
-
-# Download a specific file\n
-dandi download dandi://DANDI/000027@0.210831.2033/sub-RAT123/sub-RAT123.nwb
+\b
+ - Download only the dandiset.yaml
+   dandi download --download dandiset.yaml DANDI:000027
+\b
+ - Download only dandiset.yaml if there is a newer version
+   dandi download https://identifiers.org/DANDI:000027 --existing refresh
+\b
+ - Download only the assets
+   dandi download --download assets DANDI:000027
+\b
+ - Download all from a specific version
+   dandi download DANDI:000027/0.210831.2033
+\b
+ - Download a specific directory
+   dandi download dandi://DANDI/000027@0.210831.2033/sub-RAT123/
+\b
+ - Download a specific file
+   dandi download dandi://DANDI/000027@0.210831.2033/sub-RAT123/sub-RAT123.nwb
 """
 
 
@@ -45,7 +47,6 @@ Download files or entire folders from DANDI.
 \b
 {_dandi_url_parser.known_patterns}
 
-\b
 {_examples}
 
 """

--- a/dandi/dandiarchive.py
+++ b/dandi/dandiarchive.py
@@ -676,14 +676,14 @@ class _dandi_url_parser:
         ),
     ]
     resource_identifier_primer = """RESOURCE ID/URLS:\n
-    dandi commands accept URLs and URL-like identifiers called <resource
-    ids> in the following formats for identifying Dandisets, assets, and
-    asset collections.
+ dandi commands accept URLs and URL-like identifiers called <resource
+ ids> in the following formats for identifying Dandisets, assets, and
+ asset collections.
 
-    Text in [brackets] is optional.  A server field is a base API or GUI URL
-    for a DANDI Archive instance.  If an optional ``version`` field is
-    omitted from a URL, the given Dandiset's most recent published version
-    will be used if it has one, and its draft version will be used otherwise.
+ Text in [brackets] is optional.  A server field is a base API or GUI URL
+ for a DANDI Archive instance.  If an optional ``version`` field is
+ omitted from a URL, the given Dandiset's most recent published version
+ will be used if it has one, and its draft version will be used otherwise.
     """
     known_patterns = "Accepted resource identifier patterns:" + "\n - ".join(
         [""] + [display for _, _, display in known_urls]


### PR DESCRIPTION
Original --help is too long and a little more inconsistent  -- the "#" are shell script construct and generally not used to demarkate anything there, so kind no point to have/look odd

Here is how it would look now

```shell
❯ dandi download --help
Usage: dandi download [OPTIONS] [URL]...

  Download files or entire folders from DANDI.

  RESOURCE ID/URLS:

   dandi commands accept URLs and URL-like identifiers called <resource  ids>
   in the following formats for identifying Dandisets, assets, and  asset
   collections.

   Text in [brackets] is optional.  A server field is a base API or GUI URL
   for a DANDI Archive instance.  If an optional ``version`` field is  omitted
   from a URL, the given Dandiset's most recent published version  will be
   used if it has one, and its draft version will be used otherwise.

  Accepted resource identifier patterns:
   - DANDI:<dandiset id>[/<version>]
   - https://gui.dandiarchive.org/...
   - https://identifiers.org/DANDI:<dandiset id>[/<version id>] (<version id> cannot be 'draft')
   - https://<server>[/api]/[#/]dandiset/<dandiset id>[/<version>][/files[?location=<path>]]
   - https://*dandiarchive-org.netlify.app/...
   - https://<server>[/api]/dandisets/<dandiset id>[/versions[/<version>]]
   - https://<server>[/api]/assets/<asset id>[/download]
   - https://<server>[/api]/dandisets/<dandiset id>/versions/<version>/assets/<asset id>[/download]
   - https://<server>[/api]/dandisets/<dandiset id>/versions/<version>/assets/?path=<path>
   - https://<server>[/api]/dandisets/<dandiset id>/versions/<version>/assets/?glob=<glob>
   - dandi://<instance name>/<dandiset id>[@<version>][/<path>]
   - https://<server>/...

  EXAMPLES:

   - Download only the dandiset.yaml
     dandi download --download dandiset.yaml DANDI:000027
  
   - Download only dandiset.yaml if there is a newer version
     dandi download https://identifiers.org/DANDI:000027 --existing refresh
  
   - Download only the assets
     dandi download --download assets DANDI:000027
  
   - Download all from a specific version
     dandi download DANDI:000027/0.210831.2033
  
   - Download a specific directory
     dandi download dandi://DANDI/000027@0.210831.2033/sub-RAT123/
  
   - Download a specific file
     dandi download dandi://DANDI/000027@0.210831.2033/sub-RAT123/sub-RAT123.nwb

Options:
  -o, --output-dir DIRECTORY      Directory where to download to (directory
                                  must exist). Files will be downloaded with
                                  paths relative to that directory.
  -e, --existing [error|skip|overwrite|overwrite-different|refresh]
                                  What to do if a file found existing locally.
                                  'refresh': verify that according to the size
                                  and mtime, it is the same file, if not -
                                  download and overwrite.  [default: error]
  -f, --format [pyout|debug]      Choose the format/frontend for output. TODO:
                                  support all of the ls
  --path-type [exact|glob]        Whether to interpret asset paths in URLs as
                                  exact matches or glob patterns  [default:
                                  exact]
  -J, --jobs N[:M]                Number of parallel download jobs and,
                                  optionally number of subjobs per Zarr asset
                                  [default: 6]
  --download [dandiset.yaml,assets,all]
                                  Comma-separated list of elements to download
                                  [default: all]
  --sync                          Delete local assets that do not exist on the
                                  server
  -i, --dandi-instance TEXT       DANDI Archive instance to download from. If
                                  any URLs are provided, they must point to
                                  the given instance. If no URL is provided,
                                  and there is a local dandiset.yaml file, the
                                  Dandiset with the identifier given in the
                                  file will be downloaded from the given
                                  instance.  [env var: DANDI_INSTANCE]
  --help                          Show this message and exit.
```