### PR TITLE
Add hdmf-zarr git repo into our dev build testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,8 +72,9 @@ jobs:
       run: |
         pip install git+https://github.com/jaraco/keyring
         pip install git+https://github.com/NeurodataWithoutBorders/nwbinspector
-        pip install git+https://github.com/NeurodataWithoutBorders/pynwb
-        pip install git+https://github.com/hdmf-dev/hdmf
+        pip install git+https://github.com/NeurodataWithoutBorders/pynwb \
+            git+https://github.com/hdmf-dev/hdmf \
+            git+https://github.com/hdmf-dev/hdmf-zarr
 
     - name: Create NFS filesystem
       if: matrix.mode == 'nfs'


### PR DESCRIPTION
This should resolve our current failure due to No module named hdmf.array

Closes #1541
Ref: https://github.com/hdmf-dev/hdmf-zarr/issues/235

attn @kabilar  -- apparently I have missed @rly 's response there pointing to an obvious solution ;-), although ATM we do not use/rely on hdmf-zarr functionality directly AFAIK.

