### PR TITLE
BF: do not provide size for dandiset.yaml (and definetely not mtime for the size)

### DIFF
--- a/dandi/download.py
+++ b/dandi/download.py
@@ -438,8 +438,8 @@ class ItemsSummary:
         self.files = 0
         # TODO: get rid of needing it
         self.t0: float | None = None  # when first record is seen
-        self.size = 0
-        self.has_unknown_sizes = False
+        self.size: int = 0
+        self.has_unknown_sizes: bool = False
 
     def as_dict(self) -> dict:
         return {
@@ -576,7 +576,7 @@ def _populate_dandiset_yaml(
             existing is DownloadExisting.REFRESH
             and os.lstat(dandiset_yaml).st_mtime >= mtime.timestamp()
         ):
-            yield _skip_file("already exists", size=os.lstat(dandiset_yaml).st_mtime)
+            yield _skip_file("already exists")
             return
     ds = Dandiset(dandiset_path, allow_empty=True)
     ds.path_obj.mkdir(exist_ok=True)  # exist_ok in case of parallel race


### PR DESCRIPTION
In the logs provided for https://github.com/dandi/dandi-cli/issues/1581 I spotted lots of instances of log message due to

            extra = self.items_summary.size - active
            if extra < 0:
                lgr.debug("Extra size %d < 0 -- must not happen", extra)

where we check difference between what is known/planned to be downloaded and what was downloaded so far.

Then I spotted that we reported  GBs for dandiset.yaml

	(dandi) yoh@typhon:/data/tmp/yoh/dandi$ dandi download   -e refresh --path-type glob -J5:10 --preserve-tree 'dandi://DANDI/000026/sub-I58/ses-Hip-CT/micr/*.zarr'
	PATH                                                                     SIZE      DONE            DONE% CHECKSUM STATUS    MESSAGE
	000026/dandiset.yaml                                                     1.7 GB                                   skipped   already exists

which pointed me to this typo (should have been size for mtime).

But then fixing there for size actually would still cause confusion since generally we do not report size planned for dandiset.yaml since we do not know ahead of time.

Hence the easiest  is just to not report that size at all IMHO, as we do not typically report it ATM, e.g.

    ❯ dandi download --download dandiset.yaml --preserve-tree --existing refresh dandi://DANDI/000027/dandiset.yaml
    PATH                 SIZE DONE    DONE% CHECKSUM STATUS    MESSAGE
    000027/dandiset.yaml                             skipped   no change
    Summary:                  0 Bytes                1 skipped 1 no change
                              <0.00%
    2025-03-06 16:00:43,266 [    INFO] Logs saved in /home/yoh/.local/state/dandi-cli/log/2025.03.06-21.00.42Z-207424.log

    ❯ rm -rf 000027

    ❯ dandi download --download dandiset.yaml --preserve-tree --existing refresh dandi://DANDI/000027/dandiset.yaml
    PATH                 SIZE DONE    DONE% CHECKSUM STATUS MESSAGE
    000027/dandiset.yaml                             done   updated
    Summary:                  0 Bytes                1 done 1 updated
                              <0.00%
    2025-03-06 16:00:49,958 [    INFO] Logs saved in /home/yoh/.local/state/dandi-cli/log/2025.03.06-21.00.48Z-207482.log

While looking at the code added few obvious type annotations.