### PR TITLE
Audit warning filter

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,8 @@ markers =
     obolibrary
 filterwarnings =
     error
+    # dandi/tests/test_pynwb_utils.py::test_nwb_has_external_links
+    ignore:.*Value with data type .* is being converted:hdmf.build.warnings.DtypeConversionWarning
 
 [coverage:run]
 parallel = True

--- a/tox.ini
+++ b/tox.ini
@@ -48,28 +48,6 @@ markers =
     obolibrary
 filterwarnings =
     error
-    ignore:No cached namespaces found .*:UserWarning
-    ignore:ignoring namespace '.*' because it already exists:UserWarning
-    ignore::DeprecationWarning:responses
-    ignore::DeprecationWarning:requests_toolbelt
-    # <https://github.com/h5py/h5py/issues/1765>
-    # <https://github.com/dandi/dandi-cli/pull/275>
-    ignore:.* size changed, may indicate binary incompatibility.*:RuntimeWarning
-    # <https://github.com/hdmf-dev/hdmf/issues/547>
-    ignore:\s*safe_load will be removed.*:PendingDeprecationWarning:hdmf
-    ignore:\s*load will be removed.*:PendingDeprecationWarning:ruamel.yaml
-    ignore:Passing None into shape arguments.*:DeprecationWarning:h5py
-    ignore:the imp module is deprecated:DeprecationWarning
-    ignore:`Unit` has been deprecated:DeprecationWarning:humanize
-    ignore:The distutils package is deprecated:DeprecationWarning:joblib
-    ignore:datetime.datetime.utcfromtimestamp\(\) is deprecated.*:DeprecationWarning:dateutil
-    ignore:\s*Pyarrow will become a required dependency of pandas:DeprecationWarning
-    ignore:.*Value with data type .* is being converted:hdmf.build.warnings.DtypeConversionWarning
-    ignore:.*find_spec\(\) not found:ImportWarning
-    ignore:'cgi' is deprecated:DeprecationWarning:botocore
-    ignore:.*unclosed.*:ResourceWarning:vcr
-    # addressed in joblib 0.8.2-826-g05caf07
-    ignore:(ast.Num|Attribute n) is deprecated.*:DeprecationWarning:joblib
 
 [coverage:run]
 parallel = True


### PR DESCRIPTION
I've tested locally with python 3.9 and 3.12. 

I ran the tests with `tox -e 39` and `tox -e 312`.  Since this was sufficient for both, I figure lets let the automation run to see where we are-- I'm surprised that we dont need more filters tbh.

FWIW, there were ~20 warnings when I was testing without the `error` in filterwarnings. I was quite surprised that adding this in removed all but 1 of those warnings (the one filtered here). (I had expected that those warnings would be promoted to errors). 

<details><summary>Warnings without `filterwarnings == error`</summary>

============================================================ warnings summary =============================================================
dandi/tests/test_download.py::test_DownloadDirectory_basic
dandi/tests/test_download.py::test_DownloadDirectory_basic
  /usr/lib64/python3.12/multiprocessing/popen_fork.py:66: DeprecationWarning: This process (pid=753514) is multi-threaded, use of fork() may lead to deadlocks in the child.
    self.pid = os.fork()

dandi/tests/test_fixtures.py: 20 warnings
dandi/tests/test_organize.py: 20 warnings
  /home/austin/devel/dandi-cli/.tox/py3/lib/python3.12/site-packages/joblib/externals/loky/backend/fork_exec.py:38: DeprecationWarning: This process (pid=753514) is multi-threaded, use of fork() may lead to deadlocks in the child.
    pid = os.fork()

dandi/tests/test_organize.py::test_organize_nwb_test_data[1-dry]
dandi/tests/test_organize.py::test_organize_nwb_test_data[1-dry]
  /home/austin/devel/dandi-cli/.tox/py3/lib/python3.12/site-packages/pynwb/ecephys.py:223: DeprecationWarning: use pynwb.misc.Units or NWBFile.units instead
    warnings.warn("use pynwb.misc.Units or NWBFile.units instead", DeprecationWarning)

dandi/tests/test_organize.py::test_organize_nwb_test_data[1-dry]
  /home/austin/devel/dandi-cli/.tox/py3/lib/python3.12/site-packages/pynwb/ecephys.py:257: DeprecationWarning: use pynwb.misc.Units or NWBFile.units instead
    warnings.warn("use pynwb.misc.Units or NWBFile.units instead", DeprecationWarning)

dandi/tests/test_organize.py::test_organize_nwb_test_data[1-dry]
  /home/austin/devel/dandi-cli/.tox/py3/lib/python3.12/site-packages/pynwb/icephys.py:22: UserWarning: Unit 'A' for CurrentClampSeries 'ccs' is ignored and will be set to 'volts' as per NWB 2.1.0.
    warnings.warn(

dandi/tests/test_organize.py::test_organize_nwb_test_data[1-dry]
  /home/austin/devel/dandi-cli/.tox/py3/lib/python3.12/site-packages/pynwb/icephys.py:22: UserWarning: Unit 'A' for CurrentClampStimulusSeries 'ccss' is ignored and will be set to 'amperes' as per NWB 2.1.0.
    warnings.warn(

dandi/tests/test_organize.py::test_organize_nwb_test_data[1-dry]
  /home/austin/devel/dandi-cli/.tox/py3/lib/python3.12/site-packages/pynwb/icephys.py:226: UserWarning: Stimulus description 'NA' for IZeroClampSeries 'izcs' is ignored and will be set to 'N/A' as per NWB 2.3.0.
    warnings.warn(

dandi/tests/test_organize.py::test_organize_nwb_test_data[1-dry]
  /home/austin/devel/dandi-cli/.tox/py3/lib/python3.12/site-packages/pynwb/icephys.py:22: UserWarning: Unit 'A' for IZeroClampSeries 'izcs' is ignored and will be set to 'volts' as per NWB 2.1.0.
    warnings.warn(

dandi/tests/test_organize.py::test_organize_nwb_test_data[1-dry]
dandi/tests/test_organize.py::test_organize_nwb_test_data[1-dry]
  /home/austin/devel/dandi-cli/.tox/py3/lib/python3.12/site-packages/pynwb/icephys.py:341: DeprecationWarning: Use of SweepTable is deprecated. Use the IntracellularRecordingsTable instead. See also the  NWBFile.add_intracellular_recordings function.
    warnings.warn("Use of SweepTable is deprecated. Use the IntracellularRecordingsTable "

dandi/tests/test_organize.py::test_organize_nwb_test_data[1-dry]
dandi/tests/test_organize.py::test_organize_nwb_test_data[1-dry]
  /home/austin/devel/dandi-cli/.tox/py3/lib/python3.12/site-packages/pynwb/ophys.py:116: DeprecationWarning: The 'manifold' argument is deprecated in favor of 'origin_coords' and 'grid_spacing'.
    warnings.warn("The 'manifold' argument is deprecated in favor of 'origin_coords' and 'grid_spacing'.",

dandi/tests/test_organize.py::test_organize_nwb_test_data[1-dry]
dandi/tests/test_organize.py::test_organize_nwb_test_data[1-dry]
  /home/austin/devel/dandi-cli/.tox/py3/lib/python3.12/site-packages/pynwb/ophys.py:119: DeprecationWarning: The 'conversion' argument is deprecated in favor of 'origin_coords' and 'grid_spacing'.
    warnings.warn("The 'conversion' argument is deprecated in favor of 'origin_coords' and 'grid_spacing'.",

dandi/tests/test_organize.py::test_organize_nwb_test_data[1-dry]
dandi/tests/test_organize.py::test_organize_nwb_test_data[1-dry]
  /home/austin/devel/dandi-cli/.tox/py3/lib/python3.12/site-packages/pynwb/ophys.py:122: DeprecationWarning: The 'unit' argument is deprecated in favor of 'origin_coords_unit' and 'grid_spacing_unit'.
    warnings.warn("The 'unit' argument is deprecated in favor of 'origin_coords_unit' and 'grid_spacing_unit'.",

dandi/tests/test_organize.py::test_organize_nwb_test_data[1-dry]
  /home/austin/devel/dandi-cli/.tox/py3/lib/python3.12/site-packages/pynwb/core.py:48: UserWarning: ImageSeries 'test_iS': The number of frame indices in 'starting_frame' should have the same length as 'external_file'.
    warn(error_msg)

dandi/tests/test_organize.py::test_organize_nwb_test_data[1-dry]
  /home/austin/devel/dandi-cli/.tox/py3/lib/python3.12/site-packages/pynwb/core.py:48: UserWarning: ImageSeries 'test_iS': Format must be 'external' when external_file is specified.
    warn(error_msg)

dandi/tests/test_organize.py::test_organize_nwb_test_data[1-dry]
  /home/austin/devel/dandi-cli/.tox/py3/lib/python3.12/site-packages/pynwb/image.py:106: UserWarning: TwoPhotonSeries 'test_2ps': Length of data does not match length of timestamps. Your data may be transposed. Time should be on the 0th dimension
    warnings.warn(

dandi/tests/test_organize.py::test_organize_nwb_test_data[1-dry]
  /home/austin/devel/dandi-cli/.tox/py3/lib/python3.12/site-packages/pynwb/icephys.py:22: UserWarning: Unit 'A' for VoltageClampSeries 'vcs' is ignored and will be set to 'amperes' as per NWB 2.1.0.
    warnings.warn(

dandi/tests/test_organize.py::test_organize_nwb_test_data[1-dry]
  /home/austin/devel/dandi-cli/.tox/py3/lib/python3.12/site-packages/pynwb/icephys.py:22: UserWarning: Unit 'A' for VoltageClampStimulusSeries 'vcss' is ignored and will be set to 'volts' as per NWB 2.1.0.
    warnings.warn(

dandi/tests/test_pynwb_utils.py::test_nwb_has_external_links
  /home/austin/devel/dandi-cli/.tox/py3/lib/python3.12/site-packages/hdmf/build/objectmapper.py:264: DtypeConversionWarning: Spec 'TimeSeries/timestamps': Value with data type int64 is being converted to data type float64 as specified.
    warnings.warn(full_warning_msg, DtypeConversionWarning)

</details>