### PR TITLE
Bump test timeout to 330s

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ changedir = docs
 commands = sphinx-build -E -W -b html source build
 
 [pytest]
-addopts = --tb=short --durations=10 --timeout=300
+addopts = --tb=short --durations=10 --timeout=330
 markers =
     integration
     obolibrary


### PR DESCRIPTION
Python 3.12 tests were becoming flakey

Specifically: dandi/tests/test_metadata.py::test_nwb2asset_remote_asset - Failed: Timeout >300.0s