### PR TITLE
Specify custom ulimit on nofiles to prevent infinite loop by billiard

### DIFF
--- a/dandi/tests/data/dandiarchive-docker/docker-compose.yml
+++ b/dandi/tests/data/dandiarchive-docker/docker-compose.yml
@@ -67,6 +67,11 @@ services:
     environment:
       << : *django_env
       DJANGO_DANDI_VALIDATION_JOB_INTERVAL: "5"
+    ulimits:
+      # https://github.com/celery/billiard/pull/417
+      nofile:
+        soft: 1000
+        hard: 3000
 
   minio:
     image: minio/minio:RELEASE.2022-04-12T06-55-35Z


### PR DESCRIPTION
Closes: https://github.com/dandi/dandi-cli/issues/1488

See: https://github.com/celery/billiard/pull/417

@asmacdo please verify that it resolves the issue for you too

TODOs
- after accepted here, we better propose similar one against dandi-archive's compose recipes. In all likeliness situation would be similar there.