### PR TITLE
Support for partial download of zarrs

### DIFF
--- a/dandi/dandiapi.py
+++ b/dandi/dandiapi.py
@@ -1392,7 +1392,7 @@ class BaseRemoteAsset(ABC, APIBase):
     #: The asset's (forward-slash-separated) path
     path: str
     #: The path within the asset, as e.g. path in a zarr/
-    subpath: str | None = Field(default=None)
+    subpath: Optional[str] = None
     #: The size of the asset in bytes
     size: int
     #: The date at which the asset was created

--- a/dandi/download.py
+++ b/dandi/download.py
@@ -226,6 +226,7 @@ class Downloader:
     url: ParsedDandiURL
     output_dir: InitVar[str | Path]
     output_prefix: Path = field(init=False)
+    #: just a convenience combination of output_dir and output_prefix
     output_path: Path = field(init=False)
     existing: DownloadExisting
     get_metadata: bool
@@ -333,6 +334,12 @@ class Downloader:
                             asset.path,
                         )
                         mtime = asset.modified
+                    if asset.subpath:
+                        lgr.warning(
+                            "No downloading of subpaths within blobs yet. Got %s for %s",
+                            asset.subpath,
+                            asset.path,
+                        )
                     _download_generator = _download_file(
                         asset.get_download_file_iter(),
                         download_path,
@@ -352,7 +359,8 @@ class Downloader:
                     ), f"Asset {asset.path} is neither blob nor Zarr"
                     _download_generator = _download_zarr(
                         asset,
-                        download_path,
+                        prefix=asset.subpath,
+                        download_path=download_path,
                         toplevel_path=self.output_path,
                         existing=self.existing,
                         jobs=self.jobs_per_zarr,
@@ -812,6 +820,7 @@ def _download_file(
         lgr.warning("downloader logic: We should not be here!")
 
     final_digest = None
+
     if downloaded_digest and not resuming:
         assert downloaded_digest is not None
         final_digest = downloaded_digest.hexdigest()  # we care only about hex
@@ -977,6 +986,7 @@ def _download_zarr(
     toplevel_path: str | Path,
     existing: DownloadExisting,
     lock: Lock,
+    prefix: str | None = None,
     jobs: int | None = None,
 ) -> Iterator[dict]:
     # Avoid heavy import by importing within function:
@@ -993,7 +1003,7 @@ def _download_zarr(
             digests[path] = d
 
     def downloads_gen():
-        for entry in asset.iterfiles():
+        for entry in asset.iterfiles(prefix=prefix):
             entries.append(entry)
             etag = entry.digest
             assert etag.algorithm is DigestType.md5


### PR DESCRIPTION
implemented by adding "subpath" within an Asset record and adding support to assess it for .zarrs.

Note also that it adjusts logic from try/except to explicit checking -- much better since avoids swallowing unrelated exceptions.

Tried with

   dandi -l debug download -f debug --preserve-tree dandi://dandi/000108/sub-MITU01/ses-20210521h17m17s06/micr/sub-MITU01_ses-20210521h17m17s06_sample-178_stain-LEC_run-1_chunk-1_SPIM.ome.zarr/0/0/0/0/0

which seems succeeded downloading, we seems still need to

- [ ] disable checksumming for such partial downloads (since there is no partial checksums ATM at API level)
- [ ] add tests and verify that works on full file paths
- [ ] verify behavior upon redownloads