### PR TITLE
Authenticate user upon the move command for an embargoed Dandiset

### DIFF
--- a/dandi/move.py
+++ b/dandi/move.py
@@ -801,6 +801,10 @@ def move(
     if dandiset is None:
         dandiset = Path()
     with ExitStack() as stack:
+        client = DandiAPIClient.for_dandi_instance(dandi_instance)
+        client.dandi_authenticate()
+        stack.enter_context(client)
+
         mover: Mover
         client: DandiAPIClient | None = None
         if work_on is MoveWorkOn.AUTO:
@@ -811,8 +815,6 @@ def move(
             if isinstance(dandiset, str):
                 raise TypeError("`dandiset` must be a Path when work_on='both'")
             local_ds, subpath = find_dandiset_and_subpath(dandiset)
-            client = DandiAPIClient.for_dandi_instance(dandi_instance)
-            stack.enter_context(client)
             remote_ds = client.get_dandiset(
                 local_ds.identifier, version_id="draft", lazy=False
             )
@@ -833,6 +835,7 @@ def move(
                 if not isinstance(url, DandisetURL):
                     raise ValueError("URL does not point to a Dandiset")
                 client = url.get_client()
+                client.dandi_authenticate()
                 stack.enter_context(client)
                 rds = url.get_dandiset(client, lazy=False)
                 assert rds is not None
@@ -840,8 +843,6 @@ def move(
                 subpath = Path()
             else:
                 local_ds, subpath = find_dandiset_and_subpath(dandiset)
-                client = DandiAPIClient.for_dandi_instance(dandi_instance)
-                stack.enter_context(client)
                 remote_ds = client.get_dandiset(
                     local_ds.identifier, version_id="draft", lazy=False
                 )


### PR DESCRIPTION
I received the error below when trying to rename an asset for an embargoed Dandiset.

Command
```
dandi move sub-mr261FZ/mr261FZ.tiff sub-mr261FZ/sub-mr261.tiff
```

Error
```
2024-08-08 17:08:52,143 [   ERROR] Error 401 while sending GET request to https://api.dandiarchive.org/api/dandisets/001089/: {"detail":"Authentication credentials were not provided."}
2024-08-08 17:08:52,144 [    INFO] Logs saved in /Users/kabilar/Library/Logs/dandi-cli/2024.08.08-22.08.51Z-13496.log
Error: Error 401 while sending GET request to https://api.dandiarchive.org/api/dandisets/001089/: {"detail":"Authentication credentials were not provided."}
```

We encountered the same error on the LINC project and @aaronkanzer provided a fix which I have submitted in this pull request.

- Original LINC issue: https://github.com/lincbrain/linc-cli/issues/41
- Original LINC fix: https://github.com/lincbrain/linc-cli/pull/42

I wasn't able to test these changes to the dandi-cli locally due to some versioneer issue.  So please double check this work.  Thank you.