### PR TITLE
Temporarily restrict dandischema requirement to `< 0.10.2`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,9 @@ install_requires =
     bidsschematools ~= 0.7.0
     click >= 7.1
     click-didyoumean
-    dandischema >= 0.9.0, < 0.11
+    # Don't allow v0.10.2 of the schema until
+    # <https://github.com/dandi/dandi-archive/issues/1975> is resolved:
+    dandischema >= 0.9.0, < 0.10.2
     etelemetry >= 0.2.2
     fasteners
     fscacher >= 0.3.0


### PR DESCRIPTION
Per @jjnesbitt's advice [here](https://github.com/dandi/dandi-archive/issues/1975#issuecomment-2223977835)

Note that I have added the "release" tag to this PR in order to get this restriction out to users soon.