### PR TITLE
Revert "Temporarily restrict dandischema requirement to `< 0.10.2`"

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,9 +33,7 @@ install_requires =
     bidsschematools ~= 0.7.0
     click >= 7.1
     click-didyoumean
-    # Don't allow v0.10.2 of the schema until
-    # <https://github.com/dandi/dandi-archive/issues/1975> is resolved:
-    dandischema >= 0.9.0, < 0.10.2
+    dandischema >= 0.9.0, < 0.11
     etelemetry >= 0.2.2
     fasteners
     fscacher >= 0.3.0


### PR DESCRIPTION
This reverts commit ccf43297da2c505dc6bba21c8b551a0404d7e234.

Now that https://github.com/dandi/dandi-archive/issues/1975 has been closed as resolved.