### PR TITLE
Use "cache_spec:False" in our copy_nwb_file helper while exporting NWB copy

### DIFF
--- a/dandi/pynwb_utils.py
+++ b/dandi/pynwb_utils.py
@@ -524,7 +524,7 @@ def copy_nwb_file(src: str | Path, dest: str | Path) -> str:
             # do not export spec since
             **(
                 {"cache_spec": False}
-                if Version(pynwb.__version__) > Version("2.8.2.dev11")
+                if Version(pynwb.__version__) > Version("2.8.2")
                 else {}
             ),
         )

--- a/dandi/pynwb_utils.py
+++ b/dandi/pynwb_utils.py
@@ -518,7 +518,16 @@ def copy_nwb_file(src: str | Path, dest: str | Path) -> str:
     with pynwb.NWBHDF5IO(src, "r") as ior, pynwb.NWBHDF5IO(dest, "w") as iow:
         data = ior.read()
         data.generate_new_id()
-        iow.export(ior, nwbfile=data)
+        iow.export(
+            ior,
+            nwbfile=data,
+            # do not export spec since
+            **(
+                {"cache_spec": False}
+                if Version(pynwb.__version__) > Version("2.8.2.dev11")
+                else {}
+            ),
+        )
     return str(dest)
 
 

--- a/dandi/pynwb_utils.py
+++ b/dandi/pynwb_utils.py
@@ -515,18 +515,18 @@ def copy_nwb_file(src: str | Path, dest: str | Path) -> str:
         dest = op.join(dest, op.basename(src))
     else:
         os.makedirs(op.dirname(dest), exist_ok=True)
+    kws = {}
+    if Version(pynwb.__version__) >= Version("2.8.2"):
+        # we might make it leaner by not caching the spec if original
+        # file did not have it.  Possible only since 2.8.2.dev11
+        kws["cache_spec"] = bool(pynwb.NWBHDF5IO.get_namespaces(src))
     with pynwb.NWBHDF5IO(src, "r") as ior, pynwb.NWBHDF5IO(dest, "w") as iow:
         data = ior.read()
         data.generate_new_id()
         iow.export(
             ior,
             nwbfile=data,
-            # do not export spec since
-            **(
-                {"cache_spec": False}
-                if Version(pynwb.__version__) > Version("2.8.2")
-                else {}
-            ),
+            **kws,
         )
     return str(dest)
 


### PR DESCRIPTION
- [ ] Stopped since ideally we should make it dependent on either original file contains the spec.  Question posted 