### PR TITLE
Add ability to setup tmate debug session

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,13 @@ on:
   pull_request:
   schedule:
     - cron: '0 6 * * *'
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        type: boolean
+        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        required: false
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name }}
@@ -92,6 +99,10 @@ jobs:
     - name: Use scheduled test configuration
       if: github.event_name == 'schedule'
       run: echo PYTEST_ADDOPTS=--scheduled >> "$GITHUB_ENV"
+
+    - name: "(debug mode) Setup tmate session"
+      uses: mxschmitt/action-tmate@v3
+      if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
 
     - name: Run all tests
       if: matrix.mode != 'dandi-api'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,7 +102,7 @@ jobs:
 
     - name: "(debug mode) Setup tmate session"
       uses: mxschmitt/action-tmate@v3
-      if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+      if: ${{ (github.event_name == 'workflow_dispatch' && inputs.debug_enabled) || (env.ACTIONS_RUNNER_DEBUG == 'true') }}
 
     - name: Run all tests
       if: matrix.mode != 'dandi-api'


### PR DESCRIPTION
Current desire/need is to troubleshoot
   https://github.com/dandi/dandi-cli/pull/1499
but moreover -- Windows.  Not yet even sure if would work for windows but still -- would be good to have generally

May be later we should parametrize more, not for every debug run