### PR TITLE
Add xfail marks for some tests: test_nwb2asset_remote_asset, test_reextract_metadata, test_IteratorWithAggregation

### DIFF
--- a/dandi/cli/tests/test_service_scripts.py
+++ b/dandi/cli/tests/test_service_scripts.py
@@ -21,6 +21,10 @@ from ..cmd_service_scripts import service_scripts
 DATA_DIR = Path(__file__).with_name("data")
 
 
+@pytest.mark.xfail(
+    "nfsmount" in os.environ.get("TMPDIR", ""),
+    reason="https://github.com/dandi/dandi-cli/issues/1507",
+)
 def test_reextract_metadata(
     monkeypatch: pytest.MonkeyPatch, nwb_dandiset: SampleDandiset
 ) -> None:

--- a/dandi/support/tests/test_iterators.py
+++ b/dandi/support/tests/test_iterators.py
@@ -2,6 +2,8 @@ from time import sleep
 
 import pytest
 
+from dandi.utils import on_windows
+
 from ..iterators import IteratorWithAggregation
 
 
@@ -31,6 +33,7 @@ def sleeping_range(n, secs=0.01, thr=None):
             raise ValueError(i)
 
 
+@pytest.mark.xfail(on_windows, reason="https://github.com/dandi/dandi-cli/issues/1510")
 def test_IteratorWithAggregation():
     def sumup(v, t=0):
         return v + t

--- a/dandi/tests/test_metadata.py
+++ b/dandi/tests/test_metadata.py
@@ -883,6 +883,7 @@ def test_nwb2asset(simple2_nwb: Path) -> None:
     )
 
 
+@pytest.mark.xfail(reason="https://github.com/dandi/dandi-cli/issues/1450")
 def test_nwb2asset_remote_asset(nwb_dandiset: SampleDandiset) -> None:
     pytest.importorskip("fsspec")
     asset = nwb_dandiset.dandiset.get_asset_by_path("sub-mouse001/sub-mouse001.nwb")


### PR DESCRIPTION
Rationale: we need to bring CI into more stable operation and then see how to address them properly

TODOs
- [ ] constraint test_nwb2asset_remote_asset xfail only for timeout, otherwise way too wide