### PR TITLE
enh: log exception info (at debug) when we catch an exception in map_to_click handler

### DIFF
--- a/dandi/cli/base.py
+++ b/dandi/cli/base.py
@@ -131,7 +131,7 @@ def map_to_click_exceptions(f):
         #     raise click.UsageError(str(e))
         except Exception as e:
             e_str = str(e)
-            lgr.debug("Caught exception %s", e_str)
+            lgr.debug("Caught exception %s", e_str, exc_info=True)
             if not map_to_click_exceptions._do_map:
                 raise
             raise click.ClickException(e_str)


### PR DESCRIPTION
@Kevancic  reported a crash where logs where pretty much useless as on the source/reason for exception:

```
2024-12-11T18:28:38-0500 [DEBUG   ] dandi 1351865:139891061004032 sub-I48/ses-SPIM/micr/sub-I48_ses-SPIM_sample-BrocaAreaS01_stain-Calretinin_SPIM.ome.zarr/0/1/51/23 - verified that has correct md5 5f7119e7acfa30675994984323f9632e
2024-12-11T18:28:38-0500 [DEBUG   ] dandi 1351865:139894478612224 sub-I48/ses-SPIM/micr/sub-I48_ses-SPIM_sample-BrocaAreaS01_stain-Calretinin_SPIM.ome.zarr/0/1/51/27 - verified that has correct md5 e2e128cea135ab4d19df53208c3d649e
2024-12-11T18:28:38-0500 [DEBUG   ] dandi 1351865:139891086182144 sub-I48/ses-SPIM/micr/sub-I48_ses-SPIM_sample-BrocaAreaS01_stain-Calretinin_SPIM.ome.zarr/0/1/51/26 - verified that has correct md5 09558a4cb0d70186b0a670bf6d3d7593
2024-12-11T18:28:38-0500 [WARNING ] urllib3.connectionpool 1351865:139890152695552 Connection pool is full, discarding connection: dandiarchive.s3.amazonaws.com. Connection pool size: 10
2024-12-11T18:28:38-0500 [INFO    ] dandi 1351865:139890152695552 File 0/1/51/20 in Zarr e58463c5-08d1-40a9-ae3f-0cd6a075e74d successfully downloaded
2024-12-11T18:28:38-0500 [DEBUG   ] dandi 1351865:139890152695552 sub-I48/ses-SPIM/micr/sub-I48_ses-SPIM_sample-BrocaAreaS01_stain-Calretinin_SPIM.ome.zarr/0/1/51/20.dandidownload - entered __exit__ with position 2223375 without any exception
2024-12-11T18:28:38-0500 [DEBUG   ] dandi 1351865:139890152695552 sub-I48/ses-SPIM/micr/sub-I48_ses-SPIM_sample-BrocaAreaS01_stain-Calretinin_SPIM.ome.zarr/0/1/51/20 - verified that has correct md5 b2a38860da19b022a7389ea1fc6c99e0
2024-12-11T18:28:38-0500 [WARNING ] urllib3.connectionpool 1351865:139889148417792 Connection pool is full, discarding connection: dandiarchive.s3.amazonaws.com. Connection pool size: 10
2024-12-11T18:28:38-0500 [WARNING ] urllib3.connectionpool 1351865:139891496982272 Connection pool is full, discarding connection: dandiarchive.s3.amazonaws.com. Connection pool size: 10
2024-12-11T18:28:38-0500 [INFO    ] dandi 1351865:139889148417792 File 0/1/51/25 in Zarr e58463c5-08d1-40a9-ae3f-0cd6a075e74d successfully downloaded
2024-12-11T18:28:38-0500 [DEBUG   ] dandi 1351865:139889148417792 sub-I48/ses-SPIM/micr/sub-I48_ses-SPIM_sample-BrocaAreaS01_stain-Calretinin_SPIM.ome.zarr/0/1/51/25.dandidownload - entered __exit__ with position 2178920 without any exception
2024-12-11T18:28:38-0500 [INFO    ] dandi 1351865:139891496982272 File 0/1/51/24 in Zarr e58463c5-08d1-40a9-ae3f-0cd6a075e74d successfully downloaded
2024-12-11T18:28:38-0500 [DEBUG   ] dandi 1351865:139891496982272 sub-I48/ses-SPIM/micr/sub-I48_ses-SPIM_sample-BrocaAreaS01_stain-Calretinin_SPIM.ome.zarr/0/1/51/24.dandidownload - entered __exit__ with position 2170317 without any exception
2024-12-11T18:28:38-0500 [DEBUG   ] dandi 1351865:139889148417792 sub-I48/ses-SPIM/micr/sub-I48_ses-SPIM_sample-BrocaAreaS01_stain-Calretinin_SPIM.ome.zarr/0/1/51/25 - verified that has correct md5 4bf60fea9c866f5fb7a6967854e8b02c
2024-12-11T18:28:38-0500 [DEBUG   ] dandi 1351865:139891496982272 sub-I48/ses-SPIM/micr/sub-I48_ses-SPIM_sample-BrocaAreaS01_stain-Calretinin_SPIM.ome.zarr/0/1/51/24 - verified that has correct md5 c805c4f34e250a813f2325741faceddc
2024-12-11T18:28:38-0500 [DEBUG   ] dandi 1351865:139894578401792 Caught exception 
```

May be with traceback logged we get more of useful information