### PR TITLE
Include LINC API as a supported instance type for DANDI CLI

### DIFF
--- a/dandi/cli/tests/test_instances.py
+++ b/dandi/cli/tests/test_instances.py
@@ -19,4 +19,10 @@ def test_cmd_instances(monkeypatch):
         "dandi-staging:\n"
         "  api: https://api-staging.dandiarchive.org/api\n"
         "  gui: https://gui-staging.dandiarchive.org\n"
+        "linc:\n"
+        "  api: https://api.lincbrain.org/api\n"
+        "  gui: https://lincbrain.org\n"
+        "linc-staging:\n"
+        "  api: https://staging-api.lincbrain.org/api\n"
+        "  gui: https://staging.lincbrain.org\n"
     )

--- a/dandi/consts.py
+++ b/dandi/consts.py
@@ -132,6 +132,16 @@ known_instances = {
         f"http://{instancehost}:8085",
         f"http://{instancehost}:8000/api",
     ),
+    "linc": DandiInstance(
+        "linc",
+        "https://lincbrain.org",
+        "https://api.lincbrain.org/api",
+    ),
+    "linc-staging": DandiInstance(
+        "linc-staging",
+        "https://staging.lincbrain.org",
+        "https://staging-api.lincbrain.org/api",
+    )
 }
 # to map back url: name
 known_instances_rev = {

--- a/dandi/tests/test_dandiarchive.py
+++ b/dandi/tests/test_dandiarchive.py
@@ -439,10 +439,11 @@ def test_known_instances() -> None:
 def test_parse_dandi_url_unknown_instance() -> None:
     with pytest.raises(UnknownURLError) as excinfo:
         parse_dandi_url("dandi://not-an-instance/000001")
-    assert str(excinfo.value) == (
-        "Unknown instance 'not-an-instance'.  Valid instances: dandi,"
-        " dandi-api-local-docker-tests, dandi-staging"
-    )
+
+    valid_instances = ", ".join(sorted(known_instances.keys()))
+    expected_message = f"Unknown instance 'not-an-instance'.  Valid instances: {valid_instances}"
+
+    assert str(excinfo.value) == expected_message
 
 
 @mark.skipif_no_network

--- a/dandi/utils.py
+++ b/dandi/utils.py
@@ -604,19 +604,19 @@ def _get_instance(
                 f"Could not retrieve server info from {url},"
                 " and client does not recognize URL"
             )
-    # try:
-    #     minversion = Version(server_info.cli_minimal_version)
-    #     bad_versions = [Version(v) for v in server_info.cli_bad_versions]
-    # except ValueError as e:
-    #     raise ValueError(
-    #         f"{url} returned an incorrectly formatted version;"
-    #         f" please contact that server's administrators: {e}"
-    #     )
-    # our_version = Version(__version__)
-    # if our_version < minversion:
-    #     raise CliVersionTooOldError(our_version, minversion, bad_versions)
-    # if our_version in bad_versions:
-    #     raise BadCliVersionError(our_version, minversion, bad_versions)
+    try:
+        minversion = Version(server_info.cli_minimal_version)
+        bad_versions = [Version(v) for v in server_info.cli_bad_versions]
+    except ValueError as e:
+        raise ValueError(
+            f"{url} returned an incorrectly formatted version;"
+            f" please contact that server's administrators: {e}"
+        )
+    our_version = Version(__version__)
+    if our_version < minversion:
+        raise CliVersionTooOldError(our_version, minversion, bad_versions)
+    if our_version in bad_versions:
+        raise BadCliVersionError(our_version, minversion, bad_versions)
     api_url = server_info.services.api.url
     if dandi_id is None:
         # Don't use pydantic.AnyHttpUrl, as that sets the `port` attribute even
@@ -642,7 +642,7 @@ def _get_instance(
 
 
 def is_url(s: str) -> bool:
-    """Very primitive url detection
+    """Very primitive url detection for now
 
     TODO: redo
     """

--- a/dandi/utils.py
+++ b/dandi/utils.py
@@ -604,19 +604,19 @@ def _get_instance(
                 f"Could not retrieve server info from {url},"
                 " and client does not recognize URL"
             )
-    try:
-        minversion = Version(server_info.cli_minimal_version)
-        bad_versions = [Version(v) for v in server_info.cli_bad_versions]
-    except ValueError as e:
-        raise ValueError(
-            f"{url} returned an incorrectly formatted version;"
-            f" please contact that server's administrators: {e}"
-        )
-    our_version = Version(__version__)
-    if our_version < minversion:
-        raise CliVersionTooOldError(our_version, minversion, bad_versions)
-    if our_version in bad_versions:
-        raise BadCliVersionError(our_version, minversion, bad_versions)
+    # try:
+    #     minversion = Version(server_info.cli_minimal_version)
+    #     bad_versions = [Version(v) for v in server_info.cli_bad_versions]
+    # except ValueError as e:
+    #     raise ValueError(
+    #         f"{url} returned an incorrectly formatted version;"
+    #         f" please contact that server's administrators: {e}"
+    #     )
+    # our_version = Version(__version__)
+    # if our_version < minversion:
+    #     raise CliVersionTooOldError(our_version, minversion, bad_versions)
+    # if our_version in bad_versions:
+    #     raise BadCliVersionError(our_version, minversion, bad_versions)
     api_url = server_info.services.api.url
     if dandi_id is None:
         # Don't use pydantic.AnyHttpUrl, as that sets the `port` attribute even
@@ -642,7 +642,7 @@ def _get_instance(
 
 
 def is_url(s: str) -> bool:
-    """Very primitive url detection for now
+    """Very primitive url detection
 
     TODO: redo
     """

--- a/docs/source/cmdline/instances.rst
+++ b/docs/source/cmdline/instances.rst
@@ -22,3 +22,9 @@ Example output:
     dandi-staging:
       api: https://api-staging.dandiarchive.org/api
       gui: https://gui-staging.dandiarchive.org
+    linc-staging:
+      api: https://staging-api.lincbrain.org/api
+      gui: https://staging.lincbrain.org
+    linc:
+      api: https://api.lincbrain.org/api
+      gui: https://lincbrain.org


### PR DESCRIPTION
Relates to https://github.com/dandi/dandi-cli/issues/1517
Follow-up of https://github.com/dandi/dandi-cli/pull/1519 -- used a different fork since tags were not copied over in the prior fork in https://github.com/dandi/dandi-cli/pull/1519

Cc @kabilar 

Steps to properly test:

1. `pip uninstall dandi -y` to remove DANDI CLI locally (can use a `venv` too if desired)
2. `pip install -e git+https://github.com/lincbrain/dandi-cli.git@ak-linc#egg=dandi` -- reference my forked branch here as the `dandi` CLI version
3. Made a Dandiset on LINC: https://lincbrain.org/dandiset/000045
4. Run `dandi download https://lincbrain.org/dandiset/000045/draft` -- the CLI should prompt for an API value here
5. I copied over an NWB into the `000045` folder
6. Run  `dandi upload -i linc`
7. Observe files present in https://lincbrain.org/dandiset/000045/draft/files?location=

Prior to running any steps, I ran `dandi instances` to see that the proper values were listed

@jwodder @yarikoptic -- mind a brief re-review here?

I _think_ we should be fine here -- it seems that sometimes the CI tests for Ubuntu can be flaky -- you'd know better than I if this is a common issue over time -- I know sometimes GitHub runners can be unpredictable with longer, parallel jobs