### PR TITLE
download: provide description for an assertion error on attempts_allowed_or_not

### DIFF
--- a/dandi/download.py
+++ b/dandi/download.py
@@ -783,7 +783,10 @@ def _download_file(
                 yield {"status": "error", "message": str(exc)}
                 return
             # for clear(er) typing, here we get only with int
-            assert isinstance(attempts_allowed_or_not, int)
+            assert isinstance(attempts_allowed_or_not, int), (
+                f"attempts_allowed_or_not is {attempts_allowed_or_not!r} "
+                f"of type {type(attempts_allowed_or_not)}"
+            )
             attempts_allowed = attempts_allowed_or_not
     else:
         lgr.warning("downloader logic: We should not be here!")


### PR DESCRIPTION
Somehow, with some prior version of the code, but we did get this assertion triggered as shown in
https://github.com/dandi/dandi-cli/issues/1549#issuecomment-2537027028 although it remains unclear how that could have happened if type checking is correct since we must not end up there with None or even 0.

Unfortunately with a regular assert we just get an announcement of the fact and no details.  After this change we hope to be able to see more details which might hint on the original issue.