### PR TITLE
Disallow hdmf 3.14.4, make organize to not parallelize for a single file, log information about all exceptions while reading metadata for organize

### DIFF
--- a/dandi/organize.py
+++ b/dandi/organize.py
@@ -859,7 +859,7 @@ def organize(
             return meta
 
         if (
-            not devel_debug and jobs != 1
+            not devel_debug and jobs != 1 and not len(paths) == 1
         ):  # Do not use joblib at all if number_of_jobs=1
             # Note: It is Python (pynwb) intensive, not IO, so ATM there is little
             # to no benefit from Parallel without using multiproc!  But that would

--- a/dandi/organize.py
+++ b/dandi/organize.py
@@ -856,8 +856,6 @@ def organize(
                     str(e),
                     traceback.TracebackException.from_exception(e),
                 )
-                # meta = {}
-                # lgr.debug("Failed to get metadata for %s: %s", path, exc)
             # pbar.update(1)
             meta["path"] = path
             return meta, exc
@@ -894,7 +892,7 @@ def organize(
                     "\n".join(e[-1].format()),
                 )
 
-    metadata, skip_invalid = filter_invalid_metadata_rows([m for m, e in metadata_excs])
+    metadata, skip_invalid = filter_invalid_metadata_rows([m for m, _ in metadata_excs])
     if skip_invalid:
         msg = (
             "%d out of %d files were found not containing all necessary "

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,8 @@ install_requires =
     etelemetry >= 0.2.2
     fasteners
     fscacher >= 0.3.0
-    hdmf != 3.5.0
+    # 3.14.4: https://github.com/hdmf-dev/hdmf/issues/1186
+    hdmf != 3.5.0,!=3.14.4
     humanize
     interleave ~= 0.1
     joblib


### PR DESCRIPTION
Individual commits have more information in their description.

Overall it 
- Fixes #1494 
- Improves logging of problems in organize while loading metadata

I have  bundled all the fixes etc so we could return back our CI to green (happen there is more to fix) and release!