### PR TITLE
Remove `NotImplementedError` to allow for uploading Zarr assets to embargoed Dandisets

### DIFF
--- a/dandi/files/zarr.py
+++ b/dandi/files/zarr.py
@@ -297,12 +297,6 @@ class ZarrAsset(LocalDirectoryAsset[LocalZarrEntry]):
             ``"done"`` and an ``"asset"`` key containing the resulting
             `RemoteAsset`.
         """
-        # So that older clients don't get away with doing the wrong thing once
-        # Zarr upload to embargoed Dandisets is implemented in the API:
-        if dandiset.embargo_status is EmbargoStatus.EMBARGOED:
-            raise NotImplementedError(
-                "Uploading Zarr assets to embargoed Dandisets is currently not implemented"
-            )
         asset_path = metadata.setdefault("path", self.path)
         client = dandiset.client
         lgr.debug("%s: Producing asset", asset_path)

--- a/dandi/files/zarr.py
+++ b/dandi/files/zarr.py
@@ -22,7 +22,6 @@ from dandi.consts import (
     ZARR_DELETE_BATCH_SIZE,
     ZARR_MIME_TYPE,
     ZARR_UPLOAD_BATCH_SIZE,
-    EmbargoStatus,
 )
 from dandi.dandiapi import (
     RemoteAsset,

--- a/dandi/tests/fixtures.py
+++ b/dandi/tests/fixtures.py
@@ -610,12 +610,23 @@ def sample_dandiset_factory(
     return SampleDandisetFactory(local_dandi_api, tmp_path_factory)
 
 
+# @sweep_embargo can be used along with `new_dandiset` fixture to
+# run the test against both embargoed and non-embargoed Dandisets.
+# "embargo: bool" argument should be added to the test function.
+sweep_embargo = pytest.mark.parametrize("embargo", [True, False])
+
+
 @pytest.fixture()
 def new_dandiset(
     request: pytest.FixtureRequest, sample_dandiset_factory: SampleDandisetFactory
 ) -> SampleDandiset:
+    kws = {}
+    if "embargo" in request.node.fixturenames:
+        kws["embargo"] = request.node.callspec.params["embargo"]
     return sample_dandiset_factory.mkdandiset(
-        f"Sample Dandiset for {request.node.name}"
+        f"Sample {'Embargoed' if kws.get('embargo') else 'Public'} "
+        f"Dandiset for {request.node.name}",
+        **kws,
     )
 
 

--- a/dandi/tests/test_upload.py
+++ b/dandi/tests/test_upload.py
@@ -151,9 +151,10 @@ def test_upload_download_small_file(
     assert (tmp_path / dandiset_id / "file.txt").read_bytes() == contents
 
 
+@sweep_embargo
 @pytest.mark.parametrize("confirm", [True, False])
 def test_upload_sync(
-    confirm: bool, mocker: MockerFixture, text_dandiset: SampleDandiset
+    confirm: bool, mocker: MockerFixture, text_dandiset: SampleDandiset, embargo: bool
 ) -> None:
     (text_dandiset.dspath / "file.txt").unlink()
     confirm_mock = mocker.patch("click.confirm", return_value=confirm)

--- a/dandi/tests/test_upload.py
+++ b/dandi/tests/test_upload.py
@@ -252,7 +252,9 @@ def test_upload_bids_non_nwb_file(bids_dandiset: SampleDandiset) -> None:
 
 
 @sweep_embargo
-def test_upload_sync_zarr(mocker, zarr_dandiset: SampleDandiset, embargo: bool) -> None:
+def test_upload_sync_zarr(
+    mocker: MockerFixture, zarr_dandiset: SampleDandiset, embargo: bool
+) -> None:
     assert zarr_dandiset.dandiset.embargo_status == (
         EmbargoStatus.EMBARGOED if embargo else EmbargoStatus.OPEN
     )

--- a/dandi/tests/test_upload.py
+++ b/dandi/tests/test_upload.py
@@ -11,7 +11,7 @@ import pytest
 from pytest_mock import MockerFixture
 import zarr
 
-from .fixtures import SampleDandiset, SampleDandisetFactory
+from .fixtures import SampleDandiset, sweep_embargo
 from .test_helpers import assert_dirtrees_eq
 from ..consts import ZARR_MIME_TYPE, EmbargoStatus, dandiset_metadata_file
 from ..dandiapi import AssetType, RemoteBlobAsset, RemoteZarrAsset
@@ -250,21 +250,11 @@ def test_upload_bids_non_nwb_file(bids_dandiset: SampleDandiset) -> None:
     assert [asset.path for asset in bids_dandiset.dandiset.get_assets()] == ["README"]
 
 
-@pytest.mark.parametrize("embargo", [True, False])
-def test_upload_sync_zarr(
-    mocker, sample_dandiset_factory: SampleDandisetFactory, embargo: bool
-) -> None:
-    zarr_dandiset = sample_dandiset_factory.mkdandiset(
-        f"Sample {'embargoed' if embargo else 'public'} Dandiset",
-        embargo=embargo,
-    )
+@sweep_embargo
+def test_upload_sync_zarr(mocker, zarr_dandiset: SampleDandiset, embargo: bool) -> None:
     assert zarr_dandiset.dandiset.embargo_status == (
         EmbargoStatus.EMBARGOED if embargo else EmbargoStatus.OPEN
     )
-    zarr.save(
-        zarr_dandiset.dspath / "sample.zarr", np.arange(1000), np.arange(1000, 0, -1)
-    )
-    zarr_dandiset.upload()
     rmtree(zarr_dandiset.dspath / "sample.zarr")
     zarr.save(zarr_dandiset.dspath / "identity.zarr", np.eye(5))
     confirm_mock = mocker.patch("click.confirm", return_value=True)


### PR DESCRIPTION
- [x] Successfully upload a Zarr archive to DANDI staging server.  See the embargoed Dandiset [215792](https://gui-staging.dandiarchive.org/dandiset/215792/draft).
- [x] Add unittest(s)

cc @jjnesbitt @aaronkanzer @waxlamp 