### PR TITLE
Unrestrict `dandischema` version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,9 +35,7 @@ install_requires =
     # >=8.2.0: https://github.com/pallets/click/issues/2911
     click >= 7.1, <8.2.0
     click-didyoumean
-    # we managed to release new schema in 0.11.1, so we need to
-    # wait for dandi-archive to get ready
-    dandischema == 0.11.0
+    dandischema >= 0.11.0, < 0.12.0
     etelemetry >= 0.2.2
     # For pydantic to be able to use type annotations like `X | None`
     eval_type_backport;  python_version < "3.10"


### PR DESCRIPTION
This is to undo a change brought by https://github.com/dandi/dandi-cli/pull/1630 Now that dandiarchive is using the new JSON schema.

This PR closes https://github.com/dandi/dandi-cli/issues/1635.