### PR TITLE
ENH: organize - show files with conflicts requiring adding _obj-

### DIFF
--- a/dandi/organize.py
+++ b/dandi/organize.py
@@ -308,7 +308,7 @@ def _assign_obj_id(metadata, non_unique):
     # Avoid heavy import by importing within function:
     from .pynwb_utils import get_object_id
 
-    msg = "%d out of %d paths are not unique." % (len(non_unique), len(metadata))
+    msg = f"{len(non_unique)} out of {len(metadata)} paths are not unique."
     non_unique_paths = sorted(non_unique)
 
     # provide more information to the user
@@ -329,7 +329,7 @@ def _assign_obj_id(metadata, non_unique):
         else:
             for ex_path in non_unique_paths[1:]:
                 msg += "\n " + get_msg(ex_path)
-    lgr.info(msg + "\n We will try adding _obj- based on crc32 of object_id")
+    lgr.info("%s\n We will try adding _obj- based on crc32 of object_id", msg)
     seen_obj_ids = {}  # obj_id: object_id
     seen_object_ids = {}  # object_id: path
     recent_nwb_msg = "NWB>=2.1.0 standard (supported by pynwb>=1.1.0)."

--- a/dandi/organize.py
+++ b/dandi/organize.py
@@ -9,7 +9,6 @@ from collections import Counter
 from collections.abc import Sequence
 from copy import deepcopy
 from enum import Enum
-import logging
 import os
 import os.path as op
 from pathlib import Path, PurePosixPath
@@ -312,24 +311,22 @@ def _assign_obj_id(metadata, non_unique):
     non_unique_paths = sorted(non_unique)
 
     # provide more information to the user
-    def get_msg(path, indent="  "):
+    def get_msg(path):
         in_paths = non_unique[path]
-        return (
-            f"{len(in_paths)} paths 'compete' for the path {path!r}:"
-            + f"\n{indent}".join([""] + in_paths)
+        return f"{len(in_paths)} paths 'compete' for the path {path!r}:" + "\n  ".join(
+            [""] + in_paths
         )
 
     msg += "\n " + get_msg(non_unique_paths[0])
     if len(non_unique) > 1:
-        if not lgr.isEnabledFor(logging.DEBUG):
-            msg += (
-                " Rerun with logging at DEBUG level '-l debug' "
-                "to see {len(non_unique) - 1} more cases."
-            )
-        else:
-            for ex_path in non_unique_paths[1:]:
-                msg += "\n " + get_msg(ex_path)
-    lgr.info("%s\n We will try adding _obj- based on crc32 of object_id", msg)
+        msg += f"\n {len(non_unique) - 1} more case(s) are listed at DEBUG level."
+    lgr.info("%s", msg)
+    if len(non_unique) > 1:
+        msg = "Additional non-unique paths:"
+        for ex_path in non_unique_paths[1:]:
+            msg += "\n " + get_msg(ex_path)
+        lgr.debug("%s", msg)
+    lgr.info("We will try adding _obj- based on crc32 of object_id")
     seen_obj_ids = {}  # obj_id: object_id
     seen_object_ids = {}  # object_id: path
     recent_nwb_msg = "NWB>=2.1.0 standard (supported by pynwb>=1.1.0)."


### PR DESCRIPTION
Logging check is currently not really functioning since IIRC we do enable logging into a file at higher level than INFO. So we might need to tune decision making here

Should provide UX side to partially address:
- https://github.com/dandi/dandi-cli/issues/1489

example:

```
❯ dandi organize --dandiset-path /tmp/outds /home/yoh/proj/dandi/dandisets/000004/sub-P53CS/*nwb /home/yoh/proj/dandi/dandisets/000004/sub-P54CS/*nwb
...
2024-08-19 20:03:17,448 [    INFO] Symlink support autodetected; setting files_mode='symlink'
2024-08-19 20:03:17,452 [    INFO] 2 out of 5 paths are not unique.
 2 paths 'compete' for the path 'sub-P53CS/sub-P53CS_ses-20171101_ecephys+image.nwb':
  /home/yoh/proj/dandi/dandisets/000004/sub-P53CS/sub-P53CS_ses-20171101_obj-108aqix_ecephys+image.nwb
  /home/yoh/proj/dandi/dandisets/000004/sub-P53CS/sub-P53CS_ses-20171101_obj-lj04dr_ecephys+image.nwb
 3 paths 'compete' for the path 'sub-P54CS/sub-P54CS_ses-20180101_ecephys+image.nwb':
  /home/yoh/proj/dandi/dandisets/000004/sub-P54CS/sub-P54CS_ses-20180101_obj-1ru98u8_ecephys+image.nwb
  /home/yoh/proj/dandi/dandisets/000004/sub-P54CS/sub-P54CS_ses-20180101_obj-1ukzk61_ecephys+image.nwb
  /home/yoh/proj/dandi/dandisets/000004/sub-P54CS/sub-P54CS_ses-20180101_obj-1vx1a5w_ecephys+image.nwb
 We will try adding _obj- based on crc32 of object_id
```

TODOs
- [ ] check what leads to tests failing ATM
- [ ] extend test covering this code to have multiple groups requiring `_obj` 