### PR TITLE
add one photon to metadata dict

### DIFF
--- a/dandi/metadata/util.py
+++ b/dandi/metadata/util.py
@@ -716,6 +716,12 @@ neurodata_typemap: dict[str, Neurodatum] = {
         "technique": "two-photon microscopy technique",
         "approach": "microscopy approach; cell population imaging",
     },
+    "OnePhotonSeries": {
+        "module": "ophys",
+        "neurodata_type": "OnePhotonSeries",
+        "technique": "one-photon microscopy technique",
+        "approach": "microscopy approach; cell population imaging",
+    },
     "OpticalChannel": {
         "module": "ophys",
         "neurodata_type": "OpticalChannel",


### PR DESCRIPTION
OnePhotonSeries is a newer data type, which is why it was not included in the original list