### PR TITLE
Fix host used in minio URLs

### DIFF
--- a/dandi/tests/data/dandiarchive-docker/docker-compose.yml
+++ b/dandi/tests/data/dandiarchive-docker/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       DJANGO_MINIO_STORAGE_ENDPOINT: minio:9000
       DJANGO_MINIO_STORAGE_SECRET_KEY: minioSecretKey
       DJANGO_STORAGE_BUCKET_NAME: django-storage
-      DJANGO_MINIO_STORAGE_MEDIA_URL: http://localhost:9000/django-storage
+      DJANGO_MINIO_STORAGE_MEDIA_URL: http://127.0.0.1:9000/django-storage
       DJANGO_DANDI_SCHEMA_VERSION: ~
       DJANGO_DANDI_WEB_APP_URL: http://localhost:8085
       DJANGO_DANDI_API_URL: http://localhost:8000


### PR DESCRIPTION
Using `localhost` was causing test failures for me locally when fsspec was involved, likely due to `localhost` also resolving to `::1`, which the minio port was not exposed on.