### PR TITLE
Overhauling validation results to get them closer to cover different types of validators

### DIFF
--- a/dandi/cli/tests/test_cmd_validate.py
+++ b/dandi/cli/tests/test_cmd_validate.py
@@ -6,7 +6,14 @@ import pytest
 
 from ..cmd_validate import _process_issues, validate
 from ...tests.fixtures import BIDS_ERROR_TESTDATA_SELECTION
-from ...validate_types import Scope, Severity, ValidationOrigin, ValidationResult
+from ...validate_types import (
+    Origin,
+    OriginType,
+    Scope,
+    Severity,
+    ValidationResult,
+    Validator,
+)
 
 
 @pytest.mark.parametrize("dataset", BIDS_ERROR_TESTDATA_SELECTION)
@@ -71,9 +78,10 @@ def test_process_issues(capsys):
     issues = [
         ValidationResult(
             id="NWBI.check_data_orientation",
-            origin=ValidationOrigin(
-                name="nwbinspector",
-                version="",
+            origin=Origin(
+                type=OriginType.VALIDATION,
+                validator=Validator.nwbinspector,
+                validator_version="",
             ),
             scope=Scope.FILE,
             message="Data may be in the wrong orientation.",
@@ -82,9 +90,10 @@ def test_process_issues(capsys):
         ),
         ValidationResult(
             id="NWBI.check_data_orientation",
-            origin=ValidationOrigin(
-                name="nwbinspector",
-                version="",
+            origin=Origin(
+                type=OriginType.VALIDATION,
+                validator=Validator.nwbinspector,
+                validator_version="",
             ),
             scope=Scope.FILE,
             message="Data may be in the wrong orientation.",
@@ -93,9 +102,10 @@ def test_process_issues(capsys):
         ),
         ValidationResult(
             id="NWBI.check_missing_unit",
-            origin=ValidationOrigin(
-                name="nwbinspector",
-                version="",
+            origin=Origin(
+                type=OriginType.VALIDATION,
+                validator=Validator.nwbinspector,
+                validator_version="",
             ),
             scope=Scope.FILE,
             message="Missing text for attribute 'unit'.",

--- a/dandi/cli/tests/test_cmd_validate.py
+++ b/dandi/cli/tests/test_cmd_validate.py
@@ -75,14 +75,16 @@ def test_validate_nwb_path_grouping(organized_nwb_dir4: Path) -> None:
 
 
 def test_process_issues(capsys):
+    origin_validation_nwbinspector = Origin(
+        type=OriginType.VALIDATION,
+        validator=Validator.nwbinspector,
+        validator_version="",
+    )
+
     issues = [
         ValidationResult(
             id="NWBI.check_data_orientation",
-            origin=Origin(
-                type=OriginType.VALIDATION,
-                validator=Validator.nwbinspector,
-                validator_version="",
-            ),
+            origin=origin_validation_nwbinspector,
             scope=Scope.FILE,
             message="Data may be in the wrong orientation.",
             path=Path("dir0/sub-mouse004/sub-mouse004.nwb"),
@@ -90,11 +92,7 @@ def test_process_issues(capsys):
         ),
         ValidationResult(
             id="NWBI.check_data_orientation",
-            origin=Origin(
-                type=OriginType.VALIDATION,
-                validator=Validator.nwbinspector,
-                validator_version="",
-            ),
+            origin=origin_validation_nwbinspector,
             scope=Scope.FILE,
             message="Data may be in the wrong orientation.",
             path=Path("dir1/sub-mouse001/sub-mouse001.nwb"),
@@ -102,11 +100,7 @@ def test_process_issues(capsys):
         ),
         ValidationResult(
             id="NWBI.check_missing_unit",
-            origin=Origin(
-                type=OriginType.VALIDATION,
-                validator=Validator.nwbinspector,
-                validator_version="",
-            ),
+            origin=origin_validation_nwbinspector,
             scope=Scope.FILE,
             message="Missing text for attribute 'unit'.",
             path=Path("dir1/sub-mouse001/sub-mouse001.nwb"),

--- a/dandi/files/bases.py
+++ b/dandi/files/bases.py
@@ -29,6 +29,8 @@ from dandi.metadata.core import get_default_metadata
 from dandi.misctypes import DUMMY_DANDI_ETAG, Digest, LocalReadableFile, P
 from dandi.utils import post_upload_size_check, pre_upload_size_check, yaml_load
 from dandi.validate_types import (
+    ORIGIN_INTERNAL_DANDI,
+    ORIGIN_VALIDATION_DANDI,
     Origin,
     OriginType,
     Scope,
@@ -210,11 +212,7 @@ class LocalAsset(DandiFile):
             )
             return [
                 ValidationResult(
-                    origin=Origin(
-                        type=OriginType.INTERNAL,
-                        validator=Validator.dandi,
-                        validator_version=dandi.__version__,
-                    ),
+                    origin=ORIGIN_INTERNAL_DANDI,
                     severity=Severity.ERROR,
                     id="dandi.SOFTWARE_ERROR",
                     scope=Scope.FILE,
@@ -537,7 +535,7 @@ class NWBAsset(LocalFileAsset):
         else:
             # make sure that we have some basic metadata fields we require
             try:
-                origin = Origin(
+                origin_validation_nwbinspector = Origin(
                     type=OriginType.VALIDATION,
                     validator=Validator.nwbinspector,
                     validator_version=str(_get_nwb_inspector_version()),
@@ -561,7 +559,7 @@ class NWBAsset(LocalFileAsset):
                         }
                     errors.append(
                         ValidationResult(
-                            origin=origin,
+                            origin=origin_validation_nwbinspector,
                             severity=severity,
                             id=f"NWBI.{error.check_function_name}",
                             scope=Scope.FILE,
@@ -707,11 +705,7 @@ def _check_required_fields(
             message = f"Required field {f!r} has no value"
             errors.append(
                 ValidationResult(
-                    origin=Origin(
-                        type=OriginType.VALIDATION,
-                        validator=Validator.dandi,
-                        validator_version=dandi.__version__,
-                    ),
+                    origin=ORIGIN_VALIDATION_DANDI,
                     severity=Severity.ERROR,
                     id="dandischema.requred_field",
                     scope=Scope.FILE,
@@ -723,11 +717,7 @@ def _check_required_fields(
             message = f"Required field {f!r} has value {v!r}"
             errors.append(
                 ValidationResult(
-                    origin=Origin(
-                        type=OriginType.VALIDATION,
-                        validator=Validator.dandi,
-                        validator_version=dandi.__version__,
-                    ),
+                    origin=ORIGIN_VALIDATION_DANDI,
                     severity=Severity.WARNING,
                     id="dandischema.placeholder_value",
                     scope=Scope.FILE,

--- a/dandi/files/bids.py
+++ b/dandi/files/bids.py
@@ -111,7 +111,7 @@ class BIDSDatasetDescriptionAsset(LocalFileAsset):
                         self._asset_metadata[bids_path] = prepare_metadata(
                             result.metadata
                         )
-                        self._bids_version = result.origin.bids_version
+                        self._bids_version = result.origin.standard_version
 
     def get_asset_errors(self, asset: BIDSAsset) -> list[ValidationResult]:
         """:meta private:"""

--- a/dandi/files/zarr.py
+++ b/dandi/files/zarr.py
@@ -17,7 +17,7 @@ from dandischema.models import BareAsset, DigestType
 import requests
 from zarr_checksum.tree import ZarrChecksumTree
 
-from dandi import __version__, get_logger
+from dandi import get_logger
 from dandi.consts import (
     MAX_ZARR_DEPTH,
     ZARR_DELETE_BATCH_SIZE,
@@ -43,6 +43,7 @@ from dandi.utils import (
 
 from .bases import LocalDirectoryAsset
 from ..validate_types import (
+    ORIGIN_VALIDATION_DANDI_ZARR,
     Origin,
     OriginType,
     Scope,
@@ -269,20 +270,12 @@ class ZarrAsset(LocalDirectoryAsset[LocalZarrEntry]):
             )
             data = None
 
-        origin_internal_zarr = Origin(
-            type=OriginType.VALIDATION,
-            validator=Validator.dandi_zarr,
-            validator_version=__version__,
-        )
-        if data is not None:
-            origin_internal_zarr.standard_version = get_zarr_format_version(data)
-
         if isinstance(data, zarr.Group) and not data:
             errors.append(
                 ValidationResult(
-                    origin=origin_internal_zarr,
+                    origin=ORIGIN_VALIDATION_DANDI_ZARR,
                     severity=Severity.ERROR,
-                    id="zarr.empty_group",
+                    id="dandi_zarr.empty_group",
                     scope=Scope.FILE,
                     path=self.filepath,
                     message="Zarr group is empty.",
@@ -294,9 +287,9 @@ class ZarrAsset(LocalDirectoryAsset[LocalZarrEntry]):
                 raise ValueError(msg)
             errors.append(
                 ValidationResult(
-                    origin=origin_internal_zarr,
+                    origin=ORIGIN_VALIDATION_DANDI_ZARR,
                     severity=Severity.ERROR,
-                    id="zarr.tree_depth_exceeded",
+                    id="dandi_zarr.tree_depth_exceeded",
                     scope=Scope.FILE,
                     path=self.filepath,
                     message=msg,

--- a/dandi/files/zarr.py
+++ b/dandi/files/zarr.py
@@ -244,7 +244,7 @@ class ZarrAsset(LocalDirectoryAsset[LocalZarrEntry]):
         import zarr
 
         errors: list[ValidationResult] = []
-        origin: Origin = Origin(
+        origin_internal_zarr: Origin = Origin(
             type=OriginType.INTERNAL,
             validator=Validator.zarr,
             validator_version=zarr.__version__,
@@ -258,7 +258,7 @@ class ZarrAsset(LocalDirectoryAsset[LocalZarrEntry]):
                 raise
             errors.append(
                 ValidationResult(
-                    origin=origin,
+                    origin=origin_internal_zarr,
                     severity=Severity.ERROR,
                     id="zarr.cannot_open",
                     scope=Scope.FILE,
@@ -269,18 +269,18 @@ class ZarrAsset(LocalDirectoryAsset[LocalZarrEntry]):
             )
             data = None
 
-        origin = Origin(
+        origin_internal_zarr = Origin(
             type=OriginType.VALIDATION,
             validator=Validator.dandi_zarr,
             validator_version=__version__,
         )
         if data is not None:
-            origin.standard_version = get_zarr_format_version(data)
+            origin_internal_zarr.standard_version = get_zarr_format_version(data)
 
         if isinstance(data, zarr.Group) and not data:
             errors.append(
                 ValidationResult(
-                    origin=origin,
+                    origin=origin_internal_zarr,
                     severity=Severity.ERROR,
                     id="zarr.empty_group",
                     scope=Scope.FILE,
@@ -294,7 +294,7 @@ class ZarrAsset(LocalDirectoryAsset[LocalZarrEntry]):
                 raise ValueError(msg)
             errors.append(
                 ValidationResult(
-                    origin=origin,
+                    origin=origin_internal_zarr,
                     severity=Severity.ERROR,
                     id="zarr.tree_depth_exceeded",
                     scope=Scope.FILE,

--- a/dandi/organize.py
+++ b/dandi/organize.py
@@ -18,7 +18,7 @@ import uuid
 
 import ruamel.yaml
 
-from . import __version__, get_logger
+from . import get_logger
 from .consts import dandi_layout_fields
 from .dandiset import Dandiset
 from .exceptions import OrganizeImpossibleError
@@ -36,13 +36,10 @@ from .utils import (
     yaml_load,
 )
 from .validate_types import (
-    Origin,
-    OriginType,
+    ORIGIN_VALIDATION_DANDI_LAYOUT,
     Scope,
     Severity,
-    Standard,
     ValidationResult,
-    Validator,
 )
 
 lgr = get_logger()
@@ -1127,12 +1124,7 @@ def validate_organized_path(
         errors.append(
             ValidationResult(
                 id="DANDI.NON_DANDI_FILENAME",
-                origin=Origin(
-                    type=OriginType.VALIDATION,
-                    validator=Validator.dandi,
-                    validator_version=__version__,
-                    standard=Standard.DANDI_LAYOUT,
-                ),
+                origin=ORIGIN_VALIDATION_DANDI_LAYOUT,
                 severity=Severity.ERROR,
                 scope=Scope.FILE,
                 path=filepath,
@@ -1148,12 +1140,7 @@ def validate_organized_path(
         errors.append(
             ValidationResult(
                 id="DANDI.NON_DANDI_FOLDERNAME",
-                origin=Origin(
-                    type=OriginType.VALIDATION,
-                    validator=Validator.dandi,
-                    validator_version=__version__,
-                    standard=Standard.DANDI_LAYOUT,
-                ),
+                origin=ORIGIN_VALIDATION_DANDI_LAYOUT,
                 severity=Severity.ERROR,
                 scope=Scope.FOLDER,
                 path=filepath,
@@ -1169,12 +1156,7 @@ def validate_organized_path(
             errors.append(
                 ValidationResult(
                     id="DANDI.METADATA_MISMATCH_SUBJECT",
-                    origin=Origin(
-                        type=OriginType.VALIDATION,
-                        validator=Validator.dandi,
-                        validator_version=__version__,
-                        standard=Standard.DANDI_LAYOUT,
-                    ),
+                    origin=ORIGIN_VALIDATION_DANDI_LAYOUT,
                     severity=Severity.ERROR,
                     scope=Scope.FILE,
                     path=filepath,

--- a/dandi/organize.py
+++ b/dandi/organize.py
@@ -35,7 +35,15 @@ from .utils import (
     move_file,
     yaml_load,
 )
-from .validate_types import Scope, Severity, ValidationOrigin, ValidationResult
+from .validate_types import (
+    Origin,
+    OriginType,
+    Scope,
+    Severity,
+    Standard,
+    ValidationResult,
+    Validator,
+)
 
 lgr = get_logger()
 
@@ -1119,7 +1127,12 @@ def validate_organized_path(
         errors.append(
             ValidationResult(
                 id="DANDI.NON_DANDI_FILENAME",
-                origin=ValidationOrigin(name="dandi", version=__version__),
+                origin=Origin(
+                    type=OriginType.VALIDATION,
+                    validator=Validator.dandi,
+                    validator_version=__version__,
+                    standard=Standard.DANDI_LAYOUT,
+                ),
                 severity=Severity.ERROR,
                 scope=Scope.FILE,
                 path=filepath,
@@ -1135,7 +1148,12 @@ def validate_organized_path(
         errors.append(
             ValidationResult(
                 id="DANDI.NON_DANDI_FOLDERNAME",
-                origin=ValidationOrigin(name="dandi", version=__version__),
+                origin=Origin(
+                    type=OriginType.VALIDATION,
+                    validator=Validator.dandi,
+                    validator_version=__version__,
+                    standard=Standard.DANDI_LAYOUT,
+                ),
                 severity=Severity.ERROR,
                 scope=Scope.FOLDER,
                 path=filepath,
@@ -1151,7 +1169,12 @@ def validate_organized_path(
             errors.append(
                 ValidationResult(
                     id="DANDI.METADATA_MISMATCH_SUBJECT",
-                    origin=ValidationOrigin(name="dandi", version=__version__),
+                    origin=Origin(
+                        type=OriginType.VALIDATION,
+                        validator=Validator.dandi,
+                        validator_version=__version__,
+                        standard=Standard.DANDI_LAYOUT,
+                    ),
                     severity=Severity.ERROR,
                     scope=Scope.FILE,
                     path=filepath,

--- a/dandi/pynwb_utils.py
+++ b/dandi/pynwb_utils.py
@@ -425,6 +425,25 @@ def validate(path: str | Path, devel_debug: bool = False) -> list[ValidationResu
         else:  # Fallback if an older version
             with pynwb.NWBHDF5IO(path=path, mode="r", load_namespaces=True) as reader:
                 error_outputs = pynwb.validate(io=reader)
+    except Exception as exc:
+        if devel_debug:
+            raise
+        errors.append(
+            ValidationResult(
+                origin=Origin(
+                    type=OriginType.INTERNAL,
+                    validator=Validator.pynwb,
+                    validator_version=pynwb.__version__,
+                ),
+                severity=Severity.ERROR,
+                id="pynwb.GENERIC",
+                scope=Scope.FILE,
+                origin_result=exc,
+                path=Path(path),
+                message=f"{exc}",
+            )
+        )
+    else:
         for error in error_outputs:
             errors.append(
                 ValidationResult(
@@ -444,24 +463,6 @@ def validate(path: str | Path, devel_debug: bool = False) -> list[ValidationResu
                     within_asset_paths={path: error.location},
                 )
             )
-    except Exception as exc:
-        if devel_debug:
-            raise
-        errors.append(
-            ValidationResult(
-                origin=Origin(
-                    type=OriginType.INTERNAL,
-                    validator=Validator.pynwb,
-                    validator_version=pynwb.__version__,
-                ),
-                severity=Severity.ERROR,
-                id="pynwb.GENERIC",
-                scope=Scope.FILE,
-                origin_result=exc,
-                path=Path(path),
-                message=f"{exc}",
-            )
-        )
 
     return errors
 

--- a/dandi/tests/test_files.py
+++ b/dandi/tests/test_files.py
@@ -530,7 +530,9 @@ def test_validate_deep_zarr(tmp_path: Path) -> None:
     zf = dandi_file(zarr_path)
     assert zf.get_validation_errors() == []
     mkpaths(zarr_path, "a/b/c/d/e/f/g/h.txt")
-    assert [e.id for e in zf.get_validation_errors()] == ["zarr.tree_depth_exceeded"]
+    assert [e.id for e in zf.get_validation_errors()] == [
+        "dandi_zarr.tree_depth_exceeded"
+    ]
 
 
 def test_validate_zarr_deep_via_excluded_dotfiles(tmp_path: Path) -> None:

--- a/dandi/tests/test_validate.py
+++ b/dandi/tests/test_validate.py
@@ -7,7 +7,15 @@ from .fixtures import BIDS_ERROR_TESTDATA_SELECTION, BIDS_TESTDATA_SELECTION
 from .. import __version__
 from ..consts import dandiset_metadata_file
 from ..validate import validate
-from ..validate_types import Scope, Severity, ValidationOrigin, ValidationResult
+from ..validate_types import (
+    Origin,
+    OriginType,
+    Scope,
+    Severity,
+    Standard,
+    ValidationResult,
+    Validator,
+)
 
 
 def test_validate_nwb_error(simple3_nwb: Path) -> None:
@@ -31,7 +39,12 @@ def test_validate_empty(tmp_path: Path) -> None:
     assert list(validate(tmp_path)) == [
         ValidationResult(
             id="DANDI.NO_DANDISET_FOUND",
-            origin=ValidationOrigin(name="dandi", version=__version__),
+            origin=Origin(
+                type=OriginType.VALIDATION,
+                validator=Validator.dandi,
+                validator_version=__version__,
+                standard=Standard.DANDI_LAYOUT,
+            ),
             severity=Severity.ERROR,
             scope=Scope.DANDISET,
             path=tmp_path,

--- a/dandi/utils.py
+++ b/dandi/utils.py
@@ -4,6 +4,7 @@ from bisect import bisect
 from collections.abc import Iterable, Iterator
 import datetime
 from email.utils import parsedate_to_datetime
+from enum import Enum
 from functools import lru_cache
 from importlib.metadata import version as importlib_version
 import inspect
@@ -953,3 +954,16 @@ def get_retry_after(response: requests.Response) -> Optional[int]:
                 sleep_amount,
             )
     return sleep_amount
+
+
+class StrEnum(str, Enum):
+    """
+    A variation of Enum that is also a subclass of str, akin to IntEnum
+
+    Member instances of a subclass of this class assigned to `auto()` will have their
+    own name as their value.
+    """
+
+    @staticmethod
+    def _generate_next_value_(name, _start, _count, _last_values):
+        return name

--- a/dandi/validate.py
+++ b/dandi/validate.py
@@ -4,11 +4,11 @@ from collections.abc import Iterator
 import os
 from pathlib import Path
 
-from . import __version__
 from .consts import dandiset_metadata_file
 from .files import find_dandi_files
 from .utils import find_parent_directory_containing
 from .validate_types import (
+    ORIGIN_VALIDATION_DANDI_LAYOUT,
     Origin,
     OriginType,
     Scope,
@@ -162,12 +162,7 @@ def validate(
         if dandiset_path is None:
             yield ValidationResult(
                 id="DANDI.NO_DANDISET_FOUND",
-                origin=Origin(
-                    type=OriginType.VALIDATION,
-                    validator=Validator.dandi,
-                    validator_version=__version__,
-                    standard=Standard.DANDI_LAYOUT,
-                ),
+                origin=ORIGIN_VALIDATION_DANDI_LAYOUT,
                 severity=Severity.ERROR,
                 scope=Scope.DANDISET,
                 path=Path(p),

--- a/dandi/validate.py
+++ b/dandi/validate.py
@@ -8,7 +8,15 @@ from . import __version__
 from .consts import dandiset_metadata_file
 from .files import find_dandi_files
 from .utils import find_parent_directory_containing
-from .validate_types import Scope, Severity, ValidationOrigin, ValidationResult
+from .validate_types import (
+    Origin,
+    OriginType,
+    Scope,
+    Severity,
+    Standard,
+    ValidationResult,
+    Validator,
+)
 
 BIDS_TO_DANDI = {
     "subject": "subject_id",
@@ -46,10 +54,12 @@ def validate_bids(
 
     validation_result = validate_bids_(paths, exclude_files=["dandiset.yaml"])
     our_validation_result = []
-    origin = ValidationOrigin(
-        name="bidsschematools",
-        version=bidsschematools.__version__,
-        bids_version=validation_result["bids_version"],
+    origin = Origin(
+        type=OriginType.VALIDATION,
+        validator=Validator.bidsschematools,
+        validator_version=bidsschematools.__version__,
+        standard=Standard.BIDS,
+        standard_version=validation_result["bids_version"],
     )
 
     # Storing variable to not re-compute set paths for each individual file.
@@ -73,6 +83,7 @@ def validate_bids(
                 severity=Severity.ERROR,
                 id="BIDS.NON_BIDS_PATH_PLACEHOLDER",
                 scope=Scope.FILE,
+                origin_result=validation_result,
                 path=Path(path),
                 message="File does not match any pattern known to BIDS.",
                 dataset_path=dataset_path,
@@ -92,6 +103,7 @@ def validate_bids(
                     severity=Severity.ERROR,
                     id="BIDS.MANDATORY_FILE_MISSING_PLACEHOLDER",
                     scope=Scope.DATASET,
+                    origin_result=validation_result,
                     path_regex=pattern["regex"],
                     message="BIDS-required file is not present.",
                 )
@@ -115,6 +127,7 @@ def validate_bids(
                 origin=origin,
                 id="BIDS.MATCH",
                 scope=Scope.FILE,
+                origin_result=validation_result,
                 path=Path(file_path),
                 metadata=meta,
                 dataset_path=dataset_path,
@@ -149,7 +162,12 @@ def validate(
         if dandiset_path is None:
             yield ValidationResult(
                 id="DANDI.NO_DANDISET_FOUND",
-                origin=ValidationOrigin(name="dandi", version=__version__),
+                origin=Origin(
+                    type=OriginType.VALIDATION,
+                    validator=Validator.dandi,
+                    validator_version=__version__,
+                    standard=Standard.DANDI_LAYOUT,
+                ),
                 severity=Severity.ERROR,
                 scope=Scope.DANDISET,
                 path=Path(p),

--- a/dandi/validate_types.py
+++ b/dandi/validate_types.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+import dandi
 from dandi.utils import StrEnum
 
 
@@ -72,6 +73,25 @@ class Origin(BaseModel):
 
     standard_version: str | None = None
     """Version of the standard"""
+
+
+# Some commonly used `Origin` instances
+ORIGIN_VALIDATION_DANDI = Origin(
+    type=OriginType.VALIDATION,
+    validator=Validator.dandi,
+    validator_version=dandi.__version__,
+)
+ORIGIN_VALIDATION_DANDI_LAYOUT = Origin(
+    type=OriginType.VALIDATION,
+    validator=Validator.dandi,
+    validator_version=dandi.__version__,
+    standard=Standard.DANDI_LAYOUT,
+)
+ORIGIN_INTERNAL_DANDI = Origin(
+    type=OriginType.INTERNAL,
+    validator=Validator.dandi,
+    validator_version=dandi.__version__,
+)
 
 
 class Severity(IntEnum):

--- a/dandi/validate_types.py
+++ b/dandi/validate_types.py
@@ -87,6 +87,11 @@ ORIGIN_VALIDATION_DANDI_LAYOUT = Origin(
     validator_version=dandi.__version__,
     standard=Standard.DANDI_LAYOUT,
 )
+ORIGIN_VALIDATION_DANDI_ZARR = Origin(
+    type=OriginType.VALIDATION,
+    validator=Validator.dandi_zarr,
+    validator_version=dandi.__version__,
+)
 ORIGIN_INTERNAL_DANDI = Origin(
     type=OriginType.INTERNAL,
     validator=Validator.dandi,

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,8 @@ install_requires =
     click-didyoumean
     dandischema >= 0.11.0, < 0.12.0
     etelemetry >= 0.2.2
+    # For pydantic to be able to use type annotations like `X | None`
+    eval_type_backport;  python_version < "3.10"
     fasteners
     fscacher >= 0.3.0
     # 3.14.4: https://github.com/hdmf-dev/hdmf/issues/1186


### PR DESCRIPTION
Ref:
- https://github.com/con/validation/issues/1

and result of our chat with @candleindark while also reviewing results of linkml validation over dandisets:
- https://github.com/dandi/dandisets-linkml-status/blob/temp-with-error-locations/dandi-reports/summary.md

Notes/TODOs:
- BREAKING CHANGE: 
   - we replaced `ValidationOrigin.bids_version` to more generic `Origin.standard` + `Origin.standard_version`
   - We renamed `ValidationOrigin.name` to `Origin.validator` and `ValidationOrigin.version` to `Origin.validator_version`
   - `Severity.HINT`, `Severity.WARNING`, and `Severity.ERROR` now have value of `20`, `30`, and `40` respectively instead of `1`, `2`, and `3`.
   - Introduce `Origin.type` to indicate the type of the origin of a validation result.
   - We made the `ValidationResult` model into a Pydantic model so that it is readily to serialization to JSON.
- [x] going through the code base and harmonizing construction of those ValidationResults
- [ ] ~~redo #1176 in here~~

Please see individual commit messages for more details of the change.

**Note**:
This PR needs the changes in #1601 to pass the tests. Rebase/merge with master once #1601 is merged into master.