### PR TITLE
Rewind filehandle request bodies before retrying requests

### DIFF
--- a/dandi/dandiapi.py
+++ b/dandi/dandiapi.py
@@ -233,6 +233,8 @@ class RESTFullAPIClient:
                                 url,
                                 result.text,
                             )
+                            if data is not None and hasattr(data, "seek"):
+                                data.seek(0)
                         result.raise_for_status()
         except Exception as e:
             if isinstance(e, requests.HTTPError):


### PR DESCRIPTION
Closes #1408.

Here's what was going on:  Occasionally, requests to S3 to upload a Zarr entry fail with a 500 status due to an internal error on S3's end, causing `dandi-cli` to retry the request.  When it retries the request, it calls `session.request()` again, passing in the same arguments as before, which include an open filehandle for reading the Zarr entry from disk.  However, the filehandle was already read to the end on the initial request (the one that resulted in a 500); thus, although `requests`'s `super_len()` obtains the correct value for the file's length, it then subtracts the filehandle's current position (the end of the file) from this length to get the number of bytes that would be produced by reading from the current position to the end of file: zero — and, as previously established, when `super_len()` returns 0, `requests` falls back to "chunked" transfer encoding, which S3 responds to with a 501 error about "header implies functionality not implemented" (hereafter "HIFNI").

* The logs for #1033, the original report of the HIFNI problem, are no longer available, so I cannot check if this was happening there as well.

* This was what caused the initial HIFNI in #1257, based on the logs in [this comment](https://github.com/dandi/dandi-cli/issues/1257#issuecomment-1490249488) (I didn't check the other error logs posted later in the thread).

While this patch should eliminate most instances of the HIFNI problem, it is still conceivable that the original hypothesized cause — NFS erroneously reporting filesizes as zero — could occur.  @yarikoptic How much of [the previously-added infrastructure for dealing with this problem](https://github.com/dandi/dandi-cli/pulls?q=is%3Apr+is%3Aclosed+label%3AHIFNI) should we keep around after this?