### PR TITLE
Fix handling of `--preserve-tree` for asset ID-only URLs

### DIFF
--- a/dandi/cli/cmd_download.py
+++ b/dandi/cli/cmd_download.py
@@ -105,7 +105,8 @@ Download files or entire folders from DANDI.
     is_flag=True,
     help=(
         "When downloading only part of a Dandiset, also download"
-        " `dandiset.yaml` and do not strip leading directories from asset"
+        " `dandiset.yaml` (unless downloading an asset URL that does not"
+        " include a Dandiset ID) and do not strip leading directories from asset"
         " paths.  Implies `--download all`."
     ),
 )

--- a/dandi/download.py
+++ b/dandi/download.py
@@ -242,11 +242,14 @@ class Downloader:
 
         with self.url.navigate(strict=True) as (client, dandiset, assets):
             if (
-                isinstance(self.url, DandisetURL)
-                or self.is_dandiset_yaml()
-                or self.preserve_tree
-            ) and self.get_metadata:
-                assert dandiset is not None
+                (
+                    isinstance(self.url, DandisetURL)
+                    or self.is_dandiset_yaml()
+                    or self.preserve_tree
+                )
+                and self.get_metadata
+                and dandiset is not None
+            ):
                 for resp in _populate_dandiset_yaml(
                     self.output_path, dandiset, self.existing
                 ):

--- a/dandi/tests/test_download.py
+++ b/dandi/tests/test_download.py
@@ -250,6 +250,15 @@ def test_download_asset_id_only(text_dandiset: SampleDandiset, tmp_path: Path) -
     assert (tmp_path / "coconut.txt").read_text() == "Coconut\n"
 
 
+def test_download_asset_id_only_preserve_tree(
+    text_dandiset: SampleDandiset, tmp_path: Path
+) -> None:
+    asset = text_dandiset.dandiset.get_asset_by_path("subdir2/coconut.txt")
+    download(asset.base_download_url, tmp_path, preserve_tree=True)
+    assert list_paths(tmp_path, dirs=False) == [tmp_path / "subdir2" / "coconut.txt"]
+    assert (tmp_path / "subdir2" / "coconut.txt").read_text() == "Coconut\n"
+
+
 def test_download_asset_by_equal_prefix(
     text_dandiset: SampleDandiset, tmp_path: Path
 ) -> None:

--- a/docs/source/cmdline/download.rst
+++ b/docs/source/cmdline/download.rst
@@ -49,7 +49,8 @@ Options
 .. option:: --preserve-tree
 
     When downloading only part of a Dandiset, also download
-    :file:`dandiset.yaml` and do not strip leading directories from asset
+    :file:`dandiset.yaml` (unless downloading an asset URL that does not
+    include a Dandiset ID) and do not strip leading directories from asset
     paths.  Implies ``--download all``.
 
 .. option:: --sync


### PR DESCRIPTION
Closes #1475.