### PR TITLE
Add ability to release upon workflow dispatch

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -1,5 +1,4 @@
 {
-    "onlyPublishWithReleaseLabel": true,
     "baseBranch": "master",
     "author": "DANDI Bot <team@dandiarchive.org>",
     "noVersionPrefix": true,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   auto-release:
@@ -31,7 +32,12 @@ jobs:
         run: python -m pip install build twine
 
       - name: Create release
-        run: ~/auto shipit -vv
+        run: |
+          if [ "${{ github.event_name }}" = workflow_dispatch ]
+          then opts=
+          else opts=--only-publish-with-release-label
+          fi
+          ~/auto shipit -vv $opts
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TWINE_USERNAME: __token__


### PR DESCRIPTION
Bits are taken from http://github.com/brechtm/citeproc-py for which bits were taken from somewhere else as well.

Needed to release and realized that we do not do that upon dispatch yet here