### PR TITLE
ENH: add timeout of 300 (5 minutes) to any test running

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -89,6 +89,7 @@ test =
     pytest-cov
     pytest-mock
     pytest-rerunfailures
+    pytest-timeout
     responses != 0.24.0
     vcrpy
 tools=

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ changedir = docs
 commands = sphinx-build -E -W -b html source build
 
 [pytest]
-addopts = --tb=short --durations=10
+addopts = --tb=short --durations=10 --timeout=300
 markers =
     integration
     obolibrary


### PR DESCRIPTION
We recently started to encounter stalling test runs which lead to hours of stalled operation.  Hopefully this would lead to failed test instead of a stall

TODOs:
- [x] test if in effect by making timeout too small (e.g. 2 seconds). Will do now