### PR TITLE
download: more consistent and exhaustive logging, new `DANDI_DEVEL_AGGRESSIVE_RETRY` mode, respect (?) Retry-After

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -85,6 +85,10 @@ development command line options.
   function will patch `requests` to log the results of calls to
   `requests.utils.super_len()`
 
+- `DANDI_DOWNLOAD_AGGRESSIVE_RETRY` -- When set, would make `download()` retry
+  very aggressively - it would keep trying if at least some bytes are downloaded
+  on each attempt.  Typically is not needed and could be a sign of network issues.
+
 ## Sourcegraph
 
 The [Sourcegraph](https://sourcegraph.com) browser extension can be used to

--- a/dandi/cli/command.py
+++ b/dandi/cli/command.py
@@ -124,8 +124,9 @@ def main(ctx, log_level, pdb=False):
     )
 
     lgr.info(
-        "dandi %s, "
+        "python %s, dandi %s, "
         + ", ".join("%s %s" % (e, get_module_version(e)) for e in sorted(exts)),
+        sys.version.split()[0],
         __version__,
         extra={"file_only": True},
     )

--- a/dandi/cli/command.py
+++ b/dandi/cli/command.py
@@ -119,9 +119,11 @@ def main(ctx, log_level, pdb=False):
         "dandi v%s, dandischema v%s, hdmf v%s, pynwb v%s, h5py v%s",
         __version__,
         get_module_version("dandischema"),
+        get_module_version("h5py"),
         get_module_version("hdmf"),
         get_module_version("pynwb"),
-        get_module_version("h5py"),
+        get_module_version("requests"),
+        get_module_version("urllib3"),
         extra={"file_only": True},
     )
     lgr.info("sys.argv = %r", sys.argv, extra={"file_only": True})

--- a/dandi/cli/command.py
+++ b/dandi/cli/command.py
@@ -114,16 +114,19 @@ def main(ctx, log_level, pdb=False):
             lambda r: r.name != "pyout" and not r.name.startswith("pyout.")
         )
     root.addHandler(handler)
+    exts = (
+        "dandischema",
+        "h5py",
+        "hdmf",
+        "pynwb",
+        "requests",
+        "urllib3",
+    )
 
     lgr.info(
-        "dandi v%s, dandischema v%s, hdmf v%s, pynwb v%s, h5py v%s",
+        "dandi %s, "
+        + ", ".join("%s %s" % (e, get_module_version(e)) for e in sorted(exts)),
         __version__,
-        get_module_version("dandischema"),
-        get_module_version("h5py"),
-        get_module_version("hdmf"),
-        get_module_version("pynwb"),
-        get_module_version("requests"),
-        get_module_version("urllib3"),
         extra={"file_only": True},
     )
     lgr.info("sys.argv = %r", sys.argv, extra={"file_only": True})

--- a/dandi/dandiapi.py
+++ b/dandi/dandiapi.py
@@ -1592,10 +1592,23 @@ class BaseRemoteAsset(ABC, APIBase):
             # TODO: apparently we might need retries here as well etc
             # if result.status_code not in (200, 201):
             result.raise_for_status()
+            nbytes, nchunks = 0, 0
             for chunk in result.iter_content(chunk_size=chunk_size):
+                nchunks += 1
                 if chunk:  # could be some "keep alive"?
+                    nbytes += len(chunk)
                     yield chunk
-            lgr.info("Asset %s successfully downloaded", self.identifier)
+                else:
+                    lgr.debug("'Empty' chunk downloaded for %s", url)
+            lgr.info(
+                "Asset %s (%d bytes in %d chunks starting from %d) successfully "
+                "downloaded from %s",
+                self.identifier,
+                nbytes,
+                nchunks,
+                start_at,
+                url,
+            )
 
         return downloader
 

--- a/dandi/download.py
+++ b/dandi/download.py
@@ -750,7 +750,7 @@ def _download_file(
         # errors (among others) in addition to HTTP status errors.
         except requests.RequestException as exc:
             sleep_amount = random.random() * 5 * attempt
-            if os.environ.get("DANDI_DEVEL_AGGRESSIVE_RETRY"):
+            if os.environ.get("DANDI_DOWNLOAD_AGGRESSIVE_RETRY"):
                 # in such a case if we downloaded a little more --
                 # consider it a successful attempt
                 if downloaded_in_attempt > 0:

--- a/dandi/download.py
+++ b/dandi/download.py
@@ -867,10 +867,10 @@ class DownloadDirectory:
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> None:
+        assert self.fp is not None
         if exc_type is not None or exc_val is not None or exc_tb is not None:
             lgr.debug(
-                "%s - entered __exit__ with current position %d with exception: "
-                "%s, %s, %s",
+                "%s - entered __exit__ with position %d with exception: " "%s, %s, %s",
                 self.dirpath,
                 self.fp.tell(),
                 exc_type,
@@ -879,11 +879,10 @@ class DownloadDirectory:
             )
         else:
             lgr.debug(
-                "%s - entered __exit__ with current position %d without any exception",
+                "%s - entered __exit__ with position %d without any exception",
                 self.dirpath,
                 self.fp.tell(),
             )
-        assert self.fp is not None
         self.fp.close()
         try:
             if exc_type is None:

--- a/dandi/download.py
+++ b/dandi/download.py
@@ -870,12 +870,11 @@ class DownloadDirectory:
         assert self.fp is not None
         if exc_type is not None or exc_val is not None or exc_tb is not None:
             lgr.debug(
-                "%s - entered __exit__ with position %d with exception: " "%s, %s, %s",
+                "%s - entered __exit__ with position %d with exception: %s, %s",
                 self.dirpath,
                 self.fp.tell(),
                 exc_type,
                 exc_val,
-                exc_tb,
             )
         else:
             lgr.debug(

--- a/dandi/download.py
+++ b/dandi/download.py
@@ -844,7 +844,7 @@ class DownloadDirectory:
             # Delete the file (if it even exists) and start anew
             if not chkpath.exists():
                 lgr.debug(
-                    "%s - starting new download in new download directory", self.dirpath
+                    "%s - no prior digests found; starting new download", self.dirpath
                 )
             else:
                 lgr.debug(

--- a/dandi/download.py
+++ b/dandi/download.py
@@ -13,6 +13,7 @@ import os.path as op
 from pathlib import Path
 import random
 from shutil import rmtree
+import sys
 from threading import Lock
 import time
 from types import TracebackType
@@ -887,7 +888,12 @@ class DownloadDirectory:
             if exc_type is None:
                 try:
                     self.writefile.replace(self.filepath)
-                except IsADirectoryError:
+                except (IsADirectoryError, PermissionError) as exc:
+                    if isinstance(exc, PermissionError):
+                        if not (
+                            sys.platform.startswith("win") and self.filepath.is_dir()
+                        ):
+                            raise
                     lgr.debug(
                         "Destination path %s is a directory; removing it and retrying",
                         self.filepath,

--- a/dandi/tests/test_download.py
+++ b/dandi/tests/test_download.py
@@ -1044,6 +1044,7 @@ def test_pyouthelper_time_remaining_1339():
             assert done[-1] == f"ETA: {10 - i} seconds<"
 
 
+@mark.skipif_on_windows  # https://github.com/pytest-dev/pytest/issues/12964
 def test_DownloadDirectory_basic(tmp_path: Path) -> None:
     with DownloadDirectory(tmp_path, digests={}) as dl:
         assert dl.dirpath.exists()

--- a/dandi/tests/test_download.py
+++ b/dandi/tests/test_download.py
@@ -1058,9 +1058,14 @@ def test_DownloadDirectory_basic(tmp_path: Path) -> None:
         assert dl.offset == 0  # doesn't change
 
         dl.append(b"456")
+        inode_number = dl.writefile.stat().st_ino
+        assert inode_number != tmp_path.stat().st_ino
+
     # but after we are done - should be a full file!
     assert tmp_path.stat().st_size == 6
     assert tmp_path.read_bytes() == b"123456"
+    # we moved the file, didn't copy (expensive)
+    assert inode_number == tmp_path.stat().st_ino
 
     # no problem with overwriting with new content
     with DownloadDirectory(tmp_path, digests={}) as dl:

--- a/setup.cfg
+++ b/setup.cfg
@@ -78,7 +78,7 @@ include = dandi*
 extensions =
     allensdk
 extras =
-    duecredit
+    duecredit >= 0.6.0
     fsspec[http]
 style =
     flake8

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,8 @@ install_requires =
     ruamel.yaml >=0.15, <1
     semantic-version
     tenacity
+    # possibly silently incomplete downloads: https://github.com/dandi/dandi-cli/issues/1500
+    urllib3 >= 2.0.0
     yarl ~= 1.9
     zarr ~= 2.10
     zarr_checksum ~= 0.4.0


### PR DESCRIPTION
It was originally developed as part of the PR but derailed into fixing/robustifying download functionality. So sits on top of 
- #1499

TODOs
- [x] make sure testing passes (added test revealed some odd behavior on Windows)
-  ~~possibly fold in here~~ fixup for download to do full file checksumming if download was resumed: https://github.com/dandi/dandi-cli/issues/1528