### PR TITLE
fix: replace dandi-api link with dandi-archive

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -34,12 +34,12 @@ you can also run `tox` with `lint` and `typing`:
 tox -e lint,typing
 ```
 
-### dandi-api instance
+### dandi-archive instance
 
-The [dandi-api](https://github.com/dandi/dandi-api) repository provides a
-docker-compose recipe for establishing a local instance of a fresh dandi-api.
+The [dandi-archive](https://github.com/dandi/dandi-archive) repository provides a
+docker-compose recipe for establishing a local instance of a fresh dandi-archive.
 See
-[README.md:Docker](https://github.com/dandi/dandi-api#develop-with-docker-recommended-quickstart)
+[DEVELOPMENT.md:Docker](https://github.com/dandi/dandi-archive/blob/master/DEVELOPMENT.md#develop-with-docker-recommended-quickstart)
 for the instructions.  In a new instance, you would need to generate a new API
 key to be used by the `dandi` client for upload etc.
 


### PR DESCRIPTION
dandi-api does forward to dandi-archive, but still nice to have correct