### PR TITLE
tests: update tests docker-compose with few changes from dandi-archive

### DIFF
--- a/dandi/tests/data/dandiarchive-docker/docker-compose.yml
+++ b/dandi/tests/data/dandiarchive-docker/docker-compose.yml
@@ -69,15 +69,15 @@ services:
       DJANGO_DANDI_VALIDATION_JOB_INTERVAL: "5"
 
   minio:
-    image: minio/minio:RELEASE.2022-04-12T06-55-35Z
+    image: minio/minio:latest
     # When run with a TTY, minio prints credentials on startup
     tty: true
     command: ["server", "/data"]
     ports:
       - "127.0.0.1:9000:9000"
     environment:
-      MINIO_ACCESS_KEY: minioAccessKey
-      MINIO_SECRET_KEY: minioSecretKey
+      MINIO_ROOT_USER: minioAccessKey
+      MINIO_ROOT_PASSWORD: minioSecretKey
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
       interval: 7s
@@ -89,6 +89,7 @@ services:
       POSTGRES_DB: django
       POSTGRES_PASSWORD: postgres
     image: postgres
+    command: postgres -c log_lock_waits=on -c log_min_duration_statement=100
     expose:
       - "5432"
     healthcheck:


### PR DESCRIPTION
- 855845303901bd17a53d6c784c6cc5e5c2b1e1e9 
  Wed Dec 21 16:49:05 2022 -0500 
  Add more detailed logging to development postgres
- b3ba0e8ab15a54b6d592a84d5c155c3ed6ee0390
  Mon Oct 3 18:30:30 2022 -0400
  Unpin minio docker image and update env vars

Unfortunately it does not resolve
- https://github.com/dandi/dandi-cli/issues/1488

for me but IMHO the right thing to do.