### PR TITLE
Pin `dandischema` to require the latest `schema` version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     bidsschematools ~= 0.7.0
     click >= 7.1
     click-didyoumean
-    dandischema >= 0.11.0
+    dandischema == 0.11.0
     etelemetry >= 0.2.2
     fasteners
     fscacher >= 0.3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     bidsschematools ~= 0.7.0
     click >= 7.1
     click-didyoumean
-    dandischema >= 0.9.0, < 0.12
+    dandischema >= 0.11.0
     etelemetry >= 0.2.2
     fasteners
     fscacher >= 0.3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     bidsschematools ~= 0.7.0
     click >= 7.1
     click-didyoumean
-    dandischema == 0.11.0
+    dandischema >= 0.11.0, < 0.12.0
     etelemetry >= 0.2.2
     fasteners
     fscacher >= 0.3.0


### PR DESCRIPTION
Fixes #1463

Edit:
~We encountered this issue again today with `dandi==0.66.4` so I suggest that we pin to the latest `dandischema` version.~

~Error message:~
~$ dandi upload -i linc <path_to_ome_zarr>~
~Error: Server requires schema version 0.6.8; client only supports 0.6.9. You may need to upgrade dandi and/or dandischema~

cc @aaronkanzer @dstansby