### PR TITLE
Fixup URI scheme rendering in --help output

### DIFF
--- a/dandi/dandiarchive.py
+++ b/dandi/dandiarchive.py
@@ -704,7 +704,7 @@ class _dandi_url_parser:
  for a DANDI Archive instance.  If an optional ``version`` field is
  omitted from a URL, the given Dandiset's most recent published version
  will be used if it has one, and its draft version will be used otherwise.
-    """
+"""
     known_patterns = "Accepted resource identifier patterns:" + "\n - ".join(
         [""] + [display for _, _, display in known_urls]
     )

--- a/dandi/tests/test_helptext.py
+++ b/dandi/tests/test_helptext.py
@@ -2,8 +2,14 @@ import subprocess
 
 
 def get_helptext(command):
-    result = subprocess.run([*command, '--help'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    result = subprocess.run(
+        [*command, '--help'],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True
+    )
     return result.stdout
+
 
 def test_resource_identifier_helptext():
     # The \n chars must be included for correct rendering

--- a/dandi/tests/test_helptext.py
+++ b/dandi/tests/test_helptext.py
@@ -1,0 +1,16 @@
+import subprocess
+
+
+def get_helptext(command):
+    result = subprocess.run([*command, '--help'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    return result.stdout
+
+def test_resource_identifier_helptext():
+    # The \n chars must be included for correct rendering
+    correct = "Accepted resource identifier patterns:\n   - DANDI:<dandiset id>[/<version>]\n"
+
+    ls_helptext = get_helptext(['dandi', 'ls'])
+    assert correct in ls_helptext
+
+    download_helptext = get_helptext(['dandi', 'download'])
+    assert correct in download_helptext


### PR DESCRIPTION
Fixes https://github.com/dandi/dandi-cli/issues/1501

```
$ dandi ls --help

Usage: dandi ls [OPTIONS] PATH|URL

  List .nwb files and dandisets metadata.

  The arguments may be either resource identifiers or paths to local
  files/directories.

  RESOURCE ID/URLS:

   dandi commands accept URLs and URL-like identifiers called <resource  ids>
   in the following formats for identifying Dandisets, assets, and  asset
   collections.

   Text in [brackets] is optional.  A server field is a base API or GUI URL
   for a DANDI Archive instance.  If an optional ``version`` field is  omitted
   from a URL, the given Dandiset's most recent published version  will be
   used if it has one, and its draft version will be used otherwise.

  Accepted resource identifier patterns:
   - DANDI:<dandiset id>[/<version>]
   - https://gui.dandiarchive.org/...
   - https://identifiers.org/DANDI:<dandiset id>[/<version id>] (<version id> cannot be 'draft')
   - https://<server>[/api]/[#/]dandiset/<dandiset id>[/<version>][/files[?location=<path>]]
   - https://*dandiarchive-org.netlify.app/...
   - https://<server>[/api]/dandisets/<dandiset id>[/versions[/<version>]]
   - https://<server>[/api]/assets/<asset id>[/download]
   - https://<server>[/api]/dandisets/<dandiset id>/versions/<version>/assets/<asset id>[/download]
   - https://<server>[/api]/dandisets/<dandiset id>/versions/<version>/assets/?path=<path>
   - https://<server>[/api]/dandisets/<dandiset id>/versions/<version>/assets/?glob=<glob>
   - dandi://<instance name>/<dandiset id>[@<version>][/<path>]
   - https://<server>/...

Options:
  -F, --fields TEXT               Comma-separated list of fields to display.
                                  An empty value to trigger a list of
                                  available fields to be printed out
  -f, --format [auto|pyout|json|json_pp|json_lines|yaml]
                                  Choose the format/frontend for output. If
                                  'auto', 'pyout' will be used in case of
                                  multiple files, and 'yaml' for a single
                                  file.
  -r, --recursive                 Recurse into content of
                                  dandisets/directories. Only .nwb files will
                                  be considered.
  -J, --jobs INTEGER              Number of parallel download jobs.  [default:
                                  6]
  --metadata [api|all|assets]
  --schema VERSION                Convert metadata to new schema version
  --help                          Show this message and exit.

```

```
dandi download --help

Usage: dandi download [OPTIONS] [URL]...

  Download files or entire folders from DANDI.

  RESOURCE ID/URLS:

   dandi commands accept URLs and URL-like identifiers called <resource  ids>
   in the following formats for identifying Dandisets, assets, and  asset
   collections.

   Text in [brackets] is optional.  A server field is a base API or GUI URL
   for a DANDI Archive instance.  If an optional ``version`` field is  omitted
   from a URL, the given Dandiset's most recent published version  will be
   used if it has one, and its draft version will be used otherwise.

  Accepted resource identifier patterns:
   - DANDI:<dandiset id>[/<version>]
   - https://gui.dandiarchive.org/...
   - https://identifiers.org/DANDI:<dandiset id>[/<version id>] (<version id> cannot be 'draft')
   - https://<server>[/api]/[#/]dandiset/<dandiset id>[/<version>][/files[?location=<path>]]
   - https://*dandiarchive-org.netlify.app/...
   - https://<server>[/api]/dandisets/<dandiset id>[/versions[/<version>]]
   - https://<server>[/api]/assets/<asset id>[/download]
   - https://<server>[/api]/dandisets/<dandiset id>/versions/<version>/assets/<asset id>[/download]
   - https://<server>[/api]/dandisets/<dandiset id>/versions/<version>/assets/?path=<path>
   - https://<server>[/api]/dandisets/<dandiset id>/versions/<version>/assets/?glob=<glob>
   - dandi://<instance name>/<dandiset id>[@<version>][/<path>]
   - https://<server>/...

  EXAMPLES:

   - Download only the dandiset.yaml
     dandi download --download dandiset.yaml DANDI:000027
  
   - Download only dandiset.yaml if there is a newer version
     dandi download https://identifiers.org/DANDI:000027 --existing refresh
  
   - Download only the assets
     dandi download --download assets DANDI:000027
  
   - Download all from a specific version
     dandi download DANDI:000027/0.210831.2033
  
   - Download a specific directory
     dandi download dandi://DANDI/000027@0.210831.2033/sub-RAT123/
  
   - Download a specific file
     dandi download dandi://DANDI/000027@0.210831.2033/sub-RAT123/sub-RAT123.nwb

Options:
  -o, --output-dir DIRECTORY      Directory where to download to (directory
                        
  ...snip
```

- [x] TODO Add test