### PR TITLE
Enhance pynwb validation parsing to report the path within the file, fix pynwb typo

### DIFF
--- a/dandi/pynwb_utils.py
+++ b/dandi/pynwb_utils.py
@@ -360,18 +360,19 @@ def validate(path: str | Path, devel_debug: bool = False) -> list[ValidationResu
         else:  # Fallback if an older version
             with pynwb.NWBHDF5IO(path=path, mode="r", load_namespaces=True) as reader:
                 error_outputs = pynwb.validate(io=reader)
-        for error_output in error_outputs:
+        for error in error_outputs:
             errors.append(
                 ValidationResult(
                     origin=ValidationOrigin(
                         name="pynwb",
                         version=pynwb.__version__,
                     ),
-                    severity=Severity.WARNING,
-                    id=f"pywnb.{error_output}",
+                    severity=Severity.ERROR,
+                    id=f"pynwb.{error}",
                     scope=Scope.FILE,
                     path=Path(path),
-                    message="Failed to validate.",
+                    message=f"Failed to validate. {error.reason}",
+                    within_asset_paths={path: error.location},
                 )
             )
     except Exception as exc:
@@ -384,7 +385,7 @@ def validate(path: str | Path, devel_debug: bool = False) -> list[ValidationResu
                     version=pynwb.__version__,
                 ),
                 severity=Severity.ERROR,
-                id="pywnb.GENERIC",
+                id="pynwb.GENERIC",
                 scope=Scope.FILE,
                 path=Path(path),
                 message=f"{exc}",
@@ -416,7 +417,7 @@ def validate(path: str | Path, devel_debug: bool = False) -> list[ValidationResu
                             version=pynwb.__version__,
                         ),
                         severity=Severity.ERROR,
-                        id="pywnb.GENERIC",
+                        id="pynwb.GENERIC",
                         scope=Scope.FILE,
                         path=Path(path),
                         message=e,

--- a/dandi/tests/fixtures.py
+++ b/dandi/tests/fixtures.py
@@ -165,7 +165,7 @@ def simple4_nwb(tmp_path_factory: pytest.TempPathFactory) -> Path:
 def simple5_nwb(tmp_path_factory: pytest.TempPathFactory) -> Path:
     """
     With subject, subject_id, species, but including data orientation ambiguity, and missing
-    the `pywnb.Timeseries` `unit` attribute.
+    the `pynwb.Timeseries` `unit` attribute.
 
     Notes
     -----


### PR DESCRIPTION
re: https://github.com/con/validation/issues/1#issuecomment-2391975295

PyNWB reports a list of [HDMF validator Error objects](https://github.com/hdmf-dev/hdmf/blob/dev/src/hdmf/validate/errors.py#L19).

- Enhance pynwb validator output to report the path within the file and separate the reason (message) from the rest of the error.
- Fix typo "pywnb" -> "pynwb"