### PR TITLE
Add Python 3.13 as supported version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,7 @@ jobs:
           - '3.10'  # Needs quotes so YAML doesn't think it's 3.1
           - '3.11'
           - '3.12'
+          - '3.13'
         mode:
           - normal
         include:
@@ -46,7 +47,7 @@ jobs:
             python: 3.9
             mode: dev-deps
           - os: ubuntu-latest
-            python: 3.12
+            python: 3.13
             mode: dev-deps
           - os: ubuntu-latest
             python: 3.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Scientific/Engineering
 license = Apache 2.0
 description = Command line client for interaction with DANDI instances


### PR DESCRIPTION
Sits on top of 
- #1543 