### PR TITLE
Script to get bibliography for (all) dandisets (prototype)

### DIFF
--- a/sandbox/dandi.bib
+++ b/sandbox/dandi.bib
@@ -1,0 +1,4058 @@
+# DANDISET 000003
+@misc{dandi.000003/0.210812.1448,
+  doi = {10.48324/DANDI.000003/0.210812.1448},
+  url = {https://dandiarchive.org/dandiset/000003/0.210812.1448},
+  author = {Senzai, Yuta and Fernandez-Ruiz, Antonio and Buzsáki, György},
+  keywords = {cell types, current source density, laminar recordings, oscillations, mossy cells, granule cells, optogenetics},
+  title = {Physiological Properties and Behavioral Correlates of Hippocampal Granule Cells and Mossy Cells},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+@misc{dandi.000003/0.230629.1955,
+  doi = {10.48324/DANDI.000003/0.230629.1955},
+  url = {https://dandiarchive.org/dandiset/000003/0.230629.1955},
+  author = {Senzai, Yuta and Fernandez-Ruiz, Antonio and Buzsáki, György},
+  keywords = {cell types, current source density, laminar recordings, oscillations, mossy cells, granule cells, optogenetics},
+  title = {Physiological Properties and Behavioral Correlates of Hippocampal Granule Cells and Mossy Cells},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# Take latest as the default
+@misc{dandi.000003,
+  doi = {10.48324/DANDI.000003/0.230629.1955},
+  url = {https://dandiarchive.org/dandiset/000003/0.230629.1955},
+  author = {Senzai, Yuta and Fernandez-Ruiz, Antonio and Buzsáki, György},
+  keywords = {cell types, current source density, laminar recordings, oscillations, mossy cells, granule cells, optogenetics},
+  title = {Physiological Properties and Behavioral Correlates of Hippocampal Granule Cells and Mossy Cells},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# DANDISET 000004
+@misc{dandi.000004/0.220126.1851,
+  doi = {10.48324/DANDI.000004/0.220126.1851},
+  url = {https://dandiarchive.org/dandiset/000004/0.220126.1851},
+  author = {Chandravadia, Nand and Liang, Dehua and Schjetnan, Andrea Gomez Palacio and Carlson, April and Faraut, Mailys and Chung, Jeffrey M. and Reed, Chrystal M. and Dichter, Ben and Maoz, Uri and Kalia, Suneil K. and Valiante, Taufik A. and Mamelak, Adam N. and Rutishauser, Ueli},
+  keywords = {cognitive neuroscience, data standardization, decision making, declarative memory, neurophysiology, neurosurgery, NWB, open source, single-neurons},
+  title = {A NWB-based dataset and processing pipeline of human single-neuron activity during a declarative memory task},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+@misc{dandi.000004/0.220126.1852,
+  doi = {10.48324/DANDI.000004/0.220126.1852},
+  url = {https://dandiarchive.org/dandiset/000004/0.220126.1852},
+  author = {Chandravadia, Nand and Liang, Dehua and Schjetnan, Andrea Gomez Palacio and Carlson, April and Faraut, Mailys and Chung, Jeffrey M. and Reed, Chrystal M. and Dichter, Ben and Maoz, Uri and Kalia, Suneil K. and Valiante, Taufik A. and Mamelak, Adam N. and Rutishauser, Ueli},
+  keywords = {cognitive neuroscience, data standardization, decision making, declarative memory, neurophysiology, neurosurgery, NWB, open source, single-neurons},
+  title = {A NWB-based dataset and processing pipeline of human single-neuron activity during a declarative memory task},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# Take latest as the default
+@misc{dandi.000004,
+  doi = {10.48324/DANDI.000004/0.220126.1852},
+  url = {https://dandiarchive.org/dandiset/000004/0.220126.1852},
+  author = {Chandravadia, Nand and Liang, Dehua and Schjetnan, Andrea Gomez Palacio and Carlson, April and Faraut, Mailys and Chung, Jeffrey M. and Reed, Chrystal M. and Dichter, Ben and Maoz, Uri and Kalia, Suneil K. and Valiante, Taufik A. and Mamelak, Adam N. and Rutishauser, Ueli},
+  keywords = {cognitive neuroscience, data standardization, decision making, declarative memory, neurophysiology, neurosurgery, NWB, open source, single-neurons},
+  title = {A NWB-based dataset and processing pipeline of human single-neuron activity during a declarative memory task},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# DANDISET 000005
+@misc{dandi.000005/0.220126.1853,
+  doi = {10.48324/DANDI.000005/0.220126.1853},
+  url = {https://dandiarchive.org/dandiset/000005/0.220126.1853},
+  author = {Yu, Jianing and Gutnisky, Diego A and Hires, S Andrew and Svoboda, Karel},
+  title = {Electrophysiology data from thalamic and cortical neurons during somatosensation},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# Take latest as the default
+@misc{dandi.000005,
+  doi = {10.48324/DANDI.000005/0.220126.1853},
+  url = {https://dandiarchive.org/dandiset/000005/0.220126.1853},
+  author = {Yu, Jianing and Gutnisky, Diego A and Hires, S Andrew and Svoboda, Karel},
+  title = {Electrophysiology data from thalamic and cortical neurons during somatosensation},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# DANDISET 000006
+@misc{dandi.000006/0.220126.1855,
+  doi = {10.48324/DANDI.000006/0.220126.1855},
+  url = {https://dandiarchive.org/dandiset/000006/0.220126.1855},
+  author = {Economo, Michael N. and Svoboda, Karel},
+  title = {Mouse anterior lateral motor cortex (ALM) in delay response task},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# Take latest as the default
+@misc{dandi.000006,
+  doi = {10.48324/DANDI.000006/0.220126.1855},
+  url = {https://dandiarchive.org/dandiset/000006/0.220126.1855},
+  author = {Economo, Michael N. and Svoboda, Karel},
+  title = {Mouse anterior lateral motor cortex (ALM) in delay response task},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# DANDISET 000007
+@misc{dandi.000007/0.220126.1903,
+  doi = {10.48324/DANDI.000007/0.220126.1903},
+  url = {https://dandiarchive.org/dandiset/000007/0.220126.1903},
+  author = {Gao, Zhenyu and Davis, Courtney and Thomas, Alyse M. and Economo, Michael N. and Abrego, Amada M. and Svoboda, Karel and Zeeuw, Chris I. De and Li, Nuo},
+  title = {A cortico-cerebellar loop for motor planning},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# Take latest as the default
+@misc{dandi.000007,
+  doi = {10.48324/DANDI.000007/0.220126.1903},
+  url = {https://dandiarchive.org/dandiset/000007/0.220126.1903},
+  author = {Gao, Zhenyu and Davis, Courtney and Thomas, Alyse M. and Economo, Michael N. and Abrego, Amada M. and Svoboda, Karel and Zeeuw, Chris I. De and Li, Nuo},
+  title = {A cortico-cerebellar loop for motor planning},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# DANDISET 000008
+@misc{dandi.000008/0.211014.0808,
+  doi = {10.48324/DANDI.000008/0.211014.0808},
+  url = {https://dandiarchive.org/dandiset/000008/0.211014.0808},
+  author = {Scala, Federico and Kobak, Dmitry and Bernabucci, Matteo and Bernaerts, Yves and Cadwell, Cathryn Rene and Castro, Jesus Ramon and Hartmanis, Leonard and Jiang, Xiaolong and Laturnus, Sophie and Miranda, Elanine and Mulherkar, Shalaka and Tan, Zheng Huan and Yao, Zizhen and Zeng, Hongkui and Sandberg, Rickard and Berens, Philipp and Tolias, Andreas Savas},
+  keywords = {Patch-seq, cortex, motor cortex, mouse},
+  title = {Phenotypic variation within and across transcriptomic cell types in mouse motor cortex},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+@misc{dandi.000008/0.211014.0809,
+  doi = {10.48324/DANDI.000008/0.211014.0809},
+  url = {https://dandiarchive.org/dandiset/000008/0.211014.0809},
+  author = {Scala, Federico and Kobak, Dmitry and Bernabucci, Matteo and Bernaerts, Yves and Cadwell, Cathryn Rene and Castro, Jesus Ramon and Hartmanis, Leonard and Jiang, Xiaolong and Laturnus, Sophie and Miranda, Elanine and Mulherkar, Shalaka and Tan, Zheng Huan and Yao, Zizhen and Zeng, Hongkui and Sandberg, Rickard and Berens, Philipp and Tolias, Andreas Savas},
+  keywords = {Patch-seq, cortex, motor cortex, mouse},
+  title = {Phenotypic variation within and across transcriptomic cell types in mouse motor cortex},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+# Take latest as the default
+@misc{dandi.000008,
+  doi = {10.48324/DANDI.000008/0.211014.0809},
+  url = {https://dandiarchive.org/dandiset/000008/0.211014.0809},
+  author = {Scala, Federico and Kobak, Dmitry and Bernabucci, Matteo and Bernaerts, Yves and Cadwell, Cathryn Rene and Castro, Jesus Ramon and Hartmanis, Leonard and Jiang, Xiaolong and Laturnus, Sophie and Miranda, Elanine and Mulherkar, Shalaka and Tan, Zheng Huan and Yao, Zizhen and Zeng, Hongkui and Sandberg, Rickard and Berens, Philipp and Tolias, Andreas Savas},
+  keywords = {Patch-seq, cortex, motor cortex, mouse},
+  title = {Phenotypic variation within and across transcriptomic cell types in mouse motor cortex},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+# DANDISET 000009
+@misc{dandi.000009/0.220126.1903,
+  doi = {10.48324/DANDI.000009/0.220126.1903},
+  url = {https://dandiarchive.org/dandiset/000009/0.220126.1903},
+  author = {Guo, Zengcai and Inagaki, Hidehiko and Daie, Kayvon and Druckmann, Shaul and Gerfen, Charles R. and Svoboda, Karel},
+  title = {Maintenance of persistent activity in a frontal thalamocortical loop},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# Take latest as the default
+@misc{dandi.000009,
+  doi = {10.48324/DANDI.000009/0.220126.1903},
+  url = {https://dandiarchive.org/dandiset/000009/0.220126.1903},
+  author = {Guo, Zengcai and Inagaki, Hidehiko and Daie, Kayvon and Druckmann, Shaul and Gerfen, Charles R. and Svoboda, Karel},
+  title = {Maintenance of persistent activity in a frontal thalamocortical loop},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# DANDISET 000010
+@misc{dandi.000010/0.220126.1905,
+  doi = {10.48324/DANDI.000010/0.220126.1905},
+  url = {https://dandiarchive.org/dandiset/000010/0.220126.1905},
+  author = {Li, Nuo and Chen, Tsai-Wen and Guo, Zengcai V. and Gerfen, Charles R. and Svoboda, Karel},
+  title = {A motor cortex circuit for motor planning and movement},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# Take latest as the default
+@misc{dandi.000010,
+  doi = {10.48324/DANDI.000010/0.220126.1905},
+  url = {https://dandiarchive.org/dandiset/000010/0.220126.1905},
+  author = {Li, Nuo and Chen, Tsai-Wen and Guo, Zengcai V. and Gerfen, Charles R. and Svoboda, Karel},
+  title = {A motor cortex circuit for motor planning and movement},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# DANDISET 000011
+@misc{dandi.000011/0.220126.1907,
+  doi = {10.48324/DANDI.000011/0.220126.1907},
+  url = {https://dandiarchive.org/dandiset/000011/0.220126.1907},
+  author = {Li, Nuo and Daie, Kayvon and Svoboda, Karel and Druckmann, Shaul},
+  title = {Robust neuronal dynamics in premotor cortex during motor planning},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# Take latest as the default
+@misc{dandi.000011,
+  doi = {10.48324/DANDI.000011/0.220126.1907},
+  url = {https://dandiarchive.org/dandiset/000011/0.220126.1907},
+  author = {Li, Nuo and Daie, Kayvon and Svoboda, Karel and Druckmann, Shaul},
+  title = {Robust neuronal dynamics in premotor cortex during motor planning},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# DANDISET 000013
+@misc{dandi.000013/0.220126.2143,
+  doi = {10.48324/DANDI.000013/0.220126.2143},
+  url = {https://dandiarchive.org/dandiset/000013/0.220126.2143},
+  author = {Hires, Samuel and Gutnisky, Diego and Yu, Jianing and O'Connor, Daniel H and Svoboda, Karel},
+  title = {Low-noise encoding of active touch by layer 4 in the somatosensory cortex},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# Take latest as the default
+@misc{dandi.000013,
+  doi = {10.48324/DANDI.000013/0.220126.2143},
+  url = {https://dandiarchive.org/dandiset/000013/0.220126.2143},
+  author = {Hires, Samuel and Gutnisky, Diego and Yu, Jianing and O'Connor, Daniel H and Svoboda, Karel},
+  title = {Low-noise encoding of active touch by layer 4 in the somatosensory cortex},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# DANDISET 000015
+@misc{dandi.000015/0.220126.1914,
+  doi = {10.48324/DANDI.000015/0.220126.1914},
+  url = {https://dandiarchive.org/dandiset/000015/0.220126.1914},
+  author = {Chen, Tsai-Wen and Li, Nuo and Daie, Kayvon and Svoboda, Karel},
+  title = {A Map of Anticipatory Activity in Mouse Motor Cortex},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# Take latest as the default
+@misc{dandi.000015,
+  doi = {10.48324/DANDI.000015/0.220126.1914},
+  url = {https://dandiarchive.org/dandiset/000015/0.220126.1914},
+  author = {Chen, Tsai-Wen and Li, Nuo and Daie, Kayvon and Svoboda, Karel},
+  title = {A Map of Anticipatory Activity in Mouse Motor Cortex},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# DANDISET 000017
+@misc{dandi.000017/0.240329.1926,
+  doi = {10.48324/DANDI.000017/0.240329.1926},
+  url = {https://dandiarchive.org/dandiset/000017/0.240329.1926},
+  author = {Steinmetz, Nicholas and Zatka-Haas, Peter and Carandini, Matteo and Harris, Kenneth},
+  keywords = {neuropixels},
+  title = {Distributed coding of choice, action and engagement across the mouse brain},
+  publisher = {DANDI Archive},
+  year = {2024}
+}
+
+
+# Take latest as the default
+@misc{dandi.000017,
+  doi = {10.48324/DANDI.000017/0.240329.1926},
+  url = {https://dandiarchive.org/dandiset/000017/0.240329.1926},
+  author = {Steinmetz, Nicholas and Zatka-Haas, Peter and Carandini, Matteo and Harris, Kenneth},
+  keywords = {neuropixels},
+  title = {Distributed coding of choice, action and engagement across the mouse brain},
+  publisher = {DANDI Archive},
+  year = {2024}
+}
+
+
+# DANDISET 000019
+@misc{dandi.000019/0.220126.2148,
+  doi = {10.48324/DANDI.000019/0.220126.2148},
+  url = {https://dandiarchive.org/dandiset/000019/0.220126.2148},
+  author = {Bouchard, Kristofer E. and Chang, Edward F.},
+  keywords = {electrocorticography (ECoG), speech production},
+  title = {Human ECoG speaking consonant-vowel syllables},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# Take latest as the default
+@misc{dandi.000019,
+  doi = {10.48324/DANDI.000019/0.220126.2148},
+  url = {https://dandiarchive.org/dandiset/000019/0.220126.2148},
+  author = {Bouchard, Kristofer E. and Chang, Edward F.},
+  keywords = {electrocorticography (ECoG), speech production},
+  title = {Human ECoG speaking consonant-vowel syllables},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# DANDISET 000020
+@misc{dandi.000020/0.210913.1639,
+  doi = {10.48324/DANDI.000020/0.210913.1639},
+  url = {https://dandiarchive.org/dandiset/000020/0.210913.1639},
+  author = {Gouwens, Nathan},
+  keywords = {Patch-seq, mouse, visual cortex, interneuron},
+  title = {Patch-seq recordings from mouse visual cortex},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+# Take latest as the default
+@misc{dandi.000020,
+  doi = {10.48324/DANDI.000020/0.210913.1639},
+  url = {https://dandiarchive.org/dandiset/000020/0.210913.1639},
+  author = {Gouwens, Nathan},
+  keywords = {Patch-seq, mouse, visual cortex, interneuron},
+  title = {Patch-seq recordings from mouse visual cortex},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+# DANDISET 000023
+@misc{dandi.000023/0.210914.1900,
+  doi = {10.48324/DANDI.000023/0.210914.1900},
+  url = {https://dandiarchive.org/dandiset/000023/0.210914.1900},
+  author = {Kalmbach, Brian},
+  keywords = {Patch-seq, human, neocortex, layer 2/3},
+  title = {Patch-seq recordings from human cortex (June 2020)},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+# Take latest as the default
+@misc{dandi.000023,
+  doi = {10.48324/DANDI.000023/0.210914.1900},
+  url = {https://dandiarchive.org/dandiset/000023/0.210914.1900},
+  author = {Kalmbach, Brian},
+  keywords = {Patch-seq, human, neocortex, layer 2/3},
+  title = {Patch-seq recordings from human cortex (June 2020)},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+# DANDISET 000027
+@misc{dandi.000027/0.210831.2033,
+  doi = {10.48324/DANDI.000027/0.210831.2033},
+  url = {https://dandiarchive.org/dandiset/000027/0.210831.2033},
+  author = {Halchenko, Yaroslav O.},
+  keywords = {development},
+  title = {Test dataset for testing dandi-cli.},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+# Take latest as the default
+@misc{dandi.000027,
+  doi = {10.48324/DANDI.000027/0.210831.2033},
+  url = {https://dandiarchive.org/dandiset/000027/0.210831.2033},
+  author = {Halchenko, Yaroslav O.},
+  keywords = {development},
+  title = {Test dataset for testing dandi-cli.},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+# DANDISET 000029
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Error: DOI Not Found</title>
+
+
+
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css"
+          rel="stylesheet"
+          integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC"
+          crossorigin="anonymous">
+    <script
+            src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"
+            integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"
+            crossorigin="anonymous">
+    </script>
+
+    <script src="https://kit.fontawesome.com/731b8140c4.js" crossorigin="anonymous"></script>
+
+    <link rel="stylesheet" href="/static/css/style.css" integrity="">
+
+    <style>
+        @import url("https://fonts.googleapis.com/css2?family=Roboto+Mono&family=Roboto:wght@100&display=swap");
+    </style>
+
+    <link rel="icon" sizes="48x48" href="/static/images/favicons/favicon.ico">
+    <link rel="icon" sizes="32x32" href="/static/images/favicons/favicon-32x32.png">
+    <link rel="icon" sizes="16x16" href="/static/images/favicons/favicon-16x16.png">
+    <link rel="apple-touch-icon-precomposed" href="/static/images/favicons/apple-touch-icon.png">
+    <link rel="apple-touch-icon-precomposed" sizes="192x192" href="/static/images/favicons/android-chrome-192x192.png">
+    <link rel="apple-touch-icon-precomposed" sizes="512x512" href="/static/images/favicons/android-chrome-512x512.png">
+
+</head>
+<body class="generic-page">
+<header>
+    <div class="row">
+        <div class="col logo">
+            <a href="https://www.doi.org"><img class="header-logo" src="/static/images/logos/header_logo_cropped.svg" /></a>
+        </div>
+        <div class="col home-link">
+            <div class="link-alt">
+                <a href="https://www.doi.org">
+                    <span>VISIT DOI.ORG</span>
+                    <i class="fa-solid fa-arrow-right-long hover-move-right"></i>
+                </a>
+            </div>
+        </div>
+    </div>
+
+</header>
+
+
+<main aria-role="main">
+    <header class="homepage-header">
+    </header>
+    <div class="homepage-content">
+
+        <section class="single-top">
+            <div class="row short"></div>
+        </section>
+
+        <div class="page-content">
+            <article>
+                <div>
+                    <h2>DOI Not Found</h2>
+
+
+
+                    <h3>10.48324/dandi.000029/0.210712.1903</h3>
+
+
+
+
+                    <p>This DOI cannot be found in the DOI System.  Possible reasons are:</p>
+
+
+                    <ul>
+                        <li style="padding-bottom: .5em;">The DOI is incorrect in your source. Search for the item by name, title, or other metadata using a search engine.</li>
+                        <li style="padding-bottom: .5em;">The DOI was copied incorrectly. Check to see that the string includes all the characters before and after the slash and no sentence punctuation marks.</li>
+                        <li style="padding-bottom: .5em;">The DOI has not been activated yet. Please try again later, and report the problem if the error continues.</li>
+                    </ul>
+
+
+                </div>
+            </article>
+        </div>
+
+        <section class="home-infos">
+            <div class="row">
+                <div class="col ">
+                    <h2 class="title">WHAT CAN I DO NEXT?</h2>
+                    <ul>
+                        <li>If you believe this DOI is valid, you may <strong>report this error</strong> to the responsible DOI Registration Agency using the form here.</li>
+                        <li>If your organization is the steward of this DOI prefix, please make sure you have completed registration of this DOI with your Registration Agency.</li>
+                        <li>You can try to search again from <a href="https://www.doi.org">DOI.ORG homepage</a></li>
+                    </ul>
+                </div>
+                <div class="col form">
+                    <h2 class="title"><img src="/static/images/exclamation.svg">REPORT AN ERROR</h2>
+                    <form action="/notfound" method="post" enctype="application/x-www-form-urlencoded" name="notFoundForm" onsubmit="return submitDoiNotFound(event);">
+                        <div class="row">
+                            <div class="col"><label for="missingHandle">DOI:</label></div>
+                            <div class="col"><input id="missingHandle" name="missingHandle" value="10.48324/dandi.000029/0.210712.1903" type="text" readonly="readonly"></div>
+                        </div>
+                        <div class="row">
+                            <div class="col"><label for="referringPage">URL of Web Page Listing the DOI:</label></div>
+                            <div class="col"><input id="referringPage" name="referringPage" type="text" ></div>
+                        </div>
+                        <div class="row">
+                            <div class="col"><label for="userEmailAddress">Your Email Address:</label></div>
+                            <div class="col"><input id="userEmailAddress" name="userEmailAddress" type="text" /></div>
+                        </div>
+                        <div class="row">
+                            <div class="col"><label for="comments">Additional Information About the Error:</label></div>
+                            <div class="col"><textarea id="comments" name="comments"></textarea></div>
+                        </div>
+                        <div class="row">
+                            <div class="col"></div>
+                            <div class="col"><input class="submit" type="submit" value="Submit Error Report"></div>
+                        </div>
+                        <div class="row">
+                            <p id="invalidDoi" style="display: none; background:#F5B7B1; border-radius: 5px;">The DOI entered is not a valid DOI: it should start with 10 followed by a dot, and contain a slash with no preceding whitespace.</p>
+                            <p id="invalidEmail" style="display: none; background:#F5B7B1; border-radius: 5px;">The email address entered is invalid.</p>
+                            <p id="fallback" style="display: none;">Please <a href="mailto:doi-help@doi.org?subject=DOI%20Not%20Found">contact us</a> if you wish to report this anyway.</p>
+                        </div>
+                    </form>
+                </div>
+            </div>
+
+        </section>
+    </div>
+
+
+</main>
+
+<footer>
+    <div class="row">
+        <div class="col footer-left">
+            <a href="https://www.doi.org"><img class="footer-logo" src="/static/images/logos/footer_logo_cropped.svg" /></a>
+        </div>
+        <div class="col footer-right">
+            <div class="row more-info-heading">
+                <div class="col">
+                    <h2>More information on DOI resolution:</h2>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col">
+                    <ul>
+                        <li><a href="https://www.doi.org/the-identifier/resources/factsheets/doi-resolution-documentation">DOI Resolution Factsheet</a></li>
+                    </ul>
+                </div>
+                <div class="col">
+                    <ul>
+                        <li><a href="https://www.doi.org/the-identifier/resources/handbook">The DOI Handbook</a></li>
+                    </ul>
+                </div>
+                <div class="col">
+                    <ul>
+                        <li><a href="https://www.doi.org/privacy-policy/">Privacy Policy</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+
+    </div>
+    <div class="row">
+        <div class="col copyright">
+            <p>Copyright © 2023 DOI Foundation. <i class="fa-brands fa-fw fa-creative-commons"></i><i class="fa-brands fa-fw fa-creative-commons-by"></i> The content of this site is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/" title="Creative Commons" target="_blank">Creative Commons Attribution 4.0 International License</a>.</p><p>DOI&reg;, DOI.ORG&reg;, and shortDOI&reg; are trademarks of the DOI Foundation.</p>
+        </div>
+        <div class="col socials">
+            <ul class="socials-footer">
+
+                <li><a href="https://twitter.com/DOI_Foundation"><i class="fa-brands fa-fw fa-twitter"></i></a></li>
+
+                <li><a href="https://www.linkedin.com/company/doi-foundation-inc/"><i class="fa-brands fa-fw fa-linkedin"></i></a></li>
+
+                <li><a href="mailto:info@doi.org"><i class="fa-solid fa-fw fa-envelope"></i></a></li>
+
+            </ul>
+        </div>
+    </div>
+</footer>
+
+<script type="text/javascript">
+    function submitDoiNotFound(event) {
+        try {
+            document.getElementById("invalidEmail").style.display = "none";
+            document.getElementById("invalidDoi").style.display = "none";
+            document.getElementById("fallback").style.display = "none";
+
+            const missingHandle = document.getElementById('missingHandle').value.trim();
+            const userEmailAddress = document.getElementById('userEmailAddress').value.trim();
+
+            if (!validateDoi(missingHandle)) {
+                event.preventDefault();
+                document.getElementById("invalidDoi").style.display = "block";
+                document.getElementById("fallback").style.display = "block";
+                return false;
+            }
+            if (!validateEmail(userEmailAddress)) {
+                event.preventDefault();
+                document.getElementById("invalidEmail").style.display = "block";
+                return false;
+            }
+        } catch (error) {
+            // ignore
+        }
+    }
+
+    function validateEmail(email) {
+        const regEx = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        return regEx.test(email);
+    }
+
+    function validateDoi(doi) {
+        const regEx = /^10(?:\.[^\s\/]+)?\//;
+        return regEx.test(doi);
+    }
+</script>
+
+</body>
+</html>
+
+
+@misc{dandi.000029/0.210730.1538,
+  doi = {10.48324/DANDI.000029/0.210730.1538},
+  url = {https://dandiarchive.org/dandiset/000029/0.210730.1538},
+  author = {Last, First},
+  keywords = {development},
+  title = {Test dataset for development purposes},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+@misc{dandi.000029/0.210805.2047,
+  doi = {10.48324/DANDI.000029/0.210805.2047},
+  url = {https://dandiarchive.org/dandiset/000029/0.210805.2047},
+  author = {Last, First},
+  keywords = {development},
+  title = {Test dataset for development purposes},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+@misc{dandi.000029/0.210806.1511,
+  doi = {10.48324/DANDI.000029/0.210806.1511},
+  url = {https://dandiarchive.org/dandiset/000029/0.210806.1511},
+  author = {Last, First},
+  keywords = {development},
+  title = {Test dataset for development purposes},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+@misc{dandi.000029/0.210806.2112,
+  doi = {10.48324/DANDI.000029/0.210806.2112},
+  url = {https://dandiarchive.org/dandiset/000029/0.210806.2112},
+  author = {Last, First},
+  keywords = {development},
+  title = {Test dataset for development purposes},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+@misc{dandi.000029/0.210915.1646,
+  doi = {10.48324/DANDI.000029/0.210915.1646},
+  url = {https://dandiarchive.org/dandiset/000029/0.210915.1646},
+  author = {Last, First},
+  keywords = {development},
+  title = {Test dataset for development purposes},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+@misc{dandi.000029/0.221107.2344,
+  doi = {10.48324/DANDI.000029/0.221107.2344},
+  url = {https://dandiarchive.org/dandiset/000029/0.221107.2344},
+  author = {Last, First},
+  keywords = {development},
+  title = {Test dataset for development purposes},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+@misc{dandi.000029/0.230317.1541,
+  doi = {10.48324/DANDI.000029/0.230317.1541},
+  url = {https://dandiarchive.org/dandiset/000029/0.230317.1541},
+  author = {Last, First},
+  keywords = {development},
+  title = {Test dataset for development purposes},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Error: DOI Not Found</title>
+
+
+
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css"
+          rel="stylesheet"
+          integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC"
+          crossorigin="anonymous">
+    <script
+            src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"
+            integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"
+            crossorigin="anonymous">
+    </script>
+
+    <script src="https://kit.fontawesome.com/731b8140c4.js" crossorigin="anonymous"></script>
+
+    <link rel="stylesheet" href="/static/css/style.css" integrity="">
+
+    <style>
+        @import url("https://fonts.googleapis.com/css2?family=Roboto+Mono&family=Roboto:wght@100&display=swap");
+    </style>
+
+    <link rel="icon" sizes="48x48" href="/static/images/favicons/favicon.ico">
+    <link rel="icon" sizes="32x32" href="/static/images/favicons/favicon-32x32.png">
+    <link rel="icon" sizes="16x16" href="/static/images/favicons/favicon-16x16.png">
+    <link rel="apple-touch-icon-precomposed" href="/static/images/favicons/apple-touch-icon.png">
+    <link rel="apple-touch-icon-precomposed" sizes="192x192" href="/static/images/favicons/android-chrome-192x192.png">
+    <link rel="apple-touch-icon-precomposed" sizes="512x512" href="/static/images/favicons/android-chrome-512x512.png">
+
+</head>
+<body class="generic-page">
+<header>
+    <div class="row">
+        <div class="col logo">
+            <a href="https://www.doi.org"><img class="header-logo" src="/static/images/logos/header_logo_cropped.svg" /></a>
+        </div>
+        <div class="col home-link">
+            <div class="link-alt">
+                <a href="https://www.doi.org">
+                    <span>VISIT DOI.ORG</span>
+                    <i class="fa-solid fa-arrow-right-long hover-move-right"></i>
+                </a>
+            </div>
+        </div>
+    </div>
+
+</header>
+
+
+<main aria-role="main">
+    <header class="homepage-header">
+    </header>
+    <div class="homepage-content">
+
+        <section class="single-top">
+            <div class="row short"></div>
+        </section>
+
+        <div class="page-content">
+            <article>
+                <div>
+                    <h2>DOI Not Found</h2>
+
+
+
+                    <h3>10.48324/dandi.000029/0.230317.1553</h3>
+
+
+
+
+                    <p>This DOI cannot be found in the DOI System.  Possible reasons are:</p>
+
+
+                    <ul>
+                        <li style="padding-bottom: .5em;">The DOI is incorrect in your source. Search for the item by name, title, or other metadata using a search engine.</li>
+                        <li style="padding-bottom: .5em;">The DOI was copied incorrectly. Check to see that the string includes all the characters before and after the slash and no sentence punctuation marks.</li>
+                        <li style="padding-bottom: .5em;">The DOI has not been activated yet. Please try again later, and report the problem if the error continues.</li>
+                    </ul>
+
+
+                </div>
+            </article>
+        </div>
+
+        <section class="home-infos">
+            <div class="row">
+                <div class="col ">
+                    <h2 class="title">WHAT CAN I DO NEXT?</h2>
+                    <ul>
+                        <li>If you believe this DOI is valid, you may <strong>report this error</strong> to the responsible DOI Registration Agency using the form here.</li>
+                        <li>If your organization is the steward of this DOI prefix, please make sure you have completed registration of this DOI with your Registration Agency.</li>
+                        <li>You can try to search again from <a href="https://www.doi.org">DOI.ORG homepage</a></li>
+                    </ul>
+                </div>
+                <div class="col form">
+                    <h2 class="title"><img src="/static/images/exclamation.svg">REPORT AN ERROR</h2>
+                    <form action="/notfound" method="post" enctype="application/x-www-form-urlencoded" name="notFoundForm" onsubmit="return submitDoiNotFound(event);">
+                        <div class="row">
+                            <div class="col"><label for="missingHandle">DOI:</label></div>
+                            <div class="col"><input id="missingHandle" name="missingHandle" value="10.48324/dandi.000029/0.230317.1553" type="text" readonly="readonly"></div>
+                        </div>
+                        <div class="row">
+                            <div class="col"><label for="referringPage">URL of Web Page Listing the DOI:</label></div>
+                            <div class="col"><input id="referringPage" name="referringPage" type="text" ></div>
+                        </div>
+                        <div class="row">
+                            <div class="col"><label for="userEmailAddress">Your Email Address:</label></div>
+                            <div class="col"><input id="userEmailAddress" name="userEmailAddress" type="text" /></div>
+                        </div>
+                        <div class="row">
+                            <div class="col"><label for="comments">Additional Information About the Error:</label></div>
+                            <div class="col"><textarea id="comments" name="comments"></textarea></div>
+                        </div>
+                        <div class="row">
+                            <div class="col"></div>
+                            <div class="col"><input class="submit" type="submit" value="Submit Error Report"></div>
+                        </div>
+                        <div class="row">
+                            <p id="invalidDoi" style="display: none; background:#F5B7B1; border-radius: 5px;">The DOI entered is not a valid DOI: it should start with 10 followed by a dot, and contain a slash with no preceding whitespace.</p>
+                            <p id="invalidEmail" style="display: none; background:#F5B7B1; border-radius: 5px;">The email address entered is invalid.</p>
+                            <p id="fallback" style="display: none;">Please <a href="mailto:doi-help@doi.org?subject=DOI%20Not%20Found">contact us</a> if you wish to report this anyway.</p>
+                        </div>
+                    </form>
+                </div>
+            </div>
+
+        </section>
+    </div>
+
+
+</main>
+
+<footer>
+    <div class="row">
+        <div class="col footer-left">
+            <a href="https://www.doi.org"><img class="footer-logo" src="/static/images/logos/footer_logo_cropped.svg" /></a>
+        </div>
+        <div class="col footer-right">
+            <div class="row more-info-heading">
+                <div class="col">
+                    <h2>More information on DOI resolution:</h2>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col">
+                    <ul>
+                        <li><a href="https://www.doi.org/the-identifier/resources/factsheets/doi-resolution-documentation">DOI Resolution Factsheet</a></li>
+                    </ul>
+                </div>
+                <div class="col">
+                    <ul>
+                        <li><a href="https://www.doi.org/the-identifier/resources/handbook">The DOI Handbook</a></li>
+                    </ul>
+                </div>
+                <div class="col">
+                    <ul>
+                        <li><a href="https://www.doi.org/privacy-policy/">Privacy Policy</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+
+    </div>
+    <div class="row">
+        <div class="col copyright">
+            <p>Copyright © 2023 DOI Foundation. <i class="fa-brands fa-fw fa-creative-commons"></i><i class="fa-brands fa-fw fa-creative-commons-by"></i> The content of this site is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/" title="Creative Commons" target="_blank">Creative Commons Attribution 4.0 International License</a>.</p><p>DOI&reg;, DOI.ORG&reg;, and shortDOI&reg; are trademarks of the DOI Foundation.</p>
+        </div>
+        <div class="col socials">
+            <ul class="socials-footer">
+
+                <li><a href="https://twitter.com/DOI_Foundation"><i class="fa-brands fa-fw fa-twitter"></i></a></li>
+
+                <li><a href="https://www.linkedin.com/company/doi-foundation-inc/"><i class="fa-brands fa-fw fa-linkedin"></i></a></li>
+
+                <li><a href="mailto:info@doi.org"><i class="fa-solid fa-fw fa-envelope"></i></a></li>
+
+            </ul>
+        </div>
+    </div>
+</footer>
+
+<script type="text/javascript">
+    function submitDoiNotFound(event) {
+        try {
+            document.getElementById("invalidEmail").style.display = "none";
+            document.getElementById("invalidDoi").style.display = "none";
+            document.getElementById("fallback").style.display = "none";
+
+            const missingHandle = document.getElementById('missingHandle').value.trim();
+            const userEmailAddress = document.getElementById('userEmailAddress').value.trim();
+
+            if (!validateDoi(missingHandle)) {
+                event.preventDefault();
+                document.getElementById("invalidDoi").style.display = "block";
+                document.getElementById("fallback").style.display = "block";
+                return false;
+            }
+            if (!validateEmail(userEmailAddress)) {
+                event.preventDefault();
+                document.getElementById("invalidEmail").style.display = "block";
+                return false;
+            }
+        } catch (error) {
+            // ignore
+        }
+    }
+
+    function validateEmail(email) {
+        const regEx = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        return regEx.test(email);
+    }
+
+    function validateDoi(doi) {
+        const regEx = /^10(?:\.[^\s\/]+)?\//;
+        return regEx.test(doi);
+    }
+</script>
+
+</body>
+</html>
+
+
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Error: DOI Not Found</title>
+
+
+
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css"
+          rel="stylesheet"
+          integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC"
+          crossorigin="anonymous">
+    <script
+            src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"
+            integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"
+            crossorigin="anonymous">
+    </script>
+
+    <script src="https://kit.fontawesome.com/731b8140c4.js" crossorigin="anonymous"></script>
+
+    <link rel="stylesheet" href="/static/css/style.css" integrity="">
+
+    <style>
+        @import url("https://fonts.googleapis.com/css2?family=Roboto+Mono&family=Roboto:wght@100&display=swap");
+    </style>
+
+    <link rel="icon" sizes="48x48" href="/static/images/favicons/favicon.ico">
+    <link rel="icon" sizes="32x32" href="/static/images/favicons/favicon-32x32.png">
+    <link rel="icon" sizes="16x16" href="/static/images/favicons/favicon-16x16.png">
+    <link rel="apple-touch-icon-precomposed" href="/static/images/favicons/apple-touch-icon.png">
+    <link rel="apple-touch-icon-precomposed" sizes="192x192" href="/static/images/favicons/android-chrome-192x192.png">
+    <link rel="apple-touch-icon-precomposed" sizes="512x512" href="/static/images/favicons/android-chrome-512x512.png">
+
+</head>
+<body class="generic-page">
+<header>
+    <div class="row">
+        <div class="col logo">
+            <a href="https://www.doi.org"><img class="header-logo" src="/static/images/logos/header_logo_cropped.svg" /></a>
+        </div>
+        <div class="col home-link">
+            <div class="link-alt">
+                <a href="https://www.doi.org">
+                    <span>VISIT DOI.ORG</span>
+                    <i class="fa-solid fa-arrow-right-long hover-move-right"></i>
+                </a>
+            </div>
+        </div>
+    </div>
+
+</header>
+
+
+<main aria-role="main">
+    <header class="homepage-header">
+    </header>
+    <div class="homepage-content">
+
+        <section class="single-top">
+            <div class="row short"></div>
+        </section>
+
+        <div class="page-content">
+            <article>
+                <div>
+                    <h2>DOI Not Found</h2>
+
+
+
+                    <h3>10.48324/dandi.000029/0.231017.1955</h3>
+
+
+
+
+                    <p>This DOI cannot be found in the DOI System.  Possible reasons are:</p>
+
+
+                    <ul>
+                        <li style="padding-bottom: .5em;">The DOI is incorrect in your source. Search for the item by name, title, or other metadata using a search engine.</li>
+                        <li style="padding-bottom: .5em;">The DOI was copied incorrectly. Check to see that the string includes all the characters before and after the slash and no sentence punctuation marks.</li>
+                        <li style="padding-bottom: .5em;">The DOI has not been activated yet. Please try again later, and report the problem if the error continues.</li>
+                    </ul>
+
+
+                </div>
+            </article>
+        </div>
+
+        <section class="home-infos">
+            <div class="row">
+                <div class="col ">
+                    <h2 class="title">WHAT CAN I DO NEXT?</h2>
+                    <ul>
+                        <li>If you believe this DOI is valid, you may <strong>report this error</strong> to the responsible DOI Registration Agency using the form here.</li>
+                        <li>If your organization is the steward of this DOI prefix, please make sure you have completed registration of this DOI with your Registration Agency.</li>
+                        <li>You can try to search again from <a href="https://www.doi.org">DOI.ORG homepage</a></li>
+                    </ul>
+                </div>
+                <div class="col form">
+                    <h2 class="title"><img src="/static/images/exclamation.svg">REPORT AN ERROR</h2>
+                    <form action="/notfound" method="post" enctype="application/x-www-form-urlencoded" name="notFoundForm" onsubmit="return submitDoiNotFound(event);">
+                        <div class="row">
+                            <div class="col"><label for="missingHandle">DOI:</label></div>
+                            <div class="col"><input id="missingHandle" name="missingHandle" value="10.48324/dandi.000029/0.231017.1955" type="text" readonly="readonly"></div>
+                        </div>
+                        <div class="row">
+                            <div class="col"><label for="referringPage">URL of Web Page Listing the DOI:</label></div>
+                            <div class="col"><input id="referringPage" name="referringPage" type="text" ></div>
+                        </div>
+                        <div class="row">
+                            <div class="col"><label for="userEmailAddress">Your Email Address:</label></div>
+                            <div class="col"><input id="userEmailAddress" name="userEmailAddress" type="text" /></div>
+                        </div>
+                        <div class="row">
+                            <div class="col"><label for="comments">Additional Information About the Error:</label></div>
+                            <div class="col"><textarea id="comments" name="comments"></textarea></div>
+                        </div>
+                        <div class="row">
+                            <div class="col"></div>
+                            <div class="col"><input class="submit" type="submit" value="Submit Error Report"></div>
+                        </div>
+                        <div class="row">
+                            <p id="invalidDoi" style="display: none; background:#F5B7B1; border-radius: 5px;">The DOI entered is not a valid DOI: it should start with 10 followed by a dot, and contain a slash with no preceding whitespace.</p>
+                            <p id="invalidEmail" style="display: none; background:#F5B7B1; border-radius: 5px;">The email address entered is invalid.</p>
+                            <p id="fallback" style="display: none;">Please <a href="mailto:doi-help@doi.org?subject=DOI%20Not%20Found">contact us</a> if you wish to report this anyway.</p>
+                        </div>
+                    </form>
+                </div>
+            </div>
+
+        </section>
+    </div>
+
+
+</main>
+
+<footer>
+    <div class="row">
+        <div class="col footer-left">
+            <a href="https://www.doi.org"><img class="footer-logo" src="/static/images/logos/footer_logo_cropped.svg" /></a>
+        </div>
+        <div class="col footer-right">
+            <div class="row more-info-heading">
+                <div class="col">
+                    <h2>More information on DOI resolution:</h2>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col">
+                    <ul>
+                        <li><a href="https://www.doi.org/the-identifier/resources/factsheets/doi-resolution-documentation">DOI Resolution Factsheet</a></li>
+                    </ul>
+                </div>
+                <div class="col">
+                    <ul>
+                        <li><a href="https://www.doi.org/the-identifier/resources/handbook">The DOI Handbook</a></li>
+                    </ul>
+                </div>
+                <div class="col">
+                    <ul>
+                        <li><a href="https://www.doi.org/privacy-policy/">Privacy Policy</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+
+    </div>
+    <div class="row">
+        <div class="col copyright">
+            <p>Copyright © 2023 DOI Foundation. <i class="fa-brands fa-fw fa-creative-commons"></i><i class="fa-brands fa-fw fa-creative-commons-by"></i> The content of this site is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/" title="Creative Commons" target="_blank">Creative Commons Attribution 4.0 International License</a>.</p><p>DOI&reg;, DOI.ORG&reg;, and shortDOI&reg; are trademarks of the DOI Foundation.</p>
+        </div>
+        <div class="col socials">
+            <ul class="socials-footer">
+
+                <li><a href="https://twitter.com/DOI_Foundation"><i class="fa-brands fa-fw fa-twitter"></i></a></li>
+
+                <li><a href="https://www.linkedin.com/company/doi-foundation-inc/"><i class="fa-brands fa-fw fa-linkedin"></i></a></li>
+
+                <li><a href="mailto:info@doi.org"><i class="fa-solid fa-fw fa-envelope"></i></a></li>
+
+            </ul>
+        </div>
+    </div>
+</footer>
+
+<script type="text/javascript">
+    function submitDoiNotFound(event) {
+        try {
+            document.getElementById("invalidEmail").style.display = "none";
+            document.getElementById("invalidDoi").style.display = "none";
+            document.getElementById("fallback").style.display = "none";
+
+            const missingHandle = document.getElementById('missingHandle').value.trim();
+            const userEmailAddress = document.getElementById('userEmailAddress').value.trim();
+
+            if (!validateDoi(missingHandle)) {
+                event.preventDefault();
+                document.getElementById("invalidDoi").style.display = "block";
+                document.getElementById("fallback").style.display = "block";
+                return false;
+            }
+            if (!validateEmail(userEmailAddress)) {
+                event.preventDefault();
+                document.getElementById("invalidEmail").style.display = "block";
+                return false;
+            }
+        } catch (error) {
+            // ignore
+        }
+    }
+
+    function validateEmail(email) {
+        const regEx = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        return regEx.test(email);
+    }
+
+    function validateDoi(doi) {
+        const regEx = /^10(?:\.[^\s\/]+)?\//;
+        return regEx.test(doi);
+    }
+</script>
+
+</body>
+</html>
+
+
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Error: DOI Not Found</title>
+
+
+
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css"
+          rel="stylesheet"
+          integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC"
+          crossorigin="anonymous">
+    <script
+            src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"
+            integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"
+            crossorigin="anonymous">
+    </script>
+
+    <script src="https://kit.fontawesome.com/731b8140c4.js" crossorigin="anonymous"></script>
+
+    <link rel="stylesheet" href="/static/css/style.css" integrity="">
+
+    <style>
+        @import url("https://fonts.googleapis.com/css2?family=Roboto+Mono&family=Roboto:wght@100&display=swap");
+    </style>
+
+    <link rel="icon" sizes="48x48" href="/static/images/favicons/favicon.ico">
+    <link rel="icon" sizes="32x32" href="/static/images/favicons/favicon-32x32.png">
+    <link rel="icon" sizes="16x16" href="/static/images/favicons/favicon-16x16.png">
+    <link rel="apple-touch-icon-precomposed" href="/static/images/favicons/apple-touch-icon.png">
+    <link rel="apple-touch-icon-precomposed" sizes="192x192" href="/static/images/favicons/android-chrome-192x192.png">
+    <link rel="apple-touch-icon-precomposed" sizes="512x512" href="/static/images/favicons/android-chrome-512x512.png">
+
+</head>
+<body class="generic-page">
+<header>
+    <div class="row">
+        <div class="col logo">
+            <a href="https://www.doi.org"><img class="header-logo" src="/static/images/logos/header_logo_cropped.svg" /></a>
+        </div>
+        <div class="col home-link">
+            <div class="link-alt">
+                <a href="https://www.doi.org">
+                    <span>VISIT DOI.ORG</span>
+                    <i class="fa-solid fa-arrow-right-long hover-move-right"></i>
+                </a>
+            </div>
+        </div>
+    </div>
+
+</header>
+
+
+<main aria-role="main">
+    <header class="homepage-header">
+    </header>
+    <div class="homepage-content">
+
+        <section class="single-top">
+            <div class="row short"></div>
+        </section>
+
+        <div class="page-content">
+            <article>
+                <div>
+                    <h2>DOI Not Found</h2>
+
+
+
+                    <h3>10.48324/dandi.000029/0.231017.1959</h3>
+
+
+
+
+                    <p>This DOI cannot be found in the DOI System.  Possible reasons are:</p>
+
+
+                    <ul>
+                        <li style="padding-bottom: .5em;">The DOI is incorrect in your source. Search for the item by name, title, or other metadata using a search engine.</li>
+                        <li style="padding-bottom: .5em;">The DOI was copied incorrectly. Check to see that the string includes all the characters before and after the slash and no sentence punctuation marks.</li>
+                        <li style="padding-bottom: .5em;">The DOI has not been activated yet. Please try again later, and report the problem if the error continues.</li>
+                    </ul>
+
+
+                </div>
+            </article>
+        </div>
+
+        <section class="home-infos">
+            <div class="row">
+                <div class="col ">
+                    <h2 class="title">WHAT CAN I DO NEXT?</h2>
+                    <ul>
+                        <li>If you believe this DOI is valid, you may <strong>report this error</strong> to the responsible DOI Registration Agency using the form here.</li>
+                        <li>If your organization is the steward of this DOI prefix, please make sure you have completed registration of this DOI with your Registration Agency.</li>
+                        <li>You can try to search again from <a href="https://www.doi.org">DOI.ORG homepage</a></li>
+                    </ul>
+                </div>
+                <div class="col form">
+                    <h2 class="title"><img src="/static/images/exclamation.svg">REPORT AN ERROR</h2>
+                    <form action="/notfound" method="post" enctype="application/x-www-form-urlencoded" name="notFoundForm" onsubmit="return submitDoiNotFound(event);">
+                        <div class="row">
+                            <div class="col"><label for="missingHandle">DOI:</label></div>
+                            <div class="col"><input id="missingHandle" name="missingHandle" value="10.48324/dandi.000029/0.231017.1959" type="text" readonly="readonly"></div>
+                        </div>
+                        <div class="row">
+                            <div class="col"><label for="referringPage">URL of Web Page Listing the DOI:</label></div>
+                            <div class="col"><input id="referringPage" name="referringPage" type="text" ></div>
+                        </div>
+                        <div class="row">
+                            <div class="col"><label for="userEmailAddress">Your Email Address:</label></div>
+                            <div class="col"><input id="userEmailAddress" name="userEmailAddress" type="text" /></div>
+                        </div>
+                        <div class="row">
+                            <div class="col"><label for="comments">Additional Information About the Error:</label></div>
+                            <div class="col"><textarea id="comments" name="comments"></textarea></div>
+                        </div>
+                        <div class="row">
+                            <div class="col"></div>
+                            <div class="col"><input class="submit" type="submit" value="Submit Error Report"></div>
+                        </div>
+                        <div class="row">
+                            <p id="invalidDoi" style="display: none; background:#F5B7B1; border-radius: 5px;">The DOI entered is not a valid DOI: it should start with 10 followed by a dot, and contain a slash with no preceding whitespace.</p>
+                            <p id="invalidEmail" style="display: none; background:#F5B7B1; border-radius: 5px;">The email address entered is invalid.</p>
+                            <p id="fallback" style="display: none;">Please <a href="mailto:doi-help@doi.org?subject=DOI%20Not%20Found">contact us</a> if you wish to report this anyway.</p>
+                        </div>
+                    </form>
+                </div>
+            </div>
+
+        </section>
+    </div>
+
+
+</main>
+
+<footer>
+    <div class="row">
+        <div class="col footer-left">
+            <a href="https://www.doi.org"><img class="footer-logo" src="/static/images/logos/footer_logo_cropped.svg" /></a>
+        </div>
+        <div class="col footer-right">
+            <div class="row more-info-heading">
+                <div class="col">
+                    <h2>More information on DOI resolution:</h2>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col">
+                    <ul>
+                        <li><a href="https://www.doi.org/the-identifier/resources/factsheets/doi-resolution-documentation">DOI Resolution Factsheet</a></li>
+                    </ul>
+                </div>
+                <div class="col">
+                    <ul>
+                        <li><a href="https://www.doi.org/the-identifier/resources/handbook">The DOI Handbook</a></li>
+                    </ul>
+                </div>
+                <div class="col">
+                    <ul>
+                        <li><a href="https://www.doi.org/privacy-policy/">Privacy Policy</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+
+    </div>
+    <div class="row">
+        <div class="col copyright">
+            <p>Copyright © 2023 DOI Foundation. <i class="fa-brands fa-fw fa-creative-commons"></i><i class="fa-brands fa-fw fa-creative-commons-by"></i> The content of this site is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/" title="Creative Commons" target="_blank">Creative Commons Attribution 4.0 International License</a>.</p><p>DOI&reg;, DOI.ORG&reg;, and shortDOI&reg; are trademarks of the DOI Foundation.</p>
+        </div>
+        <div class="col socials">
+            <ul class="socials-footer">
+
+                <li><a href="https://twitter.com/DOI_Foundation"><i class="fa-brands fa-fw fa-twitter"></i></a></li>
+
+                <li><a href="https://www.linkedin.com/company/doi-foundation-inc/"><i class="fa-brands fa-fw fa-linkedin"></i></a></li>
+
+                <li><a href="mailto:info@doi.org"><i class="fa-solid fa-fw fa-envelope"></i></a></li>
+
+            </ul>
+        </div>
+    </div>
+</footer>
+
+<script type="text/javascript">
+    function submitDoiNotFound(event) {
+        try {
+            document.getElementById("invalidEmail").style.display = "none";
+            document.getElementById("invalidDoi").style.display = "none";
+            document.getElementById("fallback").style.display = "none";
+
+            const missingHandle = document.getElementById('missingHandle').value.trim();
+            const userEmailAddress = document.getElementById('userEmailAddress').value.trim();
+
+            if (!validateDoi(missingHandle)) {
+                event.preventDefault();
+                document.getElementById("invalidDoi").style.display = "block";
+                document.getElementById("fallback").style.display = "block";
+                return false;
+            }
+            if (!validateEmail(userEmailAddress)) {
+                event.preventDefault();
+                document.getElementById("invalidEmail").style.display = "block";
+                return false;
+            }
+        } catch (error) {
+            // ignore
+        }
+    }
+
+    function validateEmail(email) {
+        const regEx = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        return regEx.test(email);
+    }
+
+    function validateDoi(doi) {
+        const regEx = /^10(?:\.[^\s\/]+)?\//;
+        return regEx.test(doi);
+    }
+</script>
+
+</body>
+</html>
+
+
+@misc{dandi.000029/0.231017.2004,
+  doi = {10.48324/DANDI.000029/0.231017.2004},
+  url = {https://dandiarchive.org/dandiset/000029/0.231017.2004},
+  author = {Last, First},
+  keywords = {development},
+  title = {Test dataset for development purposes},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# Take latest as the default
+@misc{dandi.000029,
+  doi = {10.48324/DANDI.000029/0.231017.2004},
+  url = {https://dandiarchive.org/dandiset/000029/0.231017.2004},
+  author = {Last, First},
+  keywords = {development},
+  title = {Test dataset for development purposes},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# DANDISET 000034
+@misc{dandi.000034/0.211030.0713,
+  doi = {10.48324/DANDI.000034/0.211030.0713},
+  url = {https://dandiarchive.org/dandiset/000034/0.211030.0713},
+  author = {Buccino, Alessio},
+  keywords = {Spike Sorting, extracellular electrophysiology},
+  title = {SpikeInterface, a unified framework for spike sorting},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+# Take latest as the default
+@misc{dandi.000034,
+  doi = {10.48324/DANDI.000034/0.211030.0713},
+  url = {https://dandiarchive.org/dandiset/000034/0.211030.0713},
+  author = {Buccino, Alessio},
+  keywords = {Spike Sorting, extracellular electrophysiology},
+  title = {SpikeInterface, a unified framework for spike sorting},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+# DANDISET 000035
+@misc{dandi.000035/0.211014.0808,
+  doi = {10.48324/DANDI.000035/0.211014.0808},
+  url = {https://dandiarchive.org/dandiset/000035/0.211014.0808},
+  author = {Scala, Federico and Kobak, Dmitry and Bernabucci, Matteo and Bernaerts, Yves and Cadwell, Cathryn Rene and Castro, Jesus Ramon and Hartmanis, Leonard and Jiang, Xiaolong and Laturnus, Sophie and Miranda, Elanine and Mulherkar, Shalaka and Tan, Zheng Huan and Yao, Zizhen and Last, First and Zeng, Hongkui and Sandberg, Rickard and Berens, Philipp and Tolias, Andreas Savas},
+  keywords = {Patch-seq, mouse, cortex, motor cortex},
+  title = {Temperature-controlled intracellular Patch-seq recordings in mouse motor cortex},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+# Take latest as the default
+@misc{dandi.000035,
+  doi = {10.48324/DANDI.000035/0.211014.0808},
+  url = {https://dandiarchive.org/dandiset/000035/0.211014.0808},
+  author = {Scala, Federico and Kobak, Dmitry and Bernabucci, Matteo and Bernaerts, Yves and Cadwell, Cathryn Rene and Castro, Jesus Ramon and Hartmanis, Leonard and Jiang, Xiaolong and Laturnus, Sophie and Miranda, Elanine and Mulherkar, Shalaka and Tan, Zheng Huan and Yao, Zizhen and Last, First and Zeng, Hongkui and Sandberg, Rickard and Berens, Philipp and Tolias, Andreas Savas},
+  keywords = {Patch-seq, mouse, cortex, motor cortex},
+  title = {Temperature-controlled intracellular Patch-seq recordings in mouse motor cortex},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+# DANDISET 000036
+@misc{dandi.000036/0.230515.1917,
+  doi = {10.48324/DANDI.000036/0.230515.1917},
+  url = {https://dandiarchive.org/dandiset/000036/0.230515.1917},
+  author = {Lecoq, Jerome and Mayner, Will},
+  keywords = {two photon imaging, visual stimuli, mice, openscope},
+  title = {Allen Institute Openscope - Measuring Stimulus-Evoked Neurophysiological Differentiation in Distinct Populations of Neurons in Mouse Visual Cortex},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# Take latest as the default
+@misc{dandi.000036,
+  doi = {10.48324/DANDI.000036/0.230515.1917},
+  url = {https://dandiarchive.org/dandiset/000036/0.230515.1917},
+  author = {Lecoq, Jerome and Mayner, Will},
+  keywords = {two photon imaging, visual stimuli, mice, openscope},
+  title = {Allen Institute Openscope - Measuring Stimulus-Evoked Neurophysiological Differentiation in Distinct Populations of Neurons in Mouse Visual Cortex},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# DANDISET 000037
+@misc{dandi.000037/0.230426.0054,
+  doi = {10.48324/DANDI.000037/0.230426.0054},
+  url = {https://dandiarchive.org/dandiset/000037/0.230426.0054},
+  author = {Gillon, Colleen J. and Lecoq, Jérôme A. and Pina, Jason E. and Zylberberg, Joel and Richards, Blake A.},
+  keywords = {learning, neocortex, pyramidal neurons, distal apical dendrites, somata, L2/3, L5, two-photon calcium imaging, mouse VisP, prediction, credit assignment},
+  title = {Allen Institute Openscope - Responses to inconsistent stimuli in somata and distal apical dendrites in primary visual cortex},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+@misc{dandi.000037/0.240209.1623,
+  doi = {10.48324/DANDI.000037/0.240209.1623},
+  url = {https://dandiarchive.org/dandiset/000037/0.240209.1623},
+  author = {Gillon, Colleen J. and Lecoq, Jérôme A. and Pina, Jason E. and Zylberberg, Joel and Richards, Blake A.},
+  keywords = {learning, neocortex, pyramidal neurons, distal apical dendrites, somata, L2/3, L5, two-photon calcium imaging, mouse VisP, prediction, credit assignment},
+  title = {Allen Institute Openscope - Responses to inconsistent stimuli in somata and distal apical dendrites in primary visual cortex},
+  publisher = {DANDI Archive},
+  year = {2024}
+}
+
+
+# Take latest as the default
+@misc{dandi.000037,
+  doi = {10.48324/DANDI.000037/0.240209.1623},
+  url = {https://dandiarchive.org/dandiset/000037/0.240209.1623},
+  author = {Gillon, Colleen J. and Lecoq, Jérôme A. and Pina, Jason E. and Zylberberg, Joel and Richards, Blake A.},
+  keywords = {learning, neocortex, pyramidal neurons, distal apical dendrites, somata, L2/3, L5, two-photon calcium imaging, mouse VisP, prediction, credit assignment},
+  title = {Allen Institute Openscope - Responses to inconsistent stimuli in somata and distal apical dendrites in primary visual cortex},
+  publisher = {DANDI Archive},
+  year = {2024}
+}
+
+
+# DANDISET 000039
+@misc{dandi.000039/0.210902.2328,
+  doi = {10.48324/DANDI.000039/0.210902.2328},
+  url = {https://dandiarchive.org/dandiset/000039/0.210902.2328},
+  author = {Millman, Dan and Vries, Saskia de},
+  keywords = {vision, visual cortex, inhibition, inhibitory circuits, circuit dynamics, gain control},
+  title = {Allen Institute – Contrast tuning in mouse visual cortex with calcium imaging},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+@misc{dandi.000039/0.230223.1216,
+  doi = {10.48324/DANDI.000039/0.230223.1216},
+  url = {https://dandiarchive.org/dandiset/000039/0.230223.1216},
+  author = {Millman, Dan and Vries, Saskia de},
+  keywords = {vision, visual cortex, inhibition, inhibitory circuits, circuit dynamics, gain control},
+  title = {Allen Institute – Contrast tuning in mouse visual cortex with calcium imaging},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# Take latest as the default
+@misc{dandi.000039,
+  doi = {10.48324/DANDI.000039/0.230223.1216},
+  url = {https://dandiarchive.org/dandiset/000039/0.230223.1216},
+  author = {Millman, Dan and Vries, Saskia de},
+  keywords = {vision, visual cortex, inhibition, inhibitory circuits, circuit dynamics, gain control},
+  title = {Allen Institute – Contrast tuning in mouse visual cortex with calcium imaging},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# DANDISET 000041
+@misc{dandi.000041/0.210812.1515,
+  doi = {10.48324/DANDI.000041/0.210812.1515},
+  url = {https://dandiarchive.org/dandiset/000041/0.210812.1515},
+  author = {Watson, Brendon O. and Levenstein, Daniel and Greene, J. Palmer and Gelinas, Jennifer N. and Buzsáki, György},
+  keywords = {Firing patterns, Sleep/awake states, Sleep stages, Homeostasis},
+  title = {Network Homeostasis and State Dynamics of Neocortical Sleep},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+# Take latest as the default
+@misc{dandi.000041,
+  doi = {10.48324/DANDI.000041/0.210812.1515},
+  url = {https://dandiarchive.org/dandiset/000041/0.210812.1515},
+  author = {Watson, Brendon O. and Levenstein, Daniel and Greene, J. Palmer and Gelinas, Jennifer N. and Buzsáki, György},
+  keywords = {Firing patterns, Sleep/awake states, Sleep stages, Homeostasis},
+  title = {Network Homeostasis and State Dynamics of Neocortical Sleep},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+# DANDISET 000044
+@misc{dandi.000044/0.210812.1516,
+  doi = {10.48324/DANDI.000044/0.210812.1516},
+  url = {https://dandiarchive.org/dandiset/000044/0.210812.1516},
+  author = {Grosmark, Andres D. and Buzsáki, György},
+  title = {Diversity in neural firing dynamics supports both rigid and learned hippocampal sequences},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+# Take latest as the default
+@misc{dandi.000044,
+  doi = {10.48324/DANDI.000044/0.210812.1516},
+  url = {https://dandiarchive.org/dandiset/000044/0.210812.1516},
+  author = {Grosmark, Andres D. and Buzsáki, György},
+  title = {Diversity in neural firing dynamics supports both rigid and learned hippocampal sequences},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+# DANDISET 000045
+@misc{dandi.000045/0.211209.1412,
+  doi = {10.48324/DANDI.000045/0.211209.1412},
+  url = {https://dandiarchive.org/dandiset/000045/0.211209.1412},
+  author = {{International Brain Laboratory}},
+  keywords = {International Brain Laboratory},
+  title = {IBL behavioral data},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+@misc{dandi.000045/0.211209.1413,
+  doi = {10.48324/DANDI.000045/0.211209.1413},
+  url = {https://dandiarchive.org/dandiset/000045/0.211209.1413},
+  author = {{International Brain Laboratory}},
+  keywords = {International Brain Laboratory},
+  title = {IBL behavioral data},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+# Take latest as the default
+@misc{dandi.000045,
+  doi = {10.48324/DANDI.000045/0.211209.1413},
+  url = {https://dandiarchive.org/dandiset/000045/0.211209.1413},
+  author = {{International Brain Laboratory}},
+  keywords = {International Brain Laboratory},
+  title = {IBL behavioral data},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+# DANDISET 000049
+@misc{dandi.000049/0.230223.1424,
+  doi = {10.48324/DANDI.000049/0.230223.1424},
+  url = {https://dandiarchive.org/dandiset/000049/0.230223.1424},
+  author = {Millman, Daniel},
+  keywords = {Mouse, 2-photon calcium imaging, visual cortex},
+  title = {Allen Institute – TF x SF tuning in mouse visual cortex with calcium imaging},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# Take latest as the default
+@misc{dandi.000049,
+  doi = {10.48324/DANDI.000049/0.230223.1424},
+  url = {https://dandiarchive.org/dandiset/000049/0.230223.1424},
+  author = {Millman, Daniel},
+  keywords = {Mouse, 2-photon calcium imaging, visual cortex},
+  title = {Allen Institute – TF x SF tuning in mouse visual cortex with calcium imaging},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# DANDISET 000053
+@misc{dandi.000053/0.210819.0345,
+  doi = {10.48324/DANDI.000053/0.210819.0345},
+  url = {https://dandiarchive.org/dandiset/000053/0.210819.0345},
+  author = {Mallory, Caitlin S. and Hardcastle, Kiah and Campbell, Malcolm G. and Attinger, Alexander and Low, Isabel I. C. and Raymond, Jennifer L. and Giocomo, Lisa M.},
+  keywords = {neuropixel, entorhinal cortex},
+  title = {Recordings from medial entorhinal cortex during linear track and open exploration},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+# Take latest as the default
+@misc{dandi.000053,
+  doi = {10.48324/DANDI.000053/0.210819.0345},
+  url = {https://dandiarchive.org/dandiset/000053/0.210819.0345},
+  author = {Mallory, Caitlin S. and Hardcastle, Kiah and Campbell, Malcolm G. and Attinger, Alexander and Low, Isabel I. C. and Raymond, Jennifer L. and Giocomo, Lisa M.},
+  keywords = {neuropixel, entorhinal cortex},
+  title = {Recordings from medial entorhinal cortex during linear track and open exploration},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+# DANDISET 000054
+@misc{dandi.000054/0.210819.1229,
+  doi = {10.48324/DANDI.000054/0.210819.1229},
+  url = {https://dandiarchive.org/dandiset/000054/0.210819.1229},
+  author = {Plitt, Mark and Giocomo, Lisa M.},
+  title = {Plitt & Giocomo (2021) Experience Dependent Contextual Codes in the Hippocampus. Nat Neuro},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+@misc{dandi.000054/0.210819.1230,
+  doi = {10.48324/DANDI.000054/0.210819.1230},
+  url = {https://dandiarchive.org/dandiset/000054/0.210819.1230},
+  author = {Plitt, Mark and Giocomo, Lisa M.},
+  title = {Plitt & Giocomo (2021) Experience Dependent Contextual Codes in the Hippocampus. Nat Neuro},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+@misc{dandi.000054/0.210819.1547,
+  doi = {10.48324/DANDI.000054/0.210819.1547},
+  url = {https://dandiarchive.org/dandiset/000054/0.210819.1547},
+  author = {Plitt, Mark and Giocomo, Lisa M.},
+  title = {Plitt & Giocomo (2021) Experience Dependent Contextual Codes in the Hippocampus. Nat Neuro},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+# Take latest as the default
+@misc{dandi.000054,
+  doi = {10.48324/DANDI.000054/0.210819.1547},
+  url = {https://dandiarchive.org/dandiset/000054/0.210819.1547},
+  author = {Plitt, Mark and Giocomo, Lisa M.},
+  title = {Plitt & Giocomo (2021) Experience Dependent Contextual Codes in the Hippocampus. Nat Neuro},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+# DANDISET 000055
+@misc{dandi.000055/0.220127.0436,
+  doi = {10.48324/DANDI.000055/0.220127.0436},
+  url = {https://dandiarchive.org/dandiset/000055/0.220127.0436},
+  author = {Peterson, Steven M. and Singh, Satpreet H. and Dichter, Benjamin and Rao, Rajesh P. N. and Brunton, Bingni W.},
+  title = {AJILE12: Long-term naturalistic human intracranial neural recordings and pose},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# Take latest as the default
+@misc{dandi.000055,
+  doi = {10.48324/DANDI.000055/0.220127.0436},
+  url = {https://dandiarchive.org/dandiset/000055/0.220127.0436},
+  author = {Peterson, Steven M. and Singh, Satpreet H. and Dichter, Benjamin and Rao, Rajesh P. N. and Brunton, Bingni W.},
+  title = {AJILE12: Long-term naturalistic human intracranial neural recordings and pose},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# DANDISET 000056
+@misc{dandi.000056/0.210812.1518,
+  doi = {10.48324/DANDI.000056/0.210812.1518},
+  url = {https://dandiarchive.org/dandiset/000056/0.210812.1518},
+  author = {Peyrache, Adrien and Lacroix, Marie M and Petersen, Peter C and Buzsáki, György},
+  keywords = {},
+  title = {Internally organized mechanisms of the head direction sense},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+# Take latest as the default
+@misc{dandi.000056,
+  doi = {10.48324/DANDI.000056/0.210812.1518},
+  url = {https://dandiarchive.org/dandiset/000056/0.210812.1518},
+  author = {Peyrache, Adrien and Lacroix, Marie M and Petersen, Peter C and Buzsáki, György},
+  keywords = {},
+  title = {Internally organized mechanisms of the head direction sense},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+# DANDISET 000059
+@misc{dandi.000059/0.210812.1514,
+  doi = {10.48324/DANDI.000059/0.210812.1514},
+  url = {https://dandiarchive.org/dandiset/000059/0.210812.1514},
+  author = {Petersen, Peter and Buzsáki, György},
+  title = {Cooling of Medial Septum Reveals Theta Phase Lag Coordination of Hippocampal Cell Assemblies},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+@misc{dandi.000059/0.230907.2101,
+  doi = {10.48324/DANDI.000059/0.230907.2101},
+  url = {https://dandiarchive.org/dandiset/000059/0.230907.2101},
+  author = {Petersen, Peter and Buzsáki, György},
+  title = {Cooling of Medial Septum Reveals Theta Phase Lag Coordination of Hippocampal Cell Assemblies},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# Take latest as the default
+@misc{dandi.000059,
+  doi = {10.48324/DANDI.000059/0.230907.2101},
+  url = {https://dandiarchive.org/dandiset/000059/0.230907.2101},
+  author = {Petersen, Peter and Buzsáki, György},
+  title = {Cooling of Medial Septum Reveals Theta Phase Lag Coordination of Hippocampal Cell Assemblies},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# DANDISET 000061
+@misc{dandi.000061/0.210812.1517,
+  doi = {10.48324/DANDI.000061/0.210812.1517},
+  url = {https://dandiarchive.org/dandiset/000061/0.210812.1517},
+  author = {Girardeau, Gabrielle and Inema, Ingrid and Buzsáki, György},
+  title = {Reactivations of emotional memory in the hippocampus–amygdala system during sleep},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+# Take latest as the default
+@misc{dandi.000061,
+  doi = {10.48324/DANDI.000061/0.210812.1517},
+  url = {https://dandiarchive.org/dandiset/000061/0.210812.1517},
+  author = {Girardeau, Gabrielle and Inema, Ingrid and Buzsáki, György},
+  title = {Reactivations of emotional memory in the hippocampus–amygdala system during sleep},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+# DANDISET 000064
+@misc{dandi.000064/0.221025.1735,
+  doi = {10.48324/DANDI.000064/0.221025.1735},
+  url = {https://dandiarchive.org/dandiset/000064/0.221025.1735},
+  author = {Raikov, Ivan and Milstein, Aaron and Soltesz, Ivan},
+  title = {Simulation extension example},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# Take latest as the default
+@misc{dandi.000064,
+  doi = {10.48324/DANDI.000064/0.221025.1735},
+  url = {https://dandiarchive.org/dandiset/000064/0.221025.1735},
+  author = {Raikov, Ivan and Milstein, Aaron and Soltesz, Ivan},
+  title = {Simulation extension example},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# DANDISET 000067
+@misc{dandi.000067/0.210812.1457,
+  doi = {10.48324/DANDI.000067/0.210812.1457},
+  url = {https://dandiarchive.org/dandiset/000067/0.210812.1457},
+  author = {Fujisawa, Shigeyoshi and Amarasingham, Asohan and Harrison, Matthew and Buzsáki, György},
+  title = {Behavior-dependent short-term assembly dynamics in the medial prefrontal cortex},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+# Take latest as the default
+@misc{dandi.000067,
+  doi = {10.48324/DANDI.000067/0.210812.1457},
+  url = {https://dandiarchive.org/dandiset/000067/0.210812.1457},
+  author = {Fujisawa, Shigeyoshi and Amarasingham, Asohan and Harrison, Matthew and Buzsáki, György},
+  title = {Behavior-dependent short-term assembly dynamics in the medial prefrontal cortex},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+# DANDISET 000109
+@misc{dandi.000109/0.210914.1904,
+  doi = {10.48324/DANDI.000109/0.210914.1904},
+  url = {https://dandiarchive.org/dandiset/000109/0.210914.1904},
+  author = {Chartrand, Thomas},
+  keywords = {Patch-seq, human, neocortex},
+  title = {Patch-seq recordings from human cortex (June 2021)},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+# Take latest as the default
+@misc{dandi.000109,
+  doi = {10.48324/DANDI.000109/0.210914.1904},
+  url = {https://dandiarchive.org/dandiset/000109/0.210914.1904},
+  author = {Chartrand, Thomas},
+  keywords = {Patch-seq, human, neocortex},
+  title = {Patch-seq recordings from human cortex (June 2021)},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+# DANDISET 000114
+@misc{dandi.000114/0.230602.1643,
+  doi = {10.48324/DANDI.000114/0.230602.1643},
+  url = {https://dandiarchive.org/dandiset/000114/0.230602.1643},
+  author = {Carcea, Ioana and Caraballo, Naomi López and Marlin, Bianca J. and Ooyama, Rumi and Riceberg, Justin S. and Mendoza Navarro, Joyce M. and Opendak, Maya and Diaz, Veronica E. and Schuster, Luisa and Alvarado Torres, Maria I. and Lethin, Harper and Ramos, Daniel and Minder, Jessica and Mendoza, Sebastian L. and Bair-Marshall, Chloe J. and Samadjopoulos, Grace H. and Hidema, Shizu and Falkner, Annegret and Lin, Dayu and Mar, Adam and Wadghiri, Youssef Z. and Nishimori, Katsuhiko and Kikusui, Takefumi and Mogi, Kazutaka and Sullivan, Regina M. and Froemke, Robert C.},
+  keywords = {oxytocin, alloparenting, maternal behavior},
+  title = {Oxytocin neurons enable social transmission of maternal behaviour},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# Take latest as the default
+@misc{dandi.000114,
+  doi = {10.48324/DANDI.000114/0.230602.1643},
+  url = {https://dandiarchive.org/dandiset/000114/0.230602.1643},
+  author = {Carcea, Ioana and Caraballo, Naomi López and Marlin, Bianca J. and Ooyama, Rumi and Riceberg, Justin S. and Mendoza Navarro, Joyce M. and Opendak, Maya and Diaz, Veronica E. and Schuster, Luisa and Alvarado Torres, Maria I. and Lethin, Harper and Ramos, Daniel and Minder, Jessica and Mendoza, Sebastian L. and Bair-Marshall, Chloe J. and Samadjopoulos, Grace H. and Hidema, Shizu and Falkner, Annegret and Lin, Dayu and Mar, Adam and Wadghiri, Youssef Z. and Nishimori, Katsuhiko and Kikusui, Takefumi and Mogi, Kazutaka and Sullivan, Regina M. and Froemke, Robert C.},
+  keywords = {oxytocin, alloparenting, maternal behavior},
+  title = {Oxytocin neurons enable social transmission of maternal behaviour},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# DANDISET 000115
+@misc{dandi.000115/0.210914.1732,
+  doi = {10.48324/DANDI.000115/0.210914.1732},
+  url = {https://dandiarchive.org/dandiset/000115/0.210914.1732},
+  author = {Gillespie, Anna},
+  title = {Gillespie et al (2021) Hippocampal replay reflects specific past experiences rather than a plan for subsequent choice},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+# Take latest as the default
+@misc{dandi.000115,
+  doi = {10.48324/DANDI.000115/0.210914.1732},
+  url = {https://dandiarchive.org/dandiset/000115/0.210914.1732},
+  author = {Gillespie, Anna},
+  title = {Gillespie et al (2021) Hippocampal replay reflects specific past experiences rather than a plan for subsequent choice},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+# DANDISET 000126
+@misc{dandi.000126/0.210813.0327,
+  doi = {10.48324/DANDI.000126/0.210813.0327},
+  url = {https://dandiarchive.org/dandiset/000126/0.210813.0327},
+  author = {Ly, Ryan},
+  title = {NWB API Test Data},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+# Take latest as the default
+@misc{dandi.000126,
+  doi = {10.48324/DANDI.000126/0.210813.0327},
+  url = {https://dandiarchive.org/dandiset/000126/0.210813.0327},
+  author = {Ly, Ryan},
+  title = {NWB API Test Data},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+# DANDISET 000127
+@misc{dandi.000127/0.220113.0359,
+  doi = {10.48324/DANDI.000127/0.220113.0359},
+  url = {https://dandiarchive.org/dandiset/000127/0.220113.0359},
+  author = {Miller, Lee},
+  keywords = {Neural Latents Benchmark, NLB},
+  title = {Area2_Bump: macaque somatosensory area 2 spiking activity during reaching with perturbations},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# Take latest as the default
+@misc{dandi.000127,
+  doi = {10.48324/DANDI.000127/0.220113.0359},
+  url = {https://dandiarchive.org/dandiset/000127/0.220113.0359},
+  author = {Miller, Lee},
+  keywords = {Neural Latents Benchmark, NLB},
+  title = {Area2_Bump: macaque somatosensory area 2 spiking activity during reaching with perturbations},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# DANDISET 000128
+@misc{dandi.000128/0.220113.0400,
+  doi = {10.48324/DANDI.000128/0.220113.0400},
+  url = {https://dandiarchive.org/dandiset/000128/0.220113.0400},
+  author = {Churchland, Mark and Kaufman, Matthew},
+  keywords = {Neural Latents Benchmark, NLB},
+  title = {MC_Maze: macaque primary motor and dorsal premotor cortex spiking activity during delayed reaching},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# Take latest as the default
+@misc{dandi.000128,
+  doi = {10.48324/DANDI.000128/0.220113.0400},
+  url = {https://dandiarchive.org/dandiset/000128/0.220113.0400},
+  author = {Churchland, Mark and Kaufman, Matthew},
+  keywords = {Neural Latents Benchmark, NLB},
+  title = {MC_Maze: macaque primary motor and dorsal premotor cortex spiking activity during delayed reaching},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# DANDISET 000130
+@misc{dandi.000130/0.220113.0407,
+  doi = {10.48324/DANDI.000130/0.220113.0407},
+  url = {https://dandiarchive.org/dandiset/000130/0.220113.0407},
+  author = {Sohn, Hansem and Jazayeri, Mehrdad},
+  keywords = {Neural Latents Benchmark, NLB},
+  title = {DMFC_RSG: macaque dorsomedial frontal cortex spiking activity during time interval reproduction task},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# Take latest as the default
+@misc{dandi.000130,
+  doi = {10.48324/DANDI.000130/0.220113.0407},
+  url = {https://dandiarchive.org/dandiset/000130/0.220113.0407},
+  author = {Sohn, Hansem and Jazayeri, Mehrdad},
+  keywords = {Neural Latents Benchmark, NLB},
+  title = {DMFC_RSG: macaque dorsomedial frontal cortex spiking activity during time interval reproduction task},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# DANDISET 000138
+@misc{dandi.000138/0.220113.0407,
+  doi = {10.48324/DANDI.000138/0.220113.0407},
+  url = {https://dandiarchive.org/dandiset/000138/0.220113.0407},
+  author = {Churchland, Mark and Kaufman, Matthew},
+  keywords = {Neural Latents Benchmark, NLB},
+  title = {MC_Maze_Large: macaque primary motor and dorsal premotor cortex spiking activity during delayed reaching},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# Take latest as the default
+@misc{dandi.000138,
+  doi = {10.48324/DANDI.000138/0.220113.0407},
+  url = {https://dandiarchive.org/dandiset/000138/0.220113.0407},
+  author = {Churchland, Mark and Kaufman, Matthew},
+  keywords = {Neural Latents Benchmark, NLB},
+  title = {MC_Maze_Large: macaque primary motor and dorsal premotor cortex spiking activity during delayed reaching},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# DANDISET 000139
+@misc{dandi.000139/0.220113.0408,
+  doi = {10.48324/DANDI.000139/0.220113.0408},
+  url = {https://dandiarchive.org/dandiset/000139/0.220113.0408},
+  author = {Churchland, Mark and Kaufman, Matthew},
+  keywords = {Neural Latents Benchmark, NLB},
+  title = {MC_Maze_Medium: macaque primary motor and dorsal premotor cortex spiking activity during delayed reaching},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# Take latest as the default
+@misc{dandi.000139,
+  doi = {10.48324/DANDI.000139/0.220113.0408},
+  url = {https://dandiarchive.org/dandiset/000139/0.220113.0408},
+  author = {Churchland, Mark and Kaufman, Matthew},
+  keywords = {Neural Latents Benchmark, NLB},
+  title = {MC_Maze_Medium: macaque primary motor and dorsal premotor cortex spiking activity during delayed reaching},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# DANDISET 000140
+@misc{dandi.000140/0.220113.0408,
+  doi = {10.48324/DANDI.000140/0.220113.0408},
+  url = {https://dandiarchive.org/dandiset/000140/0.220113.0408},
+  author = {Churchland, Mark and Kaufman, Matthew},
+  keywords = {Neural Latents Benchmark, NLB},
+  title = {MC_Maze_Small: macaque primary motor and dorsal premotor cortex spiking activity during delayed reaching},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# Take latest as the default
+@misc{dandi.000140,
+  doi = {10.48324/DANDI.000140/0.220113.0408},
+  url = {https://dandiarchive.org/dandiset/000140/0.220113.0408},
+  author = {Churchland, Mark and Kaufman, Matthew},
+  keywords = {Neural Latents Benchmark, NLB},
+  title = {MC_Maze_Small: macaque primary motor and dorsal premotor cortex spiking activity during delayed reaching},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# DANDISET 000142
+@misc{dandi.000142/0.211007.1926,
+  doi = {10.48324/DANDI.000142/0.211007.1926},
+  url = {https://dandiarchive.org/dandiset/000142/0.211007.1926},
+  author = {Kalmbach, Brian},
+  keywords = {Patch-seq, human, neocortical},
+  title = {20210923_AIBS_Patchseq_human},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+# Take latest as the default
+@misc{dandi.000142,
+  doi = {10.48324/DANDI.000142/0.211007.1926},
+  url = {https://dandiarchive.org/dandiset/000142/0.211007.1926},
+  author = {Kalmbach, Brian},
+  keywords = {Patch-seq, human, neocortical},
+  title = {20210923_AIBS_Patchseq_human},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+# DANDISET 000147
+@misc{dandi.000147/0.220913.2243,
+  doi = {10.48324/DANDI.000147/0.220913.2243},
+  url = {https://dandiarchive.org/dandiset/000147/0.220913.2243},
+  author = {Guan, Charles and Aflalo, Tyson and Zhang, Carey and Andersen, Richard},
+  keywords = {PPC, human, finger},
+  title = {PPC_Finger: human posterior parietal cortex recordings during attempted finger movements},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+@misc{dandi.000147/0.221122.2256,
+  doi = {10.48324/DANDI.000147/0.221122.2256},
+  url = {https://dandiarchive.org/dandiset/000147/0.221122.2256},
+  author = {Guan, Charles and Aflalo, Tyson and Zhang, Carey and Andersen, Richard},
+  keywords = {PPC, human, finger},
+  title = {PPC_Finger: human posterior parietal cortex recordings during attempted finger movements},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# Take latest as the default
+@misc{dandi.000147,
+  doi = {10.48324/DANDI.000147/0.221122.2256},
+  url = {https://dandiarchive.org/dandiset/000147/0.221122.2256},
+  author = {Guan, Charles and Aflalo, Tyson and Zhang, Carey and Andersen, Richard},
+  keywords = {PPC, human, finger},
+  title = {PPC_Finger: human posterior parietal cortex recordings during attempted finger movements},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# DANDISET 000165
+@misc{dandi.000165/0.211118.1526,
+  doi = {10.48324/DANDI.000165/0.211118.1526},
+  url = {https://dandiarchive.org/dandiset/000165/0.211118.1526},
+  author = {Aery Jones, Emily and Rao, Antara and Zilberter, Misha and Djukic, Biljana and Gillespie, Anna K. and Koutsodendris, Nicole and Nelson, Maxine and Yoon, Seo Yeon and Huang, Ky and Yuan, Heidi and Gill, Theodore M. and Huang, Yadong and Frank, Loren M.},
+  keywords = {hippocampus, mouse, LFP},
+  title = {Aery Jones et al (2021) Dentate Gyrus and CA3 GABAergic Interneurons Bidirectionally Modulate Signatures of Internal and External Drive to CA1},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+# Take latest as the default
+@misc{dandi.000165,
+  doi = {10.48324/DANDI.000165/0.211118.1526},
+  url = {https://dandiarchive.org/dandiset/000165/0.211118.1526},
+  author = {Aery Jones, Emily and Rao, Antara and Zilberter, Misha and Djukic, Biljana and Gillespie, Anna K. and Koutsodendris, Nicole and Nelson, Maxine and Yoon, Seo Yeon and Huang, Ky and Yuan, Heidi and Gill, Theodore M. and Huang, Yadong and Frank, Loren M.},
+  keywords = {hippocampus, mouse, LFP},
+  title = {Aery Jones et al (2021) Dentate Gyrus and CA3 GABAergic Interneurons Bidirectionally Modulate Signatures of Internal and External Drive to CA1},
+  publisher = {DANDI Archive},
+  year = {2021}
+}
+
+
+# DANDISET 000166
+@misc{dandi.000166/0.220116.2037,
+  doi = {10.48324/DANDI.000166/0.220116.2037},
+  url = {https://dandiarchive.org/dandiset/000166/0.220116.2037},
+  author = {Senzai, Yuta and Fernandez-Ruiz, Antonio and Buzsáki, György},
+  keywords = {current source density, laminar recordings, cortex, electrophysiology},
+  title = {Layer-Specific Physiological Features and Interlaminar Interactions in the Primary Visual Cortex of the Mouse},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# Take latest as the default
+@misc{dandi.000166,
+  doi = {10.48324/DANDI.000166/0.220116.2037},
+  url = {https://dandiarchive.org/dandiset/000166/0.220116.2037},
+  author = {Senzai, Yuta and Fernandez-Ruiz, Antonio and Buzsáki, György},
+  keywords = {current source density, laminar recordings, cortex, electrophysiology},
+  title = {Layer-Specific Physiological Features and Interlaminar Interactions in the Primary Visual Cortex of the Mouse},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# DANDISET 000167
+@misc{dandi.000167/0.220329.0720,
+  doi = {10.48324/DANDI.000167/0.220329.0720},
+  url = {https://dandiarchive.org/dandiset/000167/0.220329.0720},
+  author = {PIERRÉ, Andrea},
+  title = {Odor_Set_1},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+@misc{dandi.000167/0.220928.1306,
+  doi = {10.48324/DANDI.000167/0.220928.1306},
+  url = {https://dandiarchive.org/dandiset/000167/0.220928.1306},
+  author = {Daste, Simon},
+  title = {Two photon calcium imaging of mice piriform cortex under passive odor presentation},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+@misc{dandi.000167/0.230720.2001,
+  doi = {10.48324/DANDI.000167/0.230720.2001},
+  url = {https://dandiarchive.org/dandiset/000167/0.230720.2001},
+  author = {Daste, Simon},
+  title = {Two photon calcium imaging of mice piriform cortex under passive odor presentation},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# Take latest as the default
+@misc{dandi.000167,
+  doi = {10.48324/DANDI.000167/0.230720.2001},
+  url = {https://dandiarchive.org/dandiset/000167/0.230720.2001},
+  author = {Daste, Simon},
+  title = {Two photon calcium imaging of mice piriform cortex under passive odor presentation},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# DANDISET 000173
+@misc{dandi.000173/0.220820.1811,
+  doi = {10.48324/DANDI.000173/0.220820.1811},
+  url = {https://dandiarchive.org/dandiset/000173/0.220820.1811},
+  author = {Ramachandran, Sandhya and Niu, Xiaodan and Yu, Kai and He, Bin},
+  keywords = {Ultrasound, Plasticity, Rat, tFUS, Somatosensory Cortex},
+  title = {Neural Spiking Data in Primary Somatosensory Cortex before and after Transcranial Focused Ultrasound Stimulation in Rats},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+@misc{dandi.000173/0.220927.0404,
+  doi = {10.48324/DANDI.000173/0.220927.0404},
+  url = {https://dandiarchive.org/dandiset/000173/0.220927.0404},
+  author = {Ramachandran, Sandhya and Niu, Xiaodan and Yu, Kai and He, Bin},
+  keywords = {Ultrasound, Plasticity, Rat, tFUS, Somatosensory Cortex},
+  title = {Neural Spiking Data in Primary Somatosensory Cortex before and after Transcranial Focused Ultrasound Stimulation in Rats},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# Take latest as the default
+@misc{dandi.000173,
+  doi = {10.48324/DANDI.000173/0.220927.0404},
+  url = {https://dandiarchive.org/dandiset/000173/0.220927.0404},
+  author = {Ramachandran, Sandhya and Niu, Xiaodan and Yu, Kai and He, Bin},
+  keywords = {Ultrasound, Plasticity, Rat, tFUS, Somatosensory Cortex},
+  title = {Neural Spiking Data in Primary Somatosensory Cortex before and after Transcranial Focused Ultrasound Stimulation in Rats},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# DANDISET 000206
+@misc{dandi.000206/0.220103.2119,
+  doi = {10.48324/DANDI.000206/0.220103.2119},
+  url = {https://dandiarchive.org/dandiset/000206/0.220103.2119},
+  author = {Smith, Spencer and Canzano, Joseph},
+  title = {Visual cortical activity in mice performing naturalistic virtual foraging task},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# Take latest as the default
+@misc{dandi.000206,
+  doi = {10.48324/DANDI.000206/0.220103.2119},
+  url = {https://dandiarchive.org/dandiset/000206/0.220103.2119},
+  author = {Smith, Spencer and Canzano, Joseph},
+  title = {Visual cortical activity in mice performing naturalistic virtual foraging task},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# DANDISET 000207
+@misc{dandi.000207/0.220216.0323,
+  doi = {10.48324/DANDI.000207/0.220216.0323},
+  url = {https://dandiarchive.org/dandiset/000207/0.220216.0323},
+  author = {Zheng, Jie and Schjetnan, Andrea and Yebra, Mar and Gomes, Bernard and Mosher, Clayton and Kalia, Suneil and Valiante, Taufik and Mamelak, Adam and Kreiman, Gabriel and Rutishauser, Ueli},
+  keywords = {human single neuron, hippocampus, episodic memory, event segmentation, amygdala, parahippocampal gyrus, cognitive boundaries, continuous experience, ROH consortium},
+  title = {Data for: Neurons detect cognitive boundaries to structure episodic memories in humans (Zheng et al., 2022, Nat Neuro in press)},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+@misc{dandi.000207/0.220721.1915,
+  doi = {10.48324/DANDI.000207/0.220721.1915},
+  url = {https://dandiarchive.org/dandiset/000207/0.220721.1915},
+  author = {Zheng, Jie and Schjetnan, Andrea and Yebra, Mar and Gomes, Bernard and Mosher, Clayton and Kalia, Suneil and Valiante, Taufik and Mamelak, Adam and Kreiman, Gabriel and Rutishauser, Ueli},
+  keywords = {human single neuron, hippocampus, episodic memory, event segmentation, amygdala, parahippocampal gyrus, cognitive boundaries, continuous experience, ROH consortium},
+  title = {Data for: Neurons detect cognitive boundaries to structure episodic memories in humans (Zheng et al., 2022, Nat Neuro in press)},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+@misc{dandi.000207/0.230530.1822,
+  doi = {10.48324/DANDI.000207/0.230530.1822},
+  url = {https://dandiarchive.org/dandiset/000207/0.230530.1822},
+  author = {Zheng, Jie and Schjetnan, Andrea and Yebra, Mar and Gomes, Bernard and Mosher, Clayton and Kalia, Suneil and Valiante, Taufik and Mamelak, Adam and Kreiman, Gabriel and Rutishauser, Ueli},
+  keywords = {human single neuron, hippocampus, episodic memory, event segmentation, amygdala, parahippocampal gyrus, cognitive boundaries, continuous experience, ROH consortium},
+  title = {Data for: Neurons detect cognitive boundaries to structure episodic memories in humans (Zheng et al., 2022, Nat Neuro in press)},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# Take latest as the default
+@misc{dandi.000207,
+  doi = {10.48324/DANDI.000207/0.230530.1822},
+  url = {https://dandiarchive.org/dandiset/000207/0.230530.1822},
+  author = {Zheng, Jie and Schjetnan, Andrea and Yebra, Mar and Gomes, Bernard and Mosher, Clayton and Kalia, Suneil and Valiante, Taufik and Mamelak, Adam and Kreiman, Gabriel and Rutishauser, Ueli},
+  keywords = {human single neuron, hippocampus, episodic memory, event segmentation, amygdala, parahippocampal gyrus, cognitive boundaries, continuous experience, ROH consortium},
+  title = {Data for: Neurons detect cognitive boundaries to structure episodic memories in humans (Zheng et al., 2022, Nat Neuro in press)},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# DANDISET 000209
+@misc{dandi.000209/0.230522.1918,
+  doi = {10.48324/DANDI.000209/0.230522.1918},
+  url = {https://dandiarchive.org/dandiset/000209/0.230522.1918},
+  author = {Wakeman, Wayne},
+  keywords = {Patch-seq, human, neocortical},
+  title = {20211223_AIBS_Patchseq_human},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# Take latest as the default
+@misc{dandi.000209,
+  doi = {10.48324/DANDI.000209/0.230522.1918},
+  url = {https://dandiarchive.org/dandiset/000209/0.230522.1918},
+  author = {Wakeman, Wayne},
+  keywords = {Patch-seq, human, neocortical},
+  title = {20211223_AIBS_Patchseq_human},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# DANDISET 000213
+@misc{dandi.000213/0.220127.1738,
+  doi = {10.48324/DANDI.000213/0.220127.1738},
+  url = {https://dandiarchive.org/dandiset/000213/0.220127.1738},
+  author = {Tingley, David and Buzsáki, Gyórgy},
+  keywords = {hippocampus, lateral septum, electrophysiology},
+  title = {Transformation of a Spatial Map across the Hippocampal-Lateral Septal Circuit},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# Take latest as the default
+@misc{dandi.000213,
+  doi = {10.48324/DANDI.000213/0.220127.1738},
+  url = {https://dandiarchive.org/dandiset/000213/0.220127.1738},
+  author = {Tingley, David and Buzsáki, Gyórgy},
+  keywords = {hippocampus, lateral septum, electrophysiology},
+  title = {Transformation of a Spatial Map across the Hippocampal-Lateral Septal Circuit},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# DANDISET 000217
+@misc{dandi.000217/0.220125.2004,
+  doi = {10.48324/DANDI.000217/0.220125.2004},
+  url = {https://dandiarchive.org/dandiset/000217/0.220125.2004},
+  author = {Findley, Teresa and Wyrick, David G and Cramer, Jennifer L and Brown, Morgan A and Holcomb, Blake and Attey, Robin and Yeh, Dorian and Monasevitch, Eric and Nouboussi, Nelly and Cullen, Isabelle and Songco, Jeremea O and King, Jared F and Ahmadian, Yashar and Smear, Matt},
+  title = {Sniff-synchronized, gradient-guided olfactory search by freely moving mice -- Behavioral Dataset},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# Take latest as the default
+@misc{dandi.000217,
+  doi = {10.48324/DANDI.000217/0.220125.2004},
+  url = {https://dandiarchive.org/dandiset/000217/0.220125.2004},
+  author = {Findley, Teresa and Wyrick, David G and Cramer, Jennifer L and Brown, Morgan A and Holcomb, Blake and Attey, Robin and Yeh, Dorian and Monasevitch, Eric and Nouboussi, Nelly and Cullen, Isabelle and Songco, Jeremea O and King, Jared F and Ahmadian, Yashar and Smear, Matt},
+  title = {Sniff-synchronized, gradient-guided olfactory search by freely moving mice -- Behavioral Dataset},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# DANDISET 000218
+@misc{dandi.000218/0.220131.1608,
+  doi = {10.48324/DANDI.000218/0.220131.1608},
+  url = {https://dandiarchive.org/dandiset/000218/0.220131.1608},
+  author = {Tingley, David and Buzáki, Gyórgy},
+  keywords = {hippocampus, lateral septum, electrophyisology},
+  title = {Routing of Hippocampal Ripples to Subcortical Structures via the Lateral Septum},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# Take latest as the default
+@misc{dandi.000218,
+  doi = {10.48324/DANDI.000218/0.220131.1608},
+  url = {https://dandiarchive.org/dandiset/000218/0.220131.1608},
+  author = {Tingley, David and Buzáki, Gyórgy},
+  keywords = {hippocampus, lateral septum, electrophyisology},
+  title = {Routing of Hippocampal Ripples to Subcortical Structures via the Lateral Septum},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# DANDISET 000221
+@misc{dandi.000221/0.220303.1653,
+  doi = {10.48324/DANDI.000221/0.220303.1653},
+  url = {https://dandiarchive.org/dandiset/000221/0.220303.1653},
+  author = {Inagaki, Hidehiko},
+  keywords = {Midbrain, ALM, motor planning, movement initiation},
+  title = {A midbrain-thalamus-cortex circuit reorganizes cortical dynamics to initiate movement},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+@misc{dandi.000221/0.220307.1320,
+  doi = {10.48324/DANDI.000221/0.220307.1320},
+  url = {https://dandiarchive.org/dandiset/000221/0.220307.1320},
+  author = {Inagaki, Hidehiko},
+  keywords = {Midbrain, ALM, motor planning, movement initiation},
+  title = {A midbrain-thalamus-cortex circuit reorganizes cortical dynamics to initiate movement},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# Take latest as the default
+@misc{dandi.000221,
+  doi = {10.48324/DANDI.000221/0.220307.1320},
+  url = {https://dandiarchive.org/dandiset/000221/0.220307.1320},
+  author = {Inagaki, Hidehiko},
+  keywords = {Midbrain, ALM, motor planning, movement initiation},
+  title = {A midbrain-thalamus-cortex circuit reorganizes cortical dynamics to initiate movement},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# DANDISET 000223
+@misc{dandi.000223/0.220823.0826,
+  doi = {10.48324/DANDI.000223/0.220823.0826},
+  url = {https://dandiarchive.org/dandiset/000223/0.220823.0826},
+  author = {Buccino, Alessio and Kumar, Sreedhar Saseendran and Hierlemann, Andreas and Bartram, Julian},
+  keywords = {calcium imaging; extracellular recordings; HD-MEA; spike sorting; dendritic spines},
+  title = {Inferring monosynaptic connections from paired spine calcium imaging and large-scale recording of extracellular spiking},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# Take latest as the default
+@misc{dandi.000223,
+  doi = {10.48324/DANDI.000223/0.220823.0826},
+  url = {https://dandiarchive.org/dandiset/000223/0.220823.0826},
+  author = {Buccino, Alessio and Kumar, Sreedhar Saseendran and Hierlemann, Andreas and Bartram, Julian},
+  keywords = {calcium imaging; extracellular recordings; HD-MEA; spike sorting; dendritic spines},
+  title = {Inferring monosynaptic connections from paired spine calcium imaging and large-scale recording of extracellular spiking},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# DANDISET 000226
+@misc{dandi.000226/0.230607.1747,
+  doi = {10.48324/DANDI.000226/0.230607.1747},
+  url = {https://dandiarchive.org/dandiset/000226/0.230607.1747},
+  author = {Severson, Kyle and Xu, Duo and Van de Loo, Margaret and Bai, Ling and Ginty, David D and O'Connor, Daniel H},
+  title = {Active Touch and Self-Motion Encoding by Merkel Cell-Associated Afferents},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# Take latest as the default
+@misc{dandi.000226,
+  doi = {10.48324/DANDI.000226/0.230607.1747},
+  url = {https://dandiarchive.org/dandiset/000226/0.230607.1747},
+  author = {Severson, Kyle and Xu, Duo and Van de Loo, Margaret and Bai, Ling and Ginty, David D and O'Connor, Daniel H},
+  title = {Active Touch and Self-Motion Encoding by Merkel Cell-Associated Afferents},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# DANDISET 000230
+@misc{dandi.000230/0.220422.0713,
+  doi = {10.48324/DANDI.000230/0.220422.0713},
+  url = {https://dandiarchive.org/dandiset/000230/0.220422.0713},
+  author = {Jacobsen, Ragnhild Irene and Nair, Rajeevkumar and Obenhaus, Horst and Donato, Flavio and Slettmoen, Torstein and Moser, May-Britt and Moser, Edvard I},
+  title = {Jacobsen 2022},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+@misc{dandi.000230/0.220426.0814,
+  doi = {10.48324/DANDI.000230/0.220426.0814},
+  url = {https://dandiarchive.org/dandiset/000230/0.220426.0814},
+  author = {Jacobsen, Ragnhild Irene and Nair, Rajeevkumar and Obenhaus, Horst and Donato, Flavio and Slettmoen, Torstein and Moser, May-Britt and Moser, Edvard I},
+  title = {Jacobsen 2022},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+@misc{dandi.000230/0.220426.1130,
+  doi = {10.48324/DANDI.000230/0.220426.1130},
+  url = {https://dandiarchive.org/dandiset/000230/0.220426.1130},
+  author = {Jacobsen, Ragnhild Irene and Nair, Rajeevkumar and Obenhaus, Horst and Donato, Flavio and Slettmoen, Torstein and Moser, May-Britt and Moser, Edvard I},
+  title = {Jacobsen 2022},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+@misc{dandi.000230/0.220506.1516,
+  doi = {10.48324/DANDI.000230/0.220506.1516},
+  url = {https://dandiarchive.org/dandiset/000230/0.220506.1516},
+  author = {Jacobsen, R Irene and Nair, Rajeevkumar R and Obenhaus, Horst A and Donato, Flavio and Slettmoen, Torstein and Moser, May-Britt and Moser, Edvard I},
+  title = {Jacobsen 2022},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# Take latest as the default
+@misc{dandi.000230,
+  doi = {10.48324/DANDI.000230/0.220506.1516},
+  url = {https://dandiarchive.org/dandiset/000230/0.220506.1516},
+  author = {Jacobsen, R Irene and Nair, Rajeevkumar R and Obenhaus, Horst A and Donato, Flavio and Slettmoen, Torstein and Moser, May-Britt and Moser, Edvard I},
+  title = {Jacobsen 2022},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# DANDISET 000231
+@misc{dandi.000231/0.220904.1554,
+  doi = {10.48324/DANDI.000231/0.220904.1554},
+  url = {https://dandiarchive.org/dandiset/000231/0.220904.1554},
+  author = {Rodgers, Chris},
+  keywords = {mouse behavior, whisker system, somatosensory cortex, barrel cortex, object recognition, shape discrimination, electrophysiology, pose tracking, population recordings, single unit recordings},
+  title = {A detailed behavioral, videographic, and neural dataset on object recognition in mice},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# Take latest as the default
+@misc{dandi.000231,
+  doi = {10.48324/DANDI.000231/0.220904.1554},
+  url = {https://dandiarchive.org/dandiset/000231/0.220904.1554},
+  author = {Rodgers, Chris},
+  keywords = {mouse behavior, whisker system, somatosensory cortex, barrel cortex, object recognition, shape discrimination, electrophysiology, pose tracking, population recordings, single unit recordings},
+  title = {A detailed behavioral, videographic, and neural dataset on object recognition in mice},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# DANDISET 000232
+@misc{dandi.000232/0.240510.2038,
+  doi = {10.48324/DANDI.000232/0.240510.2038},
+  url = {https://dandiarchive.org/dandiset/000232/0.240510.2038},
+  author = {Chang, Yi-Ting and OConnor, Daniel H},
+  title = {Rule-based modulation of a sensorimotor transformation across cortical areas},
+  publisher = {DANDI Archive},
+  year = {2024}
+}
+
+
+# Take latest as the default
+@misc{dandi.000232,
+  doi = {10.48324/DANDI.000232/0.240510.2038},
+  url = {https://dandiarchive.org/dandiset/000232/0.240510.2038},
+  author = {Chang, Yi-Ting and OConnor, Daniel H},
+  title = {Rule-based modulation of a sensorimotor transformation across cortical areas},
+  publisher = {DANDI Archive},
+  year = {2024}
+}
+
+
+# DANDISET 000233
+@misc{dandi.000233/0.230223.0815,
+  doi = {10.48324/DANDI.000233/0.230223.0815},
+  url = {https://dandiarchive.org/dandiset/000233/0.230223.0815},
+  author = {Tingley, David and McClain, Kathryn and Kaya, Ekin and Carpenter, Jordan and Buzsáki, György},
+  keywords = {glucose, ecephys, pharmacology},
+  title = {A metabolic function of the hippocampal sharp wave-ripple},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# Take latest as the default
+@misc{dandi.000233,
+  doi = {10.48324/DANDI.000233/0.230223.0815},
+  url = {https://dandiarchive.org/dandiset/000233/0.230223.0815},
+  author = {Tingley, David and McClain, Kathryn and Kaya, Ekin and Carpenter, Jordan and Buzsáki, György},
+  keywords = {glucose, ecephys, pharmacology},
+  title = {A metabolic function of the hippocampal sharp wave-ripple},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# DANDISET 000235
+@misc{dandi.000235/0.230316.1600,
+  doi = {10.48324/DANDI.000235/0.230316.1600},
+  url = {https://dandiarchive.org/dandiset/000235/0.230316.1600},
+  author = {{National Institutes of Health (NIH)}},
+  title = {Thermoregulatory Responses Forebrain},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# Take latest as the default
+@misc{dandi.000235,
+  doi = {10.48324/DANDI.000235/0.230316.1600},
+  url = {https://dandiarchive.org/dandiset/000235/0.230316.1600},
+  author = {{National Institutes of Health (NIH)}},
+  title = {Thermoregulatory Responses Forebrain},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# DANDISET 000236
+@misc{dandi.000236/0.230316.2031,
+  doi = {10.48324/DANDI.000236/0.230316.2031},
+  url = {https://dandiarchive.org/dandiset/000236/0.230316.2031},
+  author = {{National Institutes of Health (NIH)}},
+  title = {Thermoregulatory Responses Midbrain},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# Take latest as the default
+@misc{dandi.000236,
+  doi = {10.48324/DANDI.000236/0.230316.2031},
+  url = {https://dandiarchive.org/dandiset/000236/0.230316.2031},
+  author = {{National Institutes of Health (NIH)}},
+  title = {Thermoregulatory Responses Midbrain},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# DANDISET 000237
+@misc{dandi.000237/0.230316.1655,
+  doi = {10.48324/DANDI.000237/0.230316.1655},
+  url = {https://dandiarchive.org/dandiset/000237/0.230316.1655},
+  author = {{National Institutes of Health (NIH)}},
+  title = {Thermoregulatory Responses Hindbrain},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# Take latest as the default
+@misc{dandi.000237,
+  doi = {10.48324/DANDI.000237/0.230316.1655},
+  url = {https://dandiarchive.org/dandiset/000237/0.230316.1655},
+  author = {{National Institutes of Health (NIH)}},
+  title = {Thermoregulatory Responses Hindbrain},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# DANDISET 000238
+@misc{dandi.000238/0.230316.1519,
+  doi = {10.48324/DANDI.000238/0.230316.1519},
+  url = {https://dandiarchive.org/dandiset/000238/0.230316.1519},
+  author = {{National Institutes of Health (NIH)}},
+  title = {Thermoregulatory Responses Reticulospinal system},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# Take latest as the default
+@misc{dandi.000238,
+  doi = {10.48324/DANDI.000238/0.230316.1519},
+  url = {https://dandiarchive.org/dandiset/000238/0.230316.1519},
+  author = {{National Institutes of Health (NIH)}},
+  title = {Thermoregulatory Responses Reticulospinal system},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# DANDISET 000239
+@misc{dandi.000239/0.230607.1752,
+  doi = {10.48324/DANDI.000239/0.230607.1752},
+  url = {https://dandiarchive.org/dandiset/000239/0.230607.1752},
+  author = {Xu, Duo and Chen, Yuxi and Dong, Mingyuan and Delgado, Angel M and Hughes, Natasha C and Zhang, Linghua and O'Connor, Daniel H},
+  title = {Cortical processing of flexible and context-dependent sensorimotor sequences},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# Take latest as the default
+@misc{dandi.000239,
+  doi = {10.48324/DANDI.000239/0.230607.1752},
+  url = {https://dandiarchive.org/dandiset/000239/0.230607.1752},
+  author = {Xu, Duo and Chen, Yuxi and Dong, Mingyuan and Delgado, Angel M and Hughes, Natasha C and Zhang, Linghua and O'Connor, Daniel H},
+  title = {Cortical processing of flexible and context-dependent sensorimotor sequences},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# DANDISET 000248
+@misc{dandi.000248/0.240502.2344,
+  doi = {10.48324/DANDI.000248/0.240502.2344},
+  url = {https://dandiarchive.org/dandiset/000248/0.240502.2344},
+  author = {Shin, Hyeyoung and Adesnik, Hillel},
+  keywords = {perceptual inference, illusory contours, mouse, neuropixel, extracellular electrophysiology, neocortex, excitatory, inhibitory},
+  title = {Allen Institute Openscope - Illusion project},
+  publisher = {DANDI Archive},
+  year = {2024}
+}
+
+
+# Take latest as the default
+@misc{dandi.000248,
+  doi = {10.48324/DANDI.000248/0.240502.2344},
+  url = {https://dandiarchive.org/dandiset/000248/0.240502.2344},
+  author = {Shin, Hyeyoung and Adesnik, Hillel},
+  keywords = {perceptual inference, illusory contours, mouse, neuropixel, extracellular electrophysiology, neocortex, excitatory, inhibitory},
+  title = {Allen Institute Openscope - Illusion project},
+  publisher = {DANDI Archive},
+  year = {2024}
+}
+
+
+# DANDISET 000249
+@misc{dandi.000249/0.230423.1416,
+  doi = {10.48324/DANDI.000249/0.230423.1416},
+  url = {https://dandiarchive.org/dandiset/000249/0.230423.1416},
+  author = {Schiavo, Jennifer K. and Valtcheva, Silvana and Bair-Marshall, Chloe J. and Song, Soomin C. and Martin, Kathleen A. and Froemke, Robert C.},
+  keywords = {oxytocin},
+  title = {Innate and plastic mechanisms for maternal behaviour in auditory cortex},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# Take latest as the default
+@misc{dandi.000249,
+  doi = {10.48324/DANDI.000249/0.230423.1416},
+  url = {https://dandiarchive.org/dandiset/000249/0.230423.1416},
+  author = {Schiavo, Jennifer K. and Valtcheva, Silvana and Bair-Marshall, Chloe J. and Song, Soomin C. and Martin, Kathleen A. and Froemke, Robert C.},
+  keywords = {oxytocin},
+  title = {Innate and plastic mechanisms for maternal behaviour in auditory cortex},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# DANDISET 000252
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Error: DOI Not Found</title>
+
+
+
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css"
+          rel="stylesheet"
+          integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC"
+          crossorigin="anonymous">
+    <script
+            src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"
+            integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"
+            crossorigin="anonymous">
+    </script>
+
+    <script src="https://kit.fontawesome.com/731b8140c4.js" crossorigin="anonymous"></script>
+
+    <link rel="stylesheet" href="/static/css/style.css" integrity="">
+
+    <style>
+        @import url("https://fonts.googleapis.com/css2?family=Roboto+Mono&family=Roboto:wght@100&display=swap");
+    </style>
+
+    <link rel="icon" sizes="48x48" href="/static/images/favicons/favicon.ico">
+    <link rel="icon" sizes="32x32" href="/static/images/favicons/favicon-32x32.png">
+    <link rel="icon" sizes="16x16" href="/static/images/favicons/favicon-16x16.png">
+    <link rel="apple-touch-icon-precomposed" href="/static/images/favicons/apple-touch-icon.png">
+    <link rel="apple-touch-icon-precomposed" sizes="192x192" href="/static/images/favicons/android-chrome-192x192.png">
+    <link rel="apple-touch-icon-precomposed" sizes="512x512" href="/static/images/favicons/android-chrome-512x512.png">
+
+</head>
+<body class="generic-page">
+<header>
+    <div class="row">
+        <div class="col logo">
+            <a href="https://www.doi.org"><img class="header-logo" src="/static/images/logos/header_logo_cropped.svg" /></a>
+        </div>
+        <div class="col home-link">
+            <div class="link-alt">
+                <a href="https://www.doi.org">
+                    <span>VISIT DOI.ORG</span>
+                    <i class="fa-solid fa-arrow-right-long hover-move-right"></i>
+                </a>
+            </div>
+        </div>
+    </div>
+
+</header>
+
+
+<main aria-role="main">
+    <header class="homepage-header">
+    </header>
+    <div class="homepage-content">
+
+        <section class="single-top">
+            <div class="row short"></div>
+        </section>
+
+        <div class="page-content">
+            <article>
+                <div>
+                    <h2>DOI Not Found</h2>
+
+
+
+                    <h3>10.48324/dandi.000252/0.230408.2207</h3>
+
+
+
+
+                    <p>This DOI cannot be found in the DOI System.  Possible reasons are:</p>
+
+
+                    <ul>
+                        <li style="padding-bottom: .5em;">The DOI is incorrect in your source. Search for the item by name, title, or other metadata using a search engine.</li>
+                        <li style="padding-bottom: .5em;">The DOI was copied incorrectly. Check to see that the string includes all the characters before and after the slash and no sentence punctuation marks.</li>
+                        <li style="padding-bottom: .5em;">The DOI has not been activated yet. Please try again later, and report the problem if the error continues.</li>
+                    </ul>
+
+
+                </div>
+            </article>
+        </div>
+
+        <section class="home-infos">
+            <div class="row">
+                <div class="col ">
+                    <h2 class="title">WHAT CAN I DO NEXT?</h2>
+                    <ul>
+                        <li>If you believe this DOI is valid, you may <strong>report this error</strong> to the responsible DOI Registration Agency using the form here.</li>
+                        <li>If your organization is the steward of this DOI prefix, please make sure you have completed registration of this DOI with your Registration Agency.</li>
+                        <li>You can try to search again from <a href="https://www.doi.org">DOI.ORG homepage</a></li>
+                    </ul>
+                </div>
+                <div class="col form">
+                    <h2 class="title"><img src="/static/images/exclamation.svg">REPORT AN ERROR</h2>
+                    <form action="/notfound" method="post" enctype="application/x-www-form-urlencoded" name="notFoundForm" onsubmit="return submitDoiNotFound(event);">
+                        <div class="row">
+                            <div class="col"><label for="missingHandle">DOI:</label></div>
+                            <div class="col"><input id="missingHandle" name="missingHandle" value="10.48324/dandi.000252/0.230408.2207" type="text" readonly="readonly"></div>
+                        </div>
+                        <div class="row">
+                            <div class="col"><label for="referringPage">URL of Web Page Listing the DOI:</label></div>
+                            <div class="col"><input id="referringPage" name="referringPage" type="text" ></div>
+                        </div>
+                        <div class="row">
+                            <div class="col"><label for="userEmailAddress">Your Email Address:</label></div>
+                            <div class="col"><input id="userEmailAddress" name="userEmailAddress" type="text" /></div>
+                        </div>
+                        <div class="row">
+                            <div class="col"><label for="comments">Additional Information About the Error:</label></div>
+                            <div class="col"><textarea id="comments" name="comments"></textarea></div>
+                        </div>
+                        <div class="row">
+                            <div class="col"></div>
+                            <div class="col"><input class="submit" type="submit" value="Submit Error Report"></div>
+                        </div>
+                        <div class="row">
+                            <p id="invalidDoi" style="display: none; background:#F5B7B1; border-radius: 5px;">The DOI entered is not a valid DOI: it should start with 10 followed by a dot, and contain a slash with no preceding whitespace.</p>
+                            <p id="invalidEmail" style="display: none; background:#F5B7B1; border-radius: 5px;">The email address entered is invalid.</p>
+                            <p id="fallback" style="display: none;">Please <a href="mailto:doi-help@doi.org?subject=DOI%20Not%20Found">contact us</a> if you wish to report this anyway.</p>
+                        </div>
+                    </form>
+                </div>
+            </div>
+
+        </section>
+    </div>
+
+
+</main>
+
+<footer>
+    <div class="row">
+        <div class="col footer-left">
+            <a href="https://www.doi.org"><img class="footer-logo" src="/static/images/logos/footer_logo_cropped.svg" /></a>
+        </div>
+        <div class="col footer-right">
+            <div class="row more-info-heading">
+                <div class="col">
+                    <h2>More information on DOI resolution:</h2>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col">
+                    <ul>
+                        <li><a href="https://www.doi.org/the-identifier/resources/factsheets/doi-resolution-documentation">DOI Resolution Factsheet</a></li>
+                    </ul>
+                </div>
+                <div class="col">
+                    <ul>
+                        <li><a href="https://www.doi.org/the-identifier/resources/handbook">The DOI Handbook</a></li>
+                    </ul>
+                </div>
+                <div class="col">
+                    <ul>
+                        <li><a href="https://www.doi.org/privacy-policy/">Privacy Policy</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+
+    </div>
+    <div class="row">
+        <div class="col copyright">
+            <p>Copyright © 2023 DOI Foundation. <i class="fa-brands fa-fw fa-creative-commons"></i><i class="fa-brands fa-fw fa-creative-commons-by"></i> The content of this site is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/" title="Creative Commons" target="_blank">Creative Commons Attribution 4.0 International License</a>.</p><p>DOI&reg;, DOI.ORG&reg;, and shortDOI&reg; are trademarks of the DOI Foundation.</p>
+        </div>
+        <div class="col socials">
+            <ul class="socials-footer">
+
+                <li><a href="https://twitter.com/DOI_Foundation"><i class="fa-brands fa-fw fa-twitter"></i></a></li>
+
+                <li><a href="https://www.linkedin.com/company/doi-foundation-inc/"><i class="fa-brands fa-fw fa-linkedin"></i></a></li>
+
+                <li><a href="mailto:info@doi.org"><i class="fa-solid fa-fw fa-envelope"></i></a></li>
+
+            </ul>
+        </div>
+    </div>
+</footer>
+
+<script type="text/javascript">
+    function submitDoiNotFound(event) {
+        try {
+            document.getElementById("invalidEmail").style.display = "none";
+            document.getElementById("invalidDoi").style.display = "none";
+            document.getElementById("fallback").style.display = "none";
+
+            const missingHandle = document.getElementById('missingHandle').value.trim();
+            const userEmailAddress = document.getElementById('userEmailAddress').value.trim();
+
+            if (!validateDoi(missingHandle)) {
+                event.preventDefault();
+                document.getElementById("invalidDoi").style.display = "block";
+                document.getElementById("fallback").style.display = "block";
+                return false;
+            }
+            if (!validateEmail(userEmailAddress)) {
+                event.preventDefault();
+                document.getElementById("invalidEmail").style.display = "block";
+                return false;
+            }
+        } catch (error) {
+            // ignore
+        }
+    }
+
+    function validateEmail(email) {
+        const regEx = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        return regEx.test(email);
+    }
+
+    function validateDoi(doi) {
+        const regEx = /^10(?:\.[^\s\/]+)?\//;
+        return regEx.test(doi);
+    }
+</script>
+
+</body>
+</html>
+
+
+# Take latest as the default
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Error: DOI Not Found</title>
+
+
+
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css"
+          rel="stylesheet"
+          integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC"
+          crossorigin="anonymous">
+    <script
+            src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"
+            integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"
+            crossorigin="anonymous">
+    </script>
+
+    <script src="https://kit.fontawesome.com/731b8140c4.js" crossorigin="anonymous"></script>
+
+    <link rel="stylesheet" href="/static/css/style.css" integrity="">
+
+    <style>
+        @import url("https://fonts.googleapis.com/css2?family=Roboto+Mono&family=Roboto:wght@100&display=swap");
+    </style>
+
+    <link rel="icon" sizes="48x48" href="/static/images/favicons/favicon.ico">
+    <link rel="icon" sizes="32x32" href="/static/images/favicons/favicon-32x32.png">
+    <link rel="icon" sizes="16x16" href="/static/images/favicons/favicon-16x16.png">
+    <link rel="apple-touch-icon-precomposed" href="/static/images/favicons/apple-touch-icon.png">
+    <link rel="apple-touch-icon-precomposed" sizes="192x192" href="/static/images/favicons/android-chrome-192x192.png">
+    <link rel="apple-touch-icon-precomposed" sizes="512x512" href="/static/images/favicons/android-chrome-512x512.png">
+
+</head>
+<body class="generic-page">
+<header>
+    <div class="row">
+        <div class="col logo">
+            <a href="https://www.doi.org"><img class="header-logo" src="/static/images/logos/header_logo_cropped.svg" /></a>
+        </div>
+        <div class="col home-link">
+            <div class="link-alt">
+                <a href="https://www.doi.org">
+                    <span>VISIT DOI.ORG</span>
+                    <i class="fa-solid fa-arrow-right-long hover-move-right"></i>
+                </a>
+            </div>
+        </div>
+    </div>
+
+</header>
+
+
+<main aria-role="main">
+    <header class="homepage-header">
+    </header>
+    <div class="homepage-content">
+
+        <section class="single-top">
+            <div class="row short"></div>
+        </section>
+
+        <div class="page-content">
+            <article>
+                <div>
+                    <h2>DOI Not Found</h2>
+
+
+
+                    <h3>10.48324/dandi.000252/0.230408.2207</h3>
+
+
+
+
+                    <p>This DOI cannot be found in the DOI System.  Possible reasons are:</p>
+
+
+                    <ul>
+                        <li style="padding-bottom: .5em;">The DOI is incorrect in your source. Search for the item by name, title, or other metadata using a search engine.</li>
+                        <li style="padding-bottom: .5em;">The DOI was copied incorrectly. Check to see that the string includes all the characters before and after the slash and no sentence punctuation marks.</li>
+                        <li style="padding-bottom: .5em;">The DOI has not been activated yet. Please try again later, and report the problem if the error continues.</li>
+                    </ul>
+
+
+                </div>
+            </article>
+        </div>
+
+        <section class="home-infos">
+            <div class="row">
+                <div class="col ">
+                    <h2 class="title">WHAT CAN I DO NEXT?</h2>
+                    <ul>
+                        <li>If you believe this DOI is valid, you may <strong>report this error</strong> to the responsible DOI Registration Agency using the form here.</li>
+                        <li>If your organization is the steward of this DOI prefix, please make sure you have completed registration of this DOI with your Registration Agency.</li>
+                        <li>You can try to search again from <a href="https://www.doi.org">DOI.ORG homepage</a></li>
+                    </ul>
+                </div>
+                <div class="col form">
+                    <h2 class="title"><img src="/static/images/exclamation.svg">REPORT AN ERROR</h2>
+                    <form action="/notfound" method="post" enctype="application/x-www-form-urlencoded" name="notFoundForm" onsubmit="return submitDoiNotFound(event);">
+                        <div class="row">
+                            <div class="col"><label for="missingHandle">DOI:</label></div>
+                            <div class="col"><input id="missingHandle" name="missingHandle" value="10.48324/dandi.000252/0.230408.2207" type="text" readonly="readonly"></div>
+                        </div>
+                        <div class="row">
+                            <div class="col"><label for="referringPage">URL of Web Page Listing the DOI:</label></div>
+                            <div class="col"><input id="referringPage" name="referringPage" type="text" ></div>
+                        </div>
+                        <div class="row">
+                            <div class="col"><label for="userEmailAddress">Your Email Address:</label></div>
+                            <div class="col"><input id="userEmailAddress" name="userEmailAddress" type="text" /></div>
+                        </div>
+                        <div class="row">
+                            <div class="col"><label for="comments">Additional Information About the Error:</label></div>
+                            <div class="col"><textarea id="comments" name="comments"></textarea></div>
+                        </div>
+                        <div class="row">
+                            <div class="col"></div>
+                            <div class="col"><input class="submit" type="submit" value="Submit Error Report"></div>
+                        </div>
+                        <div class="row">
+                            <p id="invalidDoi" style="display: none; background:#F5B7B1; border-radius: 5px;">The DOI entered is not a valid DOI: it should start with 10 followed by a dot, and contain a slash with no preceding whitespace.</p>
+                            <p id="invalidEmail" style="display: none; background:#F5B7B1; border-radius: 5px;">The email address entered is invalid.</p>
+                            <p id="fallback" style="display: none;">Please <a href="mailto:doi-help@doi.org?subject=DOI%20Not%20Found">contact us</a> if you wish to report this anyway.</p>
+                        </div>
+                    </form>
+                </div>
+            </div>
+
+        </section>
+    </div>
+
+
+</main>
+
+<footer>
+    <div class="row">
+        <div class="col footer-left">
+            <a href="https://www.doi.org"><img class="footer-logo" src="/static/images/logos/footer_logo_cropped.svg" /></a>
+        </div>
+        <div class="col footer-right">
+            <div class="row more-info-heading">
+                <div class="col">
+                    <h2>More information on DOI resolution:</h2>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col">
+                    <ul>
+                        <li><a href="https://www.doi.org/the-identifier/resources/factsheets/doi-resolution-documentation">DOI Resolution Factsheet</a></li>
+                    </ul>
+                </div>
+                <div class="col">
+                    <ul>
+                        <li><a href="https://www.doi.org/the-identifier/resources/handbook">The DOI Handbook</a></li>
+                    </ul>
+                </div>
+                <div class="col">
+                    <ul>
+                        <li><a href="https://www.doi.org/privacy-policy/">Privacy Policy</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+
+    </div>
+    <div class="row">
+        <div class="col copyright">
+            <p>Copyright © 2023 DOI Foundation. <i class="fa-brands fa-fw fa-creative-commons"></i><i class="fa-brands fa-fw fa-creative-commons-by"></i> The content of this site is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/" title="Creative Commons" target="_blank">Creative Commons Attribution 4.0 International License</a>.</p><p>DOI&reg;, DOI.ORG&reg;, and shortDOI&reg; are trademarks of the DOI Foundation.</p>
+        </div>
+        <div class="col socials">
+            <ul class="socials-footer">
+
+                <li><a href="https://twitter.com/DOI_Foundation"><i class="fa-brands fa-fw fa-twitter"></i></a></li>
+
+                <li><a href="https://www.linkedin.com/company/doi-foundation-inc/"><i class="fa-brands fa-fw fa-linkedin"></i></a></li>
+
+                <li><a href="mailto:info@doi.org"><i class="fa-solid fa-fw fa-envelope"></i></a></li>
+
+            </ul>
+        </div>
+    </div>
+</footer>
+
+<script type="text/javascript">
+    function submitDoiNotFound(event) {
+        try {
+            document.getElementById("invalidEmail").style.display = "none";
+            document.getElementById("invalidDoi").style.display = "none";
+            document.getElementById("fallback").style.display = "none";
+
+            const missingHandle = document.getElementById('missingHandle').value.trim();
+            const userEmailAddress = document.getElementById('userEmailAddress').value.trim();
+
+            if (!validateDoi(missingHandle)) {
+                event.preventDefault();
+                document.getElementById("invalidDoi").style.display = "block";
+                document.getElementById("fallback").style.display = "block";
+                return false;
+            }
+            if (!validateEmail(userEmailAddress)) {
+                event.preventDefault();
+                document.getElementById("invalidEmail").style.display = "block";
+                return false;
+            }
+        } catch (error) {
+            // ignore
+        }
+    }
+
+    function validateEmail(email) {
+        const regEx = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        return regEx.test(email);
+    }
+
+    function validateDoi(doi) {
+        const regEx = /^10(?:\.[^\s\/]+)?\//;
+        return regEx.test(doi);
+    }
+</script>
+
+</body>
+</html>
+
+
+# DANDISET 000253
+@misc{dandi.000253/0.240503.0114,
+  doi = {10.48324/DANDI.000253/0.240503.0114},
+  url = {https://dandiarchive.org/dandiset/000253/0.240503.0114},
+  author = {Maier, Alex and Bastos, Andre},
+  keywords = {neocortex, predictive coding, optogenetics, neuropixels, mouse, inhibitory},
+  title = {Allen Institute Openscope - Global/Local Oddball project},
+  publisher = {DANDI Archive},
+  year = {2024}
+}
+
+
+@misc{dandi.000253/0.240503.0152,
+  doi = {10.48324/DANDI.000253/0.240503.0152},
+  url = {https://dandiarchive.org/dandiset/000253/0.240503.0152},
+  author = {Maier, Alex and Bastos, Andre},
+  keywords = {neocortex, predictive coding, optogenetics, neuropixels, mouse, inhibitory},
+  title = {Allen Institute Openscope - Global/Local Oddball project},
+  publisher = {DANDI Archive},
+  year = {2024}
+}
+
+
+# Take latest as the default
+@misc{dandi.000253,
+  doi = {10.48324/DANDI.000253/0.240503.0152},
+  url = {https://dandiarchive.org/dandiset/000253/0.240503.0152},
+  author = {Maier, Alex and Bastos, Andre},
+  keywords = {neocortex, predictive coding, optogenetics, neuropixels, mouse, inhibitory},
+  title = {Allen Institute Openscope - Global/Local Oddball project},
+  publisher = {DANDI Archive},
+  year = {2024}
+}
+
+
+# DANDISET 000292
+@misc{dandi.000292/0.220708.1652,
+  doi = {10.48324/DANDI.000292/0.220708.1652},
+  url = {https://dandiarchive.org/dandiset/000292/0.220708.1652},
+  author = {Chameh, Homeira Moradi},
+  keywords = {excitability, cortex, mouse},
+  title = {UHN whole-cell patch-clamp excitability recordings from mouse cortical neurons},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# Take latest as the default
+@misc{dandi.000292,
+  doi = {10.48324/DANDI.000292/0.220708.1652},
+  url = {https://dandiarchive.org/dandiset/000292/0.220708.1652},
+  author = {Chameh, Homeira Moradi},
+  keywords = {excitability, cortex, mouse},
+  title = {UHN whole-cell patch-clamp excitability recordings from mouse cortical neurons},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# DANDISET 000293
+@misc{dandi.000293/0.220708.1652,
+  doi = {10.48324/DANDI.000293/0.220708.1652},
+  url = {https://dandiarchive.org/dandiset/000293/0.220708.1652},
+  author = {Moradi, Homeira Moradi},
+  keywords = {excitability, human, cortex},
+  title = {UHN whole-cell patch-clamp excitability recordings from human cortical neurons},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# Take latest as the default
+@misc{dandi.000293,
+  doi = {10.48324/DANDI.000293/0.220708.1652},
+  url = {https://dandiarchive.org/dandiset/000293/0.220708.1652},
+  author = {Moradi, Homeira Moradi},
+  keywords = {excitability, human, cortex},
+  title = {UHN whole-cell patch-clamp excitability recordings from human cortical neurons},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# DANDISET 000296
+@misc{dandi.000296/0.220805.1724,
+  doi = {10.48324/DANDI.000296/0.220805.1724},
+  url = {https://dandiarchive.org/dandiset/000296/0.220805.1724},
+  author = {Gonzalez, Aneysis},
+  title = {Drosophila visual neural responses to stochastic stimuli},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# Take latest as the default
+@misc{dandi.000296,
+  doi = {10.48324/DANDI.000296/0.220805.1724},
+  url = {https://dandiarchive.org/dandiset/000296/0.220805.1724},
+  author = {Gonzalez, Aneysis},
+  title = {Drosophila visual neural responses to stochastic stimuli},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# DANDISET 000301
+@misc{dandi.000301/0.230806.0034,
+  doi = {10.48324/DANDI.000301/0.230806.0034},
+  url = {https://dandiarchive.org/dandiset/000301/0.230806.0034},
+  author = {Chinta, Suma},
+  title = {Extracellular electrophysiology unit data from mouse Superior Colliculus during whisker guided virtual navigation},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# Take latest as the default
+@misc{dandi.000301,
+  doi = {10.48324/DANDI.000301/0.230806.0034},
+  url = {https://dandiarchive.org/dandiset/000301/0.230806.0034},
+  author = {Chinta, Suma},
+  title = {Extracellular electrophysiology unit data from mouse Superior Colliculus during whisker guided virtual navigation},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# DANDISET 000350
+@misc{dandi.000350/0.221219.1506,
+  doi = {10.48324/DANDI.000350/0.221219.1506},
+  url = {https://dandiarchive.org/dandiset/000350/0.221219.1506},
+  author = {Mu, Yu and Bennett, Davis V. and Rubinov, Mikail and Narayan, Sujatha and Yang, Chao-Tsung and Tanimoto, Masashi and Mensh, Brett D.  and Looger, Loren L. and Ahrens, Misha B.},
+  keywords = {neuroscience, glia, astrocytes, norepinephrine, noradrenaline, learned helplessness, neuromodulation, behavioral states, evidence accumulation, zebrafish},
+  title = {Glia Accumulate Evidence that Actions Are Futile and Suppress Unsuccessful Behavior},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# Take latest as the default
+@misc{dandi.000350,
+  doi = {10.48324/DANDI.000350/0.221219.1506},
+  url = {https://dandiarchive.org/dandiset/000350/0.221219.1506},
+  author = {Mu, Yu and Bennett, Davis V. and Rubinov, Mikail and Narayan, Sujatha and Yang, Chao-Tsung and Tanimoto, Masashi and Mensh, Brett D.  and Looger, Loren L. and Ahrens, Misha B.},
+  keywords = {neuroscience, glia, astrocytes, norepinephrine, noradrenaline, learned helplessness, neuromodulation, behavioral states, evidence accumulation, zebrafish},
+  title = {Glia Accumulate Evidence that Actions Are Futile and Suppress Unsuccessful Behavior},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# DANDISET 000363
+@misc{dandi.000363/0.221127.2345,
+  doi = {10.48324/DANDI.000363/0.221127.2345},
+  url = {https://dandiarchive.org/dandiset/000363/0.221127.2345},
+  author = {Chen, Susu},
+  title = {Mesoscale Activity Map Dataset},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+@misc{dandi.000363/0.230124.1456,
+  doi = {10.48324/DANDI.000363/0.230124.1456},
+  url = {https://dandiarchive.org/dandiset/000363/0.230124.1456},
+  author = {Chen, Susu},
+  title = {Mesoscale Activity Map Dataset},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+@misc{dandi.000363/0.230214.1833,
+  doi = {10.48324/DANDI.000363/0.230214.1833},
+  url = {https://dandiarchive.org/dandiset/000363/0.230214.1833},
+  author = {Chen, Susu},
+  title = {Mesoscale Activity Map Dataset},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+@misc{dandi.000363/0.230613.1608,
+  doi = {10.48324/DANDI.000363/0.230613.1608},
+  url = {https://dandiarchive.org/dandiset/000363/0.230613.1608},
+  author = {Chen, Susu},
+  title = {Mesoscale Activity Map Dataset},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+@misc{dandi.000363/0.230808.2053,
+  doi = {10.48324/DANDI.000363/0.230808.2053},
+  url = {https://dandiarchive.org/dandiset/000363/0.230808.2053},
+  author = {Chen, Susu},
+  title = {Mesoscale Activity Map Dataset},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+@misc{dandi.000363/0.230822.0128,
+  doi = {10.48324/DANDI.000363/0.230822.0128},
+  url = {https://dandiarchive.org/dandiset/000363/0.230822.0128},
+  author = {Chen, Susu},
+  title = {Mesoscale Activity Map Dataset},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+@misc{dandi.000363/0.231012.2129,
+  doi = {10.48324/DANDI.000363/0.231012.2129},
+  url = {https://dandiarchive.org/dandiset/000363/0.231012.2129},
+  author = {Chen, Susu},
+  title = {Mesoscale Activity Map Dataset},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# Take latest as the default
+@misc{dandi.000363,
+  doi = {10.48324/DANDI.000363/0.231012.2129},
+  url = {https://dandiarchive.org/dandiset/000363/0.231012.2129},
+  author = {Chen, Susu},
+  title = {Mesoscale Activity Map Dataset},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# DANDISET 000398
+@misc{dandi.000398/0.221208.1803,
+  doi = {10.48324/DANDI.000398/0.221208.1803},
+  url = {https://dandiarchive.org/dandiset/000398/0.221208.1803},
+  author = {Lee, Sang Heon and Thunemann, Martin and Lee, Keundong and Cleary, Daniel R. and Tonsfeldt, Karen J. and Oh, Hongseok and Azzazy, Farid and Tchoe, Youngbin and Bourhis, Andrew M. and Hossain, Lorraine and Ro, Yun Goo and Tanaka, Atsunori and Kılıç, Kıvılcım  and Devor, Anna and Dayeh, Shadi A.},
+  title = {Scalable Thousand Channel Penetrating Microneedle Arrays on Flex for Multimodal and Large Area Coverage BrainMachine Interfaces},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# Take latest as the default
+@misc{dandi.000398,
+  doi = {10.48324/DANDI.000398/0.221208.1803},
+  url = {https://dandiarchive.org/dandiset/000398/0.221208.1803},
+  author = {Lee, Sang Heon and Thunemann, Martin and Lee, Keundong and Cleary, Daniel R. and Tonsfeldt, Karen J. and Oh, Hongseok and Azzazy, Farid and Tchoe, Youngbin and Bourhis, Andrew M. and Hossain, Lorraine and Ro, Yun Goo and Tanaka, Atsunori and Kılıç, Kıvılcım  and Devor, Anna and Dayeh, Shadi A.},
+  title = {Scalable Thousand Channel Penetrating Microneedle Arrays on Flex for Multimodal and Large Area Coverage BrainMachine Interfaces},
+  publisher = {DANDI Archive},
+  year = {2022}
+}
+
+
+# DANDISET 000402
+@misc{dandi.000402/0.230307.2132,
+  doi = {10.48324/DANDI.000402/0.230307.2132},
+  url = {https://dandiarchive.org/dandiset/000402/0.230307.2132},
+  author = {Bae, J. Alexander and Baptiste, Mahaly and Bodor, Agnes L. and Brittain, Derrick and Buchanan, JoAnn and Bumbarger, Daniel J. and Castro, Manuel A. and Celii, Brendan and Cobos, Erick  and Collman, Forrest and Maçarico da Costa, Nuno and Dorkenwald, Sven and Elabbady, Leila and Fahey, Paul G. and Fliss, Tim and Froudarakis, Emmanouil and Gager, Jay and Gamlin, Clare and Halageri, Akhilesh and Hebditch, James and Jia, Zhen and Jordan, Chris and Kapner, Daniel and Kemnitz, Nico and Kinn, Sam and Koolman, Selden and Kuehner, Kai and Lee, Kisuk and Li, Kai and Lu, Ran and Macrina, Thomas and Mahalingam, Gayathri and McReynolds, Sarah and Miranda, Elanine and Mitchell, Eric and Mondal, Shanka Subhra and Moore, Merlin and Mu, Shang and Muhammad, Taliah and Nehoran, Barak and Ogedengbe, Oluwaseun and Papadopoulos, Christos and Papadopoulos, Stelios and Patel, Saumil and Pitkow, Xaq and Popovych, Sergiy and Ramos, Anthony and Reid, R. Clay and Reimer, Jacob and Schneider-Mizell, Casey M. and Seung, H. Sebastian and Silverman, Ben and Silversmith, William and Sterling, Amy and Sinz, Fabian H. and Smith, Cameron L. and Suckow, Shelby and Takeno, Marc and Tan, Zheng H. and Tolias, Andreas S. and Torres, Russel and Turner, Nicholas L. and Walker, Edgar Y. and Wang, Tianyu and Williams, Grace and Williams, Sarah and Willie, Kyle and Willie, Ryan and Wong, William and Wu, Jingpeng and Xu, Chris and Yang, Runzhe and Yatsenko, Dimitri and Ye, Fei and Yin, Wenjing and Yu, Szi-chieh},
+  title = {MICrONS Two Photon Functional Imaging},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# Take latest as the default
+@misc{dandi.000402,
+  doi = {10.48324/DANDI.000402/0.230307.2132},
+  url = {https://dandiarchive.org/dandiset/000402/0.230307.2132},
+  author = {Bae, J. Alexander and Baptiste, Mahaly and Bodor, Agnes L. and Brittain, Derrick and Buchanan, JoAnn and Bumbarger, Daniel J. and Castro, Manuel A. and Celii, Brendan and Cobos, Erick  and Collman, Forrest and Maçarico da Costa, Nuno and Dorkenwald, Sven and Elabbady, Leila and Fahey, Paul G. and Fliss, Tim and Froudarakis, Emmanouil and Gager, Jay and Gamlin, Clare and Halageri, Akhilesh and Hebditch, James and Jia, Zhen and Jordan, Chris and Kapner, Daniel and Kemnitz, Nico and Kinn, Sam and Koolman, Selden and Kuehner, Kai and Lee, Kisuk and Li, Kai and Lu, Ran and Macrina, Thomas and Mahalingam, Gayathri and McReynolds, Sarah and Miranda, Elanine and Mitchell, Eric and Mondal, Shanka Subhra and Moore, Merlin and Mu, Shang and Muhammad, Taliah and Nehoran, Barak and Ogedengbe, Oluwaseun and Papadopoulos, Christos and Papadopoulos, Stelios and Patel, Saumil and Pitkow, Xaq and Popovych, Sergiy and Ramos, Anthony and Reid, R. Clay and Reimer, Jacob and Schneider-Mizell, Casey M. and Seung, H. Sebastian and Silverman, Ben and Silversmith, William and Sterling, Amy and Sinz, Fabian H. and Smith, Cameron L. and Suckow, Shelby and Takeno, Marc and Tan, Zheng H. and Tolias, Andreas S. and Torres, Russel and Turner, Nicholas L. and Walker, Edgar Y. and Wang, Tianyu and Williams, Grace and Williams, Sarah and Willie, Kyle and Willie, Ryan and Wong, William and Wu, Jingpeng and Xu, Chris and Yang, Runzhe and Yatsenko, Dimitri and Ye, Fei and Yin, Wenjing and Yu, Szi-chieh},
+  title = {MICrONS Two Photon Functional Imaging},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# DANDISET 000404
+@misc{dandi.000404/0.230605.2024,
+  doi = {10.48324/DANDI.000404/0.230605.2024},
+  url = {https://dandiarchive.org/dandiset/000404/0.230605.2024},
+  author = {Athalye, Vivek R and Khanna, Preeya and Gowda, Suraj and Orsborn, Amy L and Costa, Rui M and Carmena, Jose M},
+  keywords = {neural population dynamics, motor cortex, motor control, brain-machine interface, neuroprosthetics, optimal feedback control, motor commands, movement representations, dynamical systems},
+  title = {Monkey 2D cursor BMI},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# Take latest as the default
+@misc{dandi.000404,
+  doi = {10.48324/DANDI.000404/0.230605.2024},
+  url = {https://dandiarchive.org/dandiset/000404/0.230605.2024},
+  author = {Athalye, Vivek R and Khanna, Preeya and Gowda, Suraj and Orsborn, Amy L and Costa, Rui M and Carmena, Jose M},
+  keywords = {neural population dynamics, motor cortex, motor control, brain-machine interface, neuroprosthetics, optimal feedback control, motor commands, movement representations, dynamical systems},
+  title = {Monkey 2D cursor BMI},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# DANDISET 000447
+@misc{dandi.000447/0.230316.2133,
+  doi = {10.48324/DANDI.000447/0.230316.2133},
+  url = {https://dandiarchive.org/dandiset/000447/0.230316.2133},
+  author = {Shin, Justin},
+  keywords = {Hippocampus, Prefrontal cortex, Learning, Memory, Decision making},
+  title = {Novel-familiar-novel WTrack (CA1-PFC)},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# Take latest as the default
+@misc{dandi.000447,
+  doi = {10.48324/DANDI.000447/0.230316.2133},
+  url = {https://dandiarchive.org/dandiset/000447/0.230316.2133},
+  author = {Shin, Justin},
+  keywords = {Hippocampus, Prefrontal cortex, Learning, Memory, Decision making},
+  title = {Novel-familiar-novel WTrack (CA1-PFC)},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# DANDISET 000448
+@misc{dandi.000448/0.230421.1844,
+  doi = {10.48324/DANDI.000448/0.230421.1844},
+  url = {https://dandiarchive.org/dandiset/000448/0.230421.1844},
+  author = {Silkuniene, Giedre},
+  title = {Time kinetics of the membrane potential at the cathode- and anode-facing poles of a cell induced by a train of 5 pulses at 833 kHz},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# Take latest as the default
+@misc{dandi.000448,
+  doi = {10.48324/DANDI.000448/0.230421.1844},
+  url = {https://dandiarchive.org/dandiset/000448/0.230421.1844},
+  author = {Silkuniene, Giedre},
+  title = {Time kinetics of the membrane potential at the cathode- and anode-facing poles of a cell induced by a train of 5 pulses at 833 kHz},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# DANDISET 000454
+@misc{dandi.000454/0.230302.2331,
+  doi = {10.48324/DANDI.000454/0.230302.2331},
+  url = {https://dandiarchive.org/dandiset/000454/0.230302.2331},
+  author = {Klienfeld, David and Yao, Pantong and Liu, Rui and Broginni, Thomas and Thunemann, Martin},
+  title = {Guide to the construction and use of an adaptive optics two-photon microscope with direct wavefront sensing},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# Take latest as the default
+@misc{dandi.000454,
+  doi = {10.48324/DANDI.000454/0.230302.2331},
+  url = {https://dandiarchive.org/dandiset/000454/0.230302.2331},
+  author = {Klienfeld, David and Yao, Pantong and Liu, Rui and Broginni, Thomas and Thunemann, Martin},
+  title = {Guide to the construction and use of an adaptive optics two-photon microscope with direct wavefront sensing},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# DANDISET 000458
+@misc{dandi.000458/0.230317.0039,
+  doi = {10.48324/DANDI.000458/0.230317.0039},
+  url = {https://dandiarchive.org/dandiset/000458/0.230317.0039},
+  author = {Claar, Leslie D and Rembado, Irene and Kuyat, Jacqulyn R and Russo, Simone and Marks, Lydia C and Olsen, Shawn R and Koch, Christof},
+  keywords = {EEG, Neuropixels, electrical stimulation, brain states, cortico-thalamic interactions, extracellular electrophysiology},
+  title = {Simultaneous electroencephalography, extracellular electrophysiology, and cortical electrical stimulation in head-fixed mice},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# Take latest as the default
+@misc{dandi.000458,
+  doi = {10.48324/DANDI.000458/0.230317.0039},
+  url = {https://dandiarchive.org/dandiset/000458/0.230317.0039},
+  author = {Claar, Leslie D and Rembado, Irene and Kuyat, Jacqulyn R and Russo, Simone and Marks, Lydia C and Olsen, Shawn R and Koch, Christof},
+  keywords = {EEG, Neuropixels, electrical stimulation, brain states, cortico-thalamic interactions, extracellular electrophysiology},
+  title = {Simultaneous electroencephalography, extracellular electrophysiology, and cortical electrical stimulation in head-fixed mice},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# DANDISET 000462
+@misc{dandi.000462/0.230416.2132,
+  doi = {10.48324/DANDI.000462/0.230416.2132},
+  url = {https://dandiarchive.org/dandiset/000462/0.230416.2132},
+  author = {Krishnan, Seetha},
+  keywords = {hippocampus; dopamine; mice; reward; calcium imaging; VR based navigation; DREADD},
+  title = {HippocampusRewardDataset},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# Take latest as the default
+@misc{dandi.000462,
+  doi = {10.48324/DANDI.000462/0.230416.2132},
+  url = {https://dandiarchive.org/dandiset/000462/0.230416.2132},
+  author = {Krishnan, Seetha},
+  keywords = {hippocampus; dopamine; mice; reward; calcium imaging; VR based navigation; DREADD},
+  title = {HippocampusRewardDataset},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# DANDISET 000465
+@misc{dandi.000465/0.230530.2349,
+  doi = {10.48324/DANDI.000465/0.230530.2349},
+  url = {https://dandiarchive.org/dandiset/000465/0.230530.2349},
+  author = {Tchoe, Youngbin},
+  keywords = {micro-ECoG, barrel cortex, high gamma activity},
+  title = {Human brain mapping with multithousand-channel PtNRGrids resolves spatiotemporal dynamics},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# Take latest as the default
+@misc{dandi.000465,
+  doi = {10.48324/DANDI.000465/0.230530.2349},
+  url = {https://dandiarchive.org/dandiset/000465/0.230530.2349},
+  author = {Tchoe, Youngbin},
+  keywords = {micro-ECoG, barrel cortex, high gamma activity},
+  title = {Human brain mapping with multithousand-channel PtNRGrids resolves spatiotemporal dynamics},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# DANDISET 000469
+@misc{dandi.000469/0.231213.2047,
+  doi = {10.48324/DANDI.000469/0.231213.2047},
+  url = {https://dandiarchive.org/dandiset/000469/0.231213.2047},
+  author = {Kyzar, Michael and Brzezicka, Aneta and Rutishauser, Ueli},
+  keywords = {cognitive neuroscience, data standardization, working memory, neurophysiology, neurosurgery, NWB, open source, single-neurons},
+  title = {Dataset of human-single neuron activity during a Sternberg working memory task.},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+@misc{dandi.000469/0.240122.1800,
+  doi = {10.48324/DANDI.000469/0.240122.1800},
+  url = {https://dandiarchive.org/dandiset/000469/0.240122.1800},
+  author = {Kyzar, Michael and Brzezicka, Aneta and Rutishauser, Ueli},
+  keywords = {cognitive neuroscience, data standardization, working memory, neurophysiology, neurosurgery, NWB, open source, single-neurons},
+  title = {Dataset of human-single neuron activity during a Sternberg working memory task.},
+  publisher = {DANDI Archive},
+  year = {2024}
+}
+
+
+@misc{dandi.000469/0.240122.1812,
+  doi = {10.48324/DANDI.000469/0.240122.1812},
+  url = {https://dandiarchive.org/dandiset/000469/0.240122.1812},
+  author = {Kyzar, Michael and Brzezicka, Aneta and Rutishauser, Ueli},
+  keywords = {cognitive neuroscience, data standardization, working memory, neurophysiology, neurosurgery, NWB, open source, single-neurons},
+  title = {Dataset of human-single neuron activity during a Sternberg working memory task.},
+  publisher = {DANDI Archive},
+  year = {2024}
+}
+
+
+@misc{dandi.000469/0.240123.1806,
+  doi = {10.48324/DANDI.000469/0.240123.1806},
+  url = {https://dandiarchive.org/dandiset/000469/0.240123.1806},
+  author = {Kyzar, Michael and Brzezicka, Aneta and Rutishauser, Ueli},
+  keywords = {cognitive neuroscience, data standardization, working memory, neurophysiology, neurosurgery, NWB, open source, single-neurons},
+  title = {Dataset of human-single neuron activity during a Sternberg working memory task.},
+  publisher = {DANDI Archive},
+  year = {2024}
+}
+
+
+# Take latest as the default
+@misc{dandi.000469,
+  doi = {10.48324/DANDI.000469/0.240123.1806},
+  url = {https://dandiarchive.org/dandiset/000469/0.240123.1806},
+  author = {Kyzar, Michael and Brzezicka, Aneta and Rutishauser, Ueli},
+  keywords = {cognitive neuroscience, data standardization, working memory, neurophysiology, neurosurgery, NWB, open source, single-neurons},
+  title = {Dataset of human-single neuron activity during a Sternberg working memory task.},
+  publisher = {DANDI Archive},
+  year = {2024}
+}
+
+
+# DANDISET 000472
+@misc{dandi.000472/0.240402.2117,
+  doi = {10.48324/DANDI.000472/0.240402.2117},
+  url = {https://dandiarchive.org/dandiset/000472/0.240402.2117},
+  author = {Sprague, Daniel},
+  title = {NeuroPAL volumetric images},
+  publisher = {DANDI Archive},
+  year = {2024}
+}
+
+
+# Take latest as the default
+@misc{dandi.000472,
+  doi = {10.48324/DANDI.000472/0.240402.2117},
+  url = {https://dandiarchive.org/dandiset/000472/0.240402.2117},
+  author = {Sprague, Daniel},
+  title = {NeuroPAL volumetric images},
+  publisher = {DANDI Archive},
+  year = {2024}
+}
+
+
+# DANDISET 000473
+@misc{dandi.000473/0.230417.1502,
+  doi = {10.48324/DANDI.000473/0.230417.1502},
+  url = {https://dandiarchive.org/dandiset/000473/0.230417.1502},
+  author = {Calvigioni, Daniela and Fuzik, Janos and Le Merre, Pierre and Slashcheva, Marina and Jung, Felix and Ortiz, Cantin and Lentini, Antonio and Csillag, Veronika and Graziano, Marta and Nikolakopoulou, Ifigeneia and Weglage, Moritz and Lazaridis, Iakovos and Kim, Hoseok and Lenzi, Irene and Park, Hyunsoo and Reinius, Björn and Carlén, Marie and Meletis, Konstantinos},
+  keywords = {Neuropixels, Mouse, Head-fixed, Lateral Hypothalamus, Lateral Habenula, Prefrontal cortex, Aversion},
+  title = {Esr1+ hypothalamic-habenula neurons shape aversive states.},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# Take latest as the default
+@misc{dandi.000473,
+  doi = {10.48324/DANDI.000473/0.230417.1502},
+  url = {https://dandiarchive.org/dandiset/000473/0.230417.1502},
+  author = {Calvigioni, Daniela and Fuzik, Janos and Le Merre, Pierre and Slashcheva, Marina and Jung, Felix and Ortiz, Cantin and Lentini, Antonio and Csillag, Veronika and Graziano, Marta and Nikolakopoulou, Ifigeneia and Weglage, Moritz and Lazaridis, Iakovos and Kim, Hoseok and Lenzi, Irene and Park, Hyunsoo and Reinius, Björn and Carlén, Marie and Meletis, Konstantinos},
+  keywords = {Neuropixels, Mouse, Head-fixed, Lateral Hypothalamus, Lateral Habenula, Prefrontal cortex, Aversion},
+  title = {Esr1+ hypothalamic-habenula neurons shape aversive states.},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# DANDISET 000481
+@misc{dandi.000481/0.230417.2148,
+  doi = {10.48324/DANDI.000481/0.230417.2148},
+  url = {https://dandiarchive.org/dandiset/000481/0.230417.2148},
+  author = {Bereshpolova, Yulia},
+  keywords = {electrophysiology, signal processing},
+  title = {State-dependent processing in visual cortex},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# Take latest as the default
+@misc{dandi.000481,
+  doi = {10.48324/DANDI.000481/0.230417.2148},
+  url = {https://dandiarchive.org/dandiset/000481/0.230417.2148},
+  author = {Bereshpolova, Yulia},
+  keywords = {electrophysiology, signal processing},
+  title = {State-dependent processing in visual cortex},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# DANDISET 000483
+@misc{dandi.000483/0.230421.2321,
+  doi = {10.48324/DANDI.000483/0.230421.2321},
+  url = {https://dandiarchive.org/dandiset/000483/0.230421.2321},
+  author = {Sit, Kevin and Goard, Michael},
+  title = {Dataset for "Coregistration of heading to visual cues in retrosplenial cortex"},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# Take latest as the default
+@misc{dandi.000483,
+  doi = {10.48324/DANDI.000483/0.230421.2321},
+  url = {https://dandiarchive.org/dandiset/000483/0.230421.2321},
+  author = {Sit, Kevin and Goard, Michael},
+  title = {Dataset for "Coregistration of heading to visual cues in retrosplenial cortex"},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# DANDISET 000488
+@misc{dandi.000488/0.230602.2022,
+  doi = {10.48324/DANDI.000488/0.230602.2022},
+  url = {https://dandiarchive.org/dandiset/000488/0.230602.2022},
+  author = {Lecoq, Jerome A. and Garrett, Marina and Choi, Hannah and Mazzucato, Luca and Wyrick, David},
+  keywords = {neocortex, pyramidal neurons, two-photon calcium imaging, mouse VisP, prediction, predictive coding},
+  title = {Allen Institute Openscope - Differential encoding of temporal context and expectation},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# Take latest as the default
+@misc{dandi.000488,
+  doi = {10.48324/DANDI.000488/0.230602.2022},
+  url = {https://dandiarchive.org/dandiset/000488/0.230602.2022},
+  author = {Lecoq, Jerome A. and Garrett, Marina and Choi, Hannah and Mazzucato, Luca and Wyrick, David},
+  keywords = {neocortex, pyramidal neurons, two-photon calcium imaging, mouse VisP, prediction, predictive coding},
+  title = {Allen Institute Openscope - Differential encoding of temporal context and expectation},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# DANDISET 000489
+@misc{dandi.000489/0.230518.1811,
+  doi = {10.48324/DANDI.000489/0.230518.1811},
+  url = {https://dandiarchive.org/dandiset/000489/0.230518.1811},
+  author = {Silkuniene, Giedre},
+  title = {The impact of the second phase amplitude (% to the first phase) on the electroporation efficiency (measured as YP emission)},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# Take latest as the default
+@misc{dandi.000489,
+  doi = {10.48324/DANDI.000489/0.230518.1811},
+  url = {https://dandiarchive.org/dandiset/000489/0.230518.1811},
+  author = {Silkuniene, Giedre},
+  title = {The impact of the second phase amplitude (% to the first phase) on the electroporation efficiency (measured as YP emission)},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# DANDISET 000491
+@misc{dandi.000491/0.230427.1809,
+  doi = {10.48324/DANDI.000491/0.230427.1809},
+  url = {https://dandiarchive.org/dandiset/000491/0.230427.1809},
+  author = {Zhao, Yue},
+  title = {BrainWaveZZZ},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+@misc{dandi.000491/0.230602.1307,
+  doi = {10.48324/DANDI.000491/0.230602.1307},
+  url = {https://dandiarchive.org/dandiset/000491/0.230602.1307},
+  author = {Raicevic, Nikola},
+  title = {BrainFlowZZZ},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# Take latest as the default
+@misc{dandi.000491,
+  doi = {10.48324/DANDI.000491/0.230602.1307},
+  url = {https://dandiarchive.org/dandiset/000491/0.230602.1307},
+  author = {Raicevic, Nikola},
+  title = {BrainFlowZZZ},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# DANDISET 000535
+@misc{dandi.000535/0.230524.0416,
+  doi = {10.48324/DANDI.000535/0.230524.0416},
+  url = {https://dandiarchive.org/dandiset/000535/0.230524.0416},
+  author = {Murdock, Mitchell H. and Arkhipov, Anton and Ito, Shinya and Ren, Naixin and Billeh, Yazan N.},
+  keywords = {two-photon, cortical recording, gamma, neuroprotection, oscillations, visual stimuli},
+  title = {Allen Institute Openscope - Effects of Periodic Visual Stimulation on Neural Activity in Mouse Visual Cortex},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# Take latest as the default
+@misc{dandi.000535,
+  doi = {10.48324/DANDI.000535/0.230524.0416},
+  url = {https://dandiarchive.org/dandiset/000535/0.230524.0416},
+  author = {Murdock, Mitchell H. and Arkhipov, Anton and Ito, Shinya and Ren, Naixin and Billeh, Yazan N.},
+  keywords = {two-photon, cortical recording, gamma, neuroprotection, oscillations, visual stimuli},
+  title = {Allen Institute Openscope - Effects of Periodic Visual Stimulation on Neural Activity in Mouse Visual Cortex},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# DANDISET 000540
+@misc{dandi.000540/0.230515.0530,
+  doi = {10.48324/DANDI.000540/0.230515.0530},
+  url = {https://dandiarchive.org/dandiset/000540/0.230515.0530},
+  author = {Liao, Song-Mao and Kleinfeld, David},
+  keywords = {breathing, coupled oscillators, electromyogram, foraging, muscles, nose, preBotzinger complex, rearing, vibrissae, whiskers, neck},
+  title = {Dataset for: A change in behavioral state switches the pattern of motor output that underlies rhythmic head and orofacial movements},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# Take latest as the default
+@misc{dandi.000540,
+  doi = {10.48324/DANDI.000540/0.230515.0530},
+  url = {https://dandiarchive.org/dandiset/000540/0.230515.0530},
+  author = {Liao, Song-Mao and Kleinfeld, David},
+  keywords = {breathing, coupled oscillators, electromyogram, foraging, muscles, nose, preBotzinger complex, rearing, vibrissae, whiskers, neck},
+  title = {Dataset for: A change in behavioral state switches the pattern of motor output that underlies rhythmic head and orofacial movements},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# DANDISET 000544
+@misc{dandi.000544/0.230514.1148,
+  doi = {10.48324/DANDI.000544/0.230514.1148},
+  url = {https://dandiarchive.org/dandiset/000544/0.230514.1148},
+  author = {Bakshi, Kushal},
+  title = {Test Dataset},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# Take latest as the default
+@misc{dandi.000544,
+  doi = {10.48324/DANDI.000544/0.230514.1148},
+  url = {https://dandiarchive.org/dandiset/000544/0.230514.1148},
+  author = {Bakshi, Kushal},
+  title = {Test Dataset},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# DANDISET 000547
+@misc{dandi.000547/0.230822.1616,
+  doi = {10.48324/DANDI.000547/0.230822.1616},
+  url = {https://dandiarchive.org/dandiset/000547/0.230822.1616},
+  author = {Gan, Yiming and Kelley, Douglas and Holstein-Rønsbo, Stephanie and Boster, Kimberly and Thomas, John and Nedergaard, Maiken},
+  title = {Perivascular Pumping of Cerebrospinal Fluid in the Brain with a Valve Mechanism},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# Take latest as the default
+@misc{dandi.000547,
+  doi = {10.48324/DANDI.000547/0.230822.1616},
+  url = {https://dandiarchive.org/dandiset/000547/0.230822.1616},
+  author = {Gan, Yiming and Kelley, Douglas and Holstein-Rønsbo, Stephanie and Boster, Kimberly and Thomas, John and Nedergaard, Maiken},
+  title = {Perivascular Pumping of Cerebrospinal Fluid in the Brain with a Valve Mechanism},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# DANDISET 000548
+@misc{dandi.000548/0.230519.1825,
+  doi = {10.48324/DANDI.000548/0.230519.1825},
+  url = {https://dandiarchive.org/dandiset/000548/0.230519.1825},
+  author = {Silkuniene, Giedre},
+  title = {Effect of the number of pulses on electroporation by unipolar and 50 % bipolar pulses},
+  publisher = {DANDI Archive},
+  year = {2023}
+}
+
+
+# Take latest as the default
+@misc{dandi.000548,
+  doi = {10.48324/DANDI.000548/0.230519.1825},
+  url = {https://dandiarchive.org/dandiset/000548/0.230519.1825},
+  author = {Silkuniene, Giedre},
+  title = {Effect of the number of pulses on electroporation by unipolar and 50 % bipolar pulses},
+  publisher = {DANDI Archive},
+  year = {2023}
+}

--- a/sandbox/get-bibliography
+++ b/sandbox/get-bibliography
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+
+import argparse
+import json
+import logging
+import sys
+
+import requests
+
+# Configure the logging
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    stream=sys.stderr,
+)
+
+lgr = logging.getLogger(__name__)
+
+
+def fetch_dandisets(me, results=None):
+    if results is None:
+        results = {}
+
+    # Construct the query URL
+    url = (
+        f"https://api.dandiarchive.org/api/dandisets/?draft=false&empty=false"
+        f"&embargoed=false{'&user=me' if me else ''}"
+    )
+    lgr.info(f"Fetching {url}")
+    headers = {"accept": "application/json"}
+
+    # Fetch the dandisets
+    response = requests.get(url, headers=headers)
+    dandisets = response.json()["results"]
+    lgr.info(f"Got {len(dandisets)} dandisets listed")
+    # for dandiset in [{'identifier': '000027', 'most_recent_published_version':
+    #                 {'version': '0.210831.2033'}}]:
+    for dandiset in dandisets:
+        identifier = dandiset["identifier"]
+        # Fetch versions for each dandiset
+        versions_url = (
+            f"https://api.dandiarchive.org/api/dandisets/{identifier}/versions/"
+            "?page_size=1000"
+        )
+        versions_response = requests.get(versions_url, headers=headers)
+        versions = versions_response.json()["results"]
+        for version in versions:
+            version_id = version["version"]
+            if version_id == "draft":
+                continue
+            if identifier not in results:
+                results[identifier] = {}
+            if version_id not in results[identifier]:
+                doi_url = f"https://doi.org/10.48324/dandi.{identifier}/{version_id}"
+                doi_headers = {"Accept": "application/x-bibtex; charset=utf-8"}
+                doi_response = requests.get(doi_url, headers=doi_headers)
+                bibtex = doi_response.text
+                results[identifier][version_id] = bibtex.replace(
+                    "@misc{https://doi.org/10.48324/", "@misc{"
+                )
+        # The default to be cited -- ATM we do not have DOI for it, use latest version
+        v = dandiset["most_recent_published_version"]["version"]
+        # TODO: might want to robustify using `re` etc.
+        results[identifier][None] = results[identifier][v].replace(
+            f"@misc{{dandi.{identifier}/{v},", f"@misc{{dandi.{identifier},"
+        )
+
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Fetch bibliography collection")
+    # TODO: for --me to function, would need to bolt on the authorization to work
+    parser.add_argument("--me", action="store_true", help="Fetch only my dandisets")
+    parser.add_argument(
+        "--results",
+        type=str,
+        help="Path to prior results JSON file, or where to save/cache results JSON",
+        default=None,
+    )
+    # TODO:
+    # - add options for requested format (currently bibtex but probably others supported)
+    # - add option to do it only for specific datasets. Orthogonal to --me
+
+    args = parser.parse_args()
+
+    results = None
+    if args.results:
+        with open(args.results, "r") as f:
+            results = json.load(f)
+
+    results = fetch_dandisets(args.me, results)
+
+    if args.results:
+        with open(args.results, "w") as f:
+            json.dump(results, f, indent=2)
+        lgr.info("Updated results have been saved to %s", args.results)
+
+    # OUTPUT BibTeX
+    for dataset, versions in results.items():
+        print(f"# DANDISET {dataset}")
+        for version, rec in versions.items():
+            if version is None:
+                print("# Take latest as the default")
+            print(rec)
+            print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
a follow up to @bendichter  's 
- https://github.com/dandi/dandi-archive/issues/1555

I think this is a viable prototype with some TODOs (provided in the script) for us to collate/update an ultimate DANDI bibliography (as bibtex).  WDYT?  

Also includes the `dandi.bib` which script produced.

Related: 
- https://github.com/dandi/dandi-archive/issues/1709#issuecomment-1924227635 -- use Zenodo's approach and have DOI per dandiset pointing to most recent published (or draft until then).  Meanwhile I just populate per dandi for the most recent version