### PR TITLE
Stop extensively test no longer used gui.dandiarchive.org, retry HEAD (redirects) upon requests.ConnectionError

### DIFF
--- a/dandi/dandiarchive.py
+++ b/dandi/dandiarchive.py
@@ -889,31 +889,29 @@ class _dandi_url_parser:
         :raises FailedToConnectError: if a response other than 200, 400, 404,
             or one of the statuses in `~dandi.consts.RETRY_STATUSES` is returned
         """
-        i = 0
         retries = 4
-        while True:
+        for retry in range(retries + 1):
             try:
                 r = requests.head(url, allow_redirects=True)
             except requests.ConnectionError as e:
                 # we frequently get those on Windows for some reason
-                if i < retries:
+                if retry < retries:
                     lgr.warning(
                         "HEAD request to %s failed with %s; retrying...",
                         url,
                         e,
                     )
-                    sleep(0.1 * 10**i)
-                    i += 1
+                    sleep(0.1 * 10**retry)
                     continue
                 else:
                     lgr.warning("Exhausted %d retries for %s", retries, url)
                     raise  # re-raise the exception
-            if r.status_code in RETRY_STATUSES and i < retries:
+            if r.status_code in RETRY_STATUSES and retry < retries:
                 retry_after = get_retry_after(r)
                 if retry_after is not None:
                     delay = retry_after
                 else:
-                    delay = 0.1 * 10**i
+                    delay = 0.1 * 10**retry
                 if delay:
                     lgr.warning(
                         "HEAD request to %s returned %d; "
@@ -929,7 +927,6 @@ class _dandi_url_parser:
                         url,
                         r.status_code,
                     )
-                i += 1
                 continue
             elif r.status_code == 404:
                 raise NotFoundError(url)

--- a/dandi/dandiarchive.py
+++ b/dandi/dandiarchive.py
@@ -940,6 +940,7 @@ class _dandi_url_parser:
                 return r.url
             assert isinstance(url, str)
             return url
+        raise RuntimeError("Must not get here: either return or raise in the loop")
 
 
 # convenience binding

--- a/dandi/tests/test_dandiarchive.py
+++ b/dandi/tests/test_dandiarchive.py
@@ -28,16 +28,6 @@ from .fixtures import DandiAPI, SampleDandiset
 @pytest.mark.parametrize(
     "url,parsed_url",
     [
-        # DANDI web UI driven by DANDI API.
-        pytest.param(
-            "https://dandiarchive.org/dandiset/000001",
-            DandisetURL(
-                instance=known_instances["dandi"],
-                dandiset_id="000001",
-                version_id=None,
-            ),
-            marks=mark.skipif_no_network,
-        ),
         # Test the one with /#/ in URL (redirected)
         pytest.param(
             "https://dandiarchive.org/#/dandiset/000001",
@@ -48,8 +38,9 @@ from .fixtures import DandiAPI, SampleDandiset
             ),
             marks=mark.skipif_no_network,
         ),
+        # DANDI web UI driven by DANDI API.
         pytest.param(
-            "https://dandiarchive.org/dandiset/000001/",
+            "https://dandiarchive.org/dandiset/000001",
             DandisetURL(
                 instance=known_instances["dandi"],
                 dandiset_id="000001",
@@ -68,42 +59,6 @@ from .fixtures import DandiAPI, SampleDandiset
         ),
         pytest.param(
             "https://dandiarchive.org/dandiset/000001/0.201104.2302/",
-            DandisetURL(
-                instance=known_instances["dandi"],
-                dandiset_id="000001",
-                version_id="0.201104.2302",
-            ),
-            marks=mark.skipif_no_network,
-        ),
-        pytest.param(
-            "https://dandiarchive.org/dandiset/000001/0.201104.2302/files",
-            DandisetURL(
-                instance=known_instances["dandi"],
-                dandiset_id="000001",
-                version_id="0.201104.2302",
-            ),
-            marks=mark.skipif_no_network,
-        ),
-        pytest.param(
-            "https://dandiarchive.org/dandiset/000001/draft",
-            DandisetURL(
-                instance=known_instances["dandi"],
-                dandiset_id="000001",
-                version_id="draft",
-            ),
-            marks=mark.skipif_no_network,
-        ),
-        pytest.param(
-            "https://dandiarchive.org/dandiset/000001",
-            DandisetURL(
-                instance=known_instances["dandi"],
-                dandiset_id="000001",
-                version_id=None,
-            ),
-            marks=mark.skipif_no_network,
-        ),
-        pytest.param(
-            "https://dandiarchive.org/dandiset/000001/0.201104.2302",
             DandisetURL(
                 instance=known_instances["dandi"],
                 dandiset_id="000001",
@@ -170,7 +125,7 @@ from .fixtures import DandiAPI, SampleDandiset
                 version_id=None,
             ),
         ),
-        (
+        (  # no trailing /
             "http://localhost:8000/api/dandisets/000002",
             DandisetURL(
                 instance=known_instances["dandi-api-local-docker-tests"],

--- a/dandi/tests/test_dandiarchive.py
+++ b/dandi/tests/test_dandiarchive.py
@@ -28,7 +28,7 @@ from .fixtures import DandiAPI, SampleDandiset
 @pytest.mark.parametrize(
     "url,parsed_url",
     [
-        # New DANDI web UI driven by DANDI API.
+        # DANDI web UI driven by DANDI API.
         pytest.param(
             "https://dandiarchive.org/dandiset/000001",
             DandisetURL(

--- a/dandi/tests/test_dandiarchive.py
+++ b/dandi/tests/test_dandiarchive.py
@@ -28,7 +28,17 @@ from .fixtures import DandiAPI, SampleDandiset
     [
         # New DANDI web UI driven by DANDI API.
         pytest.param(
-            "https://gui.dandiarchive.org/#/dandiset/000001",
+            "https://dandiarchive.org/dandiset/000001",
+            DandisetURL(
+                instance=known_instances["dandi"],
+                dandiset_id="000001",
+                version_id=None,
+            ),
+            marks=mark.skipif_no_network,
+        ),
+        # Test the one with /#/ in URL (redirected)
+        pytest.param(
+            "https://dandiarchive.org/#/dandiset/000001",
             DandisetURL(
                 instance=known_instances["dandi"],
                 dandiset_id="000001",
@@ -37,7 +47,7 @@ from .fixtures import DandiAPI, SampleDandiset
             marks=mark.skipif_no_network,
         ),
         pytest.param(
-            "https://gui.dandiarchive.org/#/dandiset/000001/",
+            "https://dandiarchive.org/dandiset/000001/",
             DandisetURL(
                 instance=known_instances["dandi"],
                 dandiset_id="000001",
@@ -46,7 +56,7 @@ from .fixtures import DandiAPI, SampleDandiset
             marks=mark.skipif_no_network,
         ),
         pytest.param(
-            "https://gui.dandiarchive.org/#/dandiset/000001/0.201104.2302",
+            "https://dandiarchive.org/dandiset/000001/0.201104.2302",
             DandisetURL(
                 instance=known_instances["dandi"],
                 dandiset_id="000001",
@@ -55,7 +65,7 @@ from .fixtures import DandiAPI, SampleDandiset
             marks=mark.skipif_no_network,
         ),
         pytest.param(
-            "https://gui.dandiarchive.org/#/dandiset/000001/0.201104.2302/",
+            "https://dandiarchive.org/dandiset/000001/0.201104.2302/",
             DandisetURL(
                 instance=known_instances["dandi"],
                 dandiset_id="000001",
@@ -64,7 +74,7 @@ from .fixtures import DandiAPI, SampleDandiset
             marks=mark.skipif_no_network,
         ),
         pytest.param(
-            "https://gui.dandiarchive.org/#/dandiset/000001/0.201104.2302/files",
+            "https://dandiarchive.org/dandiset/000001/0.201104.2302/files",
             DandisetURL(
                 instance=known_instances["dandi"],
                 dandiset_id="000001",
@@ -73,7 +83,7 @@ from .fixtures import DandiAPI, SampleDandiset
             marks=mark.skipif_no_network,
         ),
         pytest.param(
-            "https://gui.dandiarchive.org/#/dandiset/000001/draft",
+            "https://dandiarchive.org/dandiset/000001/draft",
             DandisetURL(
                 instance=known_instances["dandi"],
                 dandiset_id="000001",
@@ -82,7 +92,7 @@ from .fixtures import DandiAPI, SampleDandiset
             marks=mark.skipif_no_network,
         ),
         pytest.param(
-            "https://gui.dandiarchive.org/dandiset/000001",
+            "https://dandiarchive.org/dandiset/000001",
             DandisetURL(
                 instance=known_instances["dandi"],
                 dandiset_id="000001",
@@ -91,7 +101,7 @@ from .fixtures import DandiAPI, SampleDandiset
             marks=mark.skipif_no_network,
         ),
         pytest.param(
-            "https://gui.dandiarchive.org/dandiset/000001/0.201104.2302",
+            "https://dandiarchive.org/dandiset/000001/0.201104.2302",
             DandisetURL(
                 instance=known_instances["dandi"],
                 dandiset_id="000001",
@@ -100,7 +110,7 @@ from .fixtures import DandiAPI, SampleDandiset
             marks=mark.skipif_no_network,
         ),
         pytest.param(
-            "https://gui.dandiarchive.org/dandiset/000001/0.201104.2302/files",
+            "https://dandiarchive.org/dandiset/000001/0.201104.2302/files",
             DandisetURL(
                 instance=known_instances["dandi"],
                 dandiset_id="000001",
@@ -109,7 +119,7 @@ from .fixtures import DandiAPI, SampleDandiset
             marks=mark.skipif_no_network,
         ),
         pytest.param(
-            "https://gui.dandiarchive.org/dandiset/000001/draft",
+            "https://dandiarchive.org/dandiset/000001/draft",
             DandisetURL(
                 instance=known_instances["dandi"],
                 dandiset_id="000001",
@@ -191,7 +201,7 @@ from .fixtures import DandiAPI, SampleDandiset
             ),
         ),
         pytest.param(
-            "https://gui.dandiarchive.org/#/dandiset/000001/files"
+            "https://dandiarchive.org/#/dandiset/000001/files"
             "?location=%2Fsub-anm369962",
             AssetFolderURL(
                 instance=known_instances["dandi"],
@@ -202,7 +212,7 @@ from .fixtures import DandiAPI, SampleDandiset
             marks=mark.skipif_no_network,
         ),
         pytest.param(
-            "https://gui.dandiarchive.org/#/dandiset/000006/0.200714.1807/files"
+            "https://dandiarchive.org/#/dandiset/000006/0.200714.1807/files"
             "?location=%2Fsub-anm369962",
             AssetFolderURL(
                 instance=known_instances["dandi"],
@@ -213,7 +223,7 @@ from .fixtures import DandiAPI, SampleDandiset
             marks=mark.skipif_no_network,
         ),
         pytest.param(
-            "https://gui.dandiarchive.org/#/dandiset/001001/draft/files"
+            "https://dandiarchive.org/#/dandiset/001001/draft/files"
             "?location=sub-RAT123%2F",
             AssetFolderURL(
                 instance=known_instances["dandi"],
@@ -322,17 +332,6 @@ from .fixtures import DandiAPI, SampleDandiset
                 version_id=None,
             ),
         ),
-        pytest.param(
-            "https://gui.dandiarchive.org/#/dandiset/001001/draft/files"
-            "?location=sub-RAT123/*.nwb",
-            AssetFolderURL(
-                instance=known_instances["dandi"],
-                dandiset_id="001001",
-                version_id="draft",
-                path="sub-RAT123/*.nwb/",
-            ),
-            marks=mark.skipif_no_network,
-        ),
         (
             "dandi://dandi-api-local-docker-tests/000002/f*/bar.nwb",
             AssetItemURL(
@@ -370,17 +369,6 @@ def test_parse_api_url(url: str, parsed_url: ParsedDandiURL) -> None:
                 version_id="draft",
                 path="sub-RAT123/*.nwb",
             ),
-        ),
-        pytest.param(
-            "https://gui.dandiarchive.org/#/dandiset/001001/draft/files"
-            "?location=sub-RAT123/*.nwb",
-            AssetGlobURL(
-                instance=known_instances["dandi"],
-                dandiset_id="001001",
-                version_id="draft",
-                path="sub-RAT123/*.nwb",
-            ),
-            marks=mark.skipif_no_network,
         ),
         (
             "dandi://dandi-api-local-docker-tests/000002/f*/bar.nwb",


### PR DESCRIPTION
We long migrated to just dandiarchive.org . Excessive use of gui. resulted in too many redirects and seems like likely heroku limiting our requests thus tests some times failing to get all the way to redirected site. But since we no longer even use gui.  domain, there is no need to test it. I also adjusted test to exclude /# from URL since also no longer there and would be redirected/handled.

I would consider it
- Closes #1598

Also added one more change to test redirect actually against this gui. (but once) instead of bit.ly -- hopefully would be more robust on windows.