### PR TITLE
BF(workaround): disallow click 8.2.0 due to regression

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,8 @@ project_urls =
 python_requires = >=3.9
 install_requires =
     bidsschematools ~= 1.0
-    click >= 7.1
+    # 8.2.0: https://github.com/pallets/click/issues/2911
+    click >= 7.1, !=8.2.0
     click-didyoumean
     dandischema >= 0.11.0, < 0.12.0
     etelemetry >= 0.2.2


### PR DESCRIPTION
refs:
- https://github.com/pallets/click/issues/2911
- https://github.com/dandi/dandi-cli/issues/1627