### PR TITLE
Switch to python 3.9 in dev-deps CI matrix run since dev deps are now beginning to drop Python 3.8 which is EOL soon

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
             python: 3.8
             mode: dandi-api
           - os: ubuntu-latest
-            python: 3.8
+            python: 3.9
             mode: dev-deps
           - os: ubuntu-latest
             python: 3.8


### PR DESCRIPTION
Fixes https://github.com/dandi/dandi-cli/issues/1503