### PR TITLE
Add superuser name for creation

### DIFF
--- a/dandi/dandiapi.py
+++ b/dandi/dandiapi.py
@@ -1106,6 +1106,10 @@ class RemoteDandiset:
             v = self.get_version(self.version_id)
             if v.status is VersionStatus.VALID and not v.asset_validation_errors:
                 return
+            # TODO(asmacdo) can we fail fast?
+            if v.status is VersionStatus.INVALID:
+                break
+
             sleep(0.5)
         # TODO: Improve the presentation of the error messages
         about = {

--- a/dandi/tests/fixtures.py
+++ b/dandi/tests/fixtures.py
@@ -434,12 +434,16 @@ def docker_compose_setup() -> Iterator[dict[str, str]]:
                     "--rm",
                     "-e",
                     "DJANGO_SUPERUSER_PASSWORD=nsNc48DBiS",
+                    "-e",
+                    "DJANGO_SUPERUSER_EMAIL=admin@nil.nil",
+                    "-e",
+                    "DJANGO_SUPERUSER_FIRST_NAME=Test",
+                    "-e",
+                    "DJANGO_SUPERUSER_LAST_NAME=Admin",
                     "django",
                     "./manage.py",
                     "createsuperuser",
                     "--no-input",
-                    "--email",
-                    "admin@nil.nil",
                 ],
                 cwd=str(LOCAL_DOCKER_DIR),
                 env=env,
@@ -578,10 +582,6 @@ class SampleDandisetFactory:
             {
                 "description": "A test Dandiset",
                 "license": ["spdx:CC0-1.0"],
-                # The contributor needs to be given explicitly here or else
-                # it'll be set based on the user account.  For the Docker
-                # Compose setup, that would mean basing it on the admin user,
-                # whose name doesn't validate under dandischema.
                 "contributor": [
                     {
                         "schemaKey": "Person",


### PR DESCRIPTION
This avoids creating dandisets with invalid metadata,
     ie contributor name = ", "


This will require changes in dandi-archive to pass.