### PR TITLE
Revert "Unbreak vcrpy install"

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,12 +39,5 @@ jobs:
         python -m pip install --upgrade pip wheel
         python -m pip install --upgrade tox
 
-    # <https://github.com/kevin1024/vcrpy/issues/855>
-    # <https://github.com/pypa/setuptools/issues/4519>
-    - name: Unbreak vcrpy install
-      run: |
-        echo 'setuptools<72' > /tmp/pip-constraint.txt
-        echo PIP_CONSTRAINT=/tmp/pip-constraint.txt >> "$GITHUB_ENV"
-
     - name: Build docs
       run: tox -e docs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,27 +12,16 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
         python-version: '3.8'
-
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         python -m pip install --upgrade tox
-
     # Annotate codespell within PR
     - uses: codespell-project/codespell-problem-matcher@v1
-
-    # <https://github.com/kevin1024/vcrpy/issues/855>
-    # <https://github.com/pypa/setuptools/issues/4519>
-    - name: Unbreak vcrpy install
-      run: |
-        echo 'setuptools<72' > /tmp/pip-constraint.txt
-        echo PIP_CONSTRAINT=/tmp/pip-constraint.txt >> "$GITHUB_ENV"
-
     - name: Run linters
       run: |
         tox -e lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,13 +63,6 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
 
-    # <https://github.com/kevin1024/vcrpy/issues/855>
-    # <https://github.com/pypa/setuptools/issues/4519>
-    - name: Unbreak vcrpy install
-      run: |
-        echo 'setuptools<72' > /tmp/pip-constraint.txt
-        echo PIP_CONSTRAINT=/tmp/pip-constraint.txt >> "$GITHUB_ENV"
-
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip wheel

--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -23,12 +23,5 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install --upgrade tox
 
-      # <https://github.com/kevin1024/vcrpy/issues/855>
-      # <https://github.com/pypa/setuptools/issues/4519>
-      - name: Unbreak vcrpy install
-        run: |
-          echo 'setuptools<72' > /tmp/pip-constraint.txt
-          echo PIP_CONSTRAINT=/tmp/pip-constraint.txt >> "$GITHUB_ENV"
-
       - name: Run type checker
         run: tox -e typing


### PR DESCRIPTION
This reverts commit b9c726d21a67a685bf7ac04b50984d0e418e70a8.

This should no longer be necessary as of the release of setuptools 72.1.0 within the last half-hour.