### PR TITLE
Don't use version 0.25.5 of `responses`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -92,7 +92,7 @@ test =
     pytest-mock
     pytest-rerunfailures
     pytest-timeout
-    responses != 0.24.0
+    responses != 0.24.0, != 0.25.5
     vcrpy
 tools=
     boto3


### PR DESCRIPTION
The latest release of `responses` somehow omitted its `py.typed` file, resulting in type-checking errors from projects that use it.  [[Bug report](https://github.com/getsentry/responses/issues/751)]