### PR TITLE
Use Python 3.10 to build docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,8 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - 3.9
-          #- 3.10
+          - '3.10'
           #- 3.11
     steps:
     - name: Check out repository

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,7 +2,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.10"
 python:
     install:
         - requirements: docs/requirements.txt


### PR DESCRIPTION
The docs builds have been failing in CI for a while, always(?) due to pip giving up after excessive backtracking while trying to resolve dependencies. I tested out the following failing command from a recent CI run:

```
pip install 'anys~=0.2' 'bidsschematools~=0.7.0' click-didyoumean 'click>=7.1' coverage 'dandischema<0.12,>=0.9.0' 'etelemetry>=0.2.2' fasteners 'fscacher>=0.3.0' 'hdmf!=3.14.4,!=3.5.0' humanize 'interleave~=0.1' joblib 'keyring!=23.9.0' keyrings.alt 'nwbinspector!=0.4.32,>=0.4.28' opencv-python packaging platformdirs pycryptodomex 'pydantic~=2.0' 'pynwb!=1.1.0,!=2.3.0,>=1.0.3' 'pyout!=0.6.0,>=0.5' pytest pytest-cov pytest-mock pytest-rerunfailures pytest-timeout python-dateutil 'requests~=2.20' 'responses!=0.24.0,!=0.25.5' 'ruamel.yaml<1,>=0.15' semantic-version tenacity 'urllib3>=2.0.0' vcrpy 'yarl~=1.9' 'zarr_checksum~=0.4.0' 'zarr~=2.10'
```

... in Docker images of Python 3.9, 3.10, 3.11, & 3.13, and 3.9 (the version our docs CI uses) was the only one that went into excessive backtracking.  I suspect that something in our dependency tree dropped support for Python 3.9 in a recent version, but I'm not going to go digging to try to find out what.

Strangely, this does not explain why other CI runs using Python 3.9 aren't failing.