### PR TITLE
Add superuser name for creation

### DIFF
--- a/dandi/cli/tests/data/update_dandiset_from_doi/biorxiv.json
+++ b/dandi/cli/tests/data/update_dandiset_from_doi/biorxiv.json
@@ -13,11 +13,21 @@
     ],
     "version": "draft",
     "@context": "https://raw.githubusercontent.com/dandi/schema/master/releases/0.6.4/context.json",
-    "citation": "Aguillon-Rodriguez, Valeria; Angelaki, Dora E.; Bayer, Hannah M.; Bonacchi, Niccol\u00f2; Carandini, Matteo; Cazettes, Fanny; Chapuis, Gaelle A.; Churchland, Anne K.; Dan, Yang; Dewitt, Eric E. J.; Faulkner, Mayo; Forrest, Hamish; Haetzel, Laura M.; Hausser, Michael; Hofer, Sonja B.; Hu, Fei; Khanal, Anup; Krasniak, Christopher S.; Laranjeira, In\u00eas; Mainen, Zachary F.; Meijer, Guido T.; Miska, Nathaniel J.; Mrsic-Flogel, Thomas D.; Murakami, Masayoshi; Noel, Jean-Paul; Pan-Vazquez, Alejandro; Rossant, Cyrille; Sanders, Joshua I.; Socha, Karolina Z.; Terry, Rebecca; Urai, Anne E.; Vergara, Hernando M.; Wells, Miles J.; Wilson, Christian J.; Witten, Ilana B.; Wool, Lauren E.; Zador, Anthony (2023) Standardized and reproducible measurement of decision-making in mice (Version draft) [Data set]. DANDI Archive. http://localhost:8085/dandiset/000001/draft",
+    "citation": "Admin, Test; Aguillon-Rodriguez, Valeria; Angelaki, Dora E.; Bayer, Hannah M.; Bonacchi, Niccol\u00f2; Carandini, Matteo; Cazettes, Fanny; Chapuis, Gaelle A.; Churchland, Anne K.; Dan, Yang; Dewitt, Eric E. J.; Faulkner, Mayo; Forrest, Hamish; Haetzel, Laura M.; Hausser, Michael; Hofer, Sonja B.; Hu, Fei; Khanal, Anup; Krasniak, Christopher S.; Laranjeira, In\u00eas; Mainen, Zachary F.; Meijer, Guido T.; Miska, Nathaniel J.; Mrsic-Flogel, Thomas D.; Murakami, Masayoshi; Noel, Jean-Paul; Pan-Vazquez, Alejandro; Rossant, Cyrille; Sanders, Joshua I.; Socha, Karolina Z.; Terry, Rebecca; Urai, Anne E.; Vergara, Hernando M.; Wells, Miles J.; Wilson, Christian J.; Witten, Ilana B.; Wool, Lauren E.; Zador, Anthony (2023) Standardized and reproducible measurement of decision-making in mice (Version draft) [Data set]. DANDI Archive. http://localhost:8085/dandiset/000001/draft",
     "schemaKey": "Dandiset",
     "identifier": "DANDI:000001",
     "repository": "http://localhost:8085",
     "contributor": [
+        {
+            "affiliation": [],
+            "email": "admin@nil.nil",
+            "includeInCitation": true,
+            "name": "Admin, Test",
+            "roleName": [
+                "dcite:ContactPerson"
+            ],
+            "schemaKey": "Person"
+        },
         {
             "name": "Tests, DANDI-Cli",
             "email": "nemo@example.com",

--- a/dandi/cli/tests/data/update_dandiset_from_doi/elife.json
+++ b/dandi/cli/tests/data/update_dandiset_from_doi/elife.json
@@ -13,11 +13,21 @@
     ],
     "version": "draft",
     "@context": "https://raw.githubusercontent.com/dandi/schema/master/releases/0.6.4/context.json",
-    "citation": "Chowdhury, Raeed H; Glaser, Joshua I; Miller, Lee E (2023) Area 2 of primary somatosensory cortex encodes kinematics of the whole arm (Version draft) [Data set]. DANDI Archive. http://localhost:8085/dandiset/000004/draft",
+    "citation": "Admin, Test; Chowdhury, Raeed H; Glaser, Joshua I; Miller, Lee E (2023) Area 2 of primary somatosensory cortex encodes kinematics of the whole arm (Version draft) [Data set]. DANDI Archive. http://localhost:8085/dandiset/000004/draft",
     "schemaKey": "Dandiset",
     "identifier": "DANDI:000004",
     "repository": "http://localhost:8085",
     "contributor": [
+        {
+            "affiliation": [],
+            "email": "admin@nil.nil",
+            "includeInCitation": true,
+            "name": "Admin, Test",
+            "roleName": [
+                "dcite:ContactPerson"
+            ],
+            "schemaKey": "Person"
+        },
         {
             "name": "Tests, DANDI-Cli",
             "email": "nemo@example.com",

--- a/dandi/cli/tests/data/update_dandiset_from_doi/jneurosci.json
+++ b/dandi/cli/tests/data/update_dandiset_from_doi/jneurosci.json
@@ -13,11 +13,21 @@
     ],
     "version": "draft",
     "@context": "https://raw.githubusercontent.com/dandi/schema/master/releases/0.6.4/context.json",
-    "citation": "Ito, Makoto; Doya, Kenji (2023) Validation of Decision-Making Models and Analysis of Decision Variables in the Rat Basal Ganglia (Version draft) [Data set]. DANDI Archive. http://localhost:8085/dandiset/000002/draft",
+    "citation": "Admin, Test; Ito, Makoto; Doya, Kenji (2023) Validation of Decision-Making Models and Analysis of Decision Variables in the Rat Basal Ganglia (Version draft) [Data set]. DANDI Archive. http://localhost:8085/dandiset/000002/draft",
     "schemaKey": "Dandiset",
     "identifier": "DANDI:000002",
     "repository": "http://localhost:8085",
     "contributor": [
+        {
+            "affiliation": [],
+            "email": "admin@nil.nil",
+            "includeInCitation": true,
+            "name": "Admin, Test",
+            "roleName": [
+                "dcite:ContactPerson"
+            ],
+            "schemaKey": "Person"
+        },
         {
             "name": "Tests, DANDI-Cli",
             "email": "nemo@example.com",

--- a/dandi/cli/tests/data/update_dandiset_from_doi/nature.json
+++ b/dandi/cli/tests/data/update_dandiset_from_doi/nature.json
@@ -13,11 +13,21 @@
     ],
     "version": "draft",
     "@context": "https://raw.githubusercontent.com/dandi/schema/master/releases/0.6.4/context.json",
-    "citation": "Sit, Kevin K.; Goard, Michael J. (2023) Coregistration of heading to visual cues in retrosplenial cortex (Version draft) [Data set]. DANDI Archive. http://localhost:8085/dandiset/000005/draft",
+    "citation": "Admin, Test; Sit, Kevin K.; Goard, Michael J. (2023) Coregistration of heading to visual cues in retrosplenial cortex (Version draft) [Data set]. DANDI Archive. http://localhost:8085/dandiset/000005/draft",
     "schemaKey": "Dandiset",
     "identifier": "DANDI:000005",
     "repository": "http://localhost:8085",
     "contributor": [
+        {
+            "affiliation": [],
+            "email": "admin@nil.nil",
+            "includeInCitation": true,
+            "name": "Admin, Test",
+            "roleName": [
+                "dcite:ContactPerson"
+            ],
+            "schemaKey": "Person"
+        },
         {
             "name": "Tests, DANDI-Cli",
             "email": "nemo@example.com",

--- a/dandi/cli/tests/data/update_dandiset_from_doi/neuron.json
+++ b/dandi/cli/tests/data/update_dandiset_from_doi/neuron.json
@@ -13,11 +13,21 @@
     ],
     "version": "draft",
     "@context": "https://raw.githubusercontent.com/dandi/schema/master/releases/0.6.4/context.json",
-    "citation": "Tingley, David; Buzs\u00e1ki, Gy\u00f6rgy (2023) Routing of Hippocampal Ripples to Subcortical Structures via the Lateral Septum (Version draft) [Data set]. DANDI Archive. http://localhost:8085/dandiset/000003/draft",
+    "citation": "Admin, Test; Tingley, David; Buzs\u00e1ki, Gy\u00f6rgy (2023) Routing of Hippocampal Ripples to Subcortical Structures via the Lateral Septum (Version draft) [Data set]. DANDI Archive. http://localhost:8085/dandiset/000003/draft",
     "schemaKey": "Dandiset",
     "identifier": "DANDI:000003",
     "repository": "http://localhost:8085",
     "contributor": [
+        {
+            "affiliation": [],
+            "email": "admin@nil.nil",
+            "includeInCitation": true,
+            "name": "Admin, Test",
+            "roleName": [
+                "dcite:ContactPerson"
+            ],
+            "schemaKey": "Person"
+        },
         {
             "name": "Tests, DANDI-Cli",
             "email": "nemo@example.com",

--- a/dandi/dandiapi.py
+++ b/dandi/dandiapi.py
@@ -1106,6 +1106,10 @@ class RemoteDandiset:
             v = self.get_version(self.version_id)
             if v.status is VersionStatus.VALID and not v.asset_validation_errors:
                 return
+            # TODO(asmacdo) can we fail fast?
+            if v.status is VersionStatus.INVALID:
+                break
+
             sleep(0.5)
         # TODO: Improve the presentation of the error messages
         about = {

--- a/dandi/dandiapi.py
+++ b/dandi/dandiapi.py
@@ -1106,10 +1106,6 @@ class RemoteDandiset:
             v = self.get_version(self.version_id)
             if v.status is VersionStatus.VALID and not v.asset_validation_errors:
                 return
-            # TODO(asmacdo) can we fail fast?
-            if v.status is VersionStatus.INVALID:
-                break
-
             sleep(0.5)
         # TODO: Improve the presentation of the error messages
         about = {

--- a/dandi/tests/fixtures.py
+++ b/dandi/tests/fixtures.py
@@ -434,12 +434,16 @@ def docker_compose_setup() -> Iterator[dict[str, str]]:
                     "--rm",
                     "-e",
                     "DJANGO_SUPERUSER_PASSWORD=nsNc48DBiS",
+                    "-e",
+                    "DJANGO_SUPERUSER_EMAIL=admin@nil.nil",
+                    "-e",
+                    "DJANGO_SUPERUSER_FIRST_NAME=Test",
+                    "-e",
+                    "DJANGO_SUPERUSER_LAST_NAME=Admin",
                     "django",
                     "./manage.py",
                     "createsuperuser",
                     "--no-input",
-                    "--email",
-                    "admin@nil.nil",
                 ],
                 cwd=str(LOCAL_DOCKER_DIR),
                 env=env,
@@ -578,10 +582,6 @@ class SampleDandisetFactory:
             {
                 "description": "A test Dandiset",
                 "license": ["spdx:CC0-1.0"],
-                # The contributor needs to be given explicitly here or else
-                # it'll be set based on the user account.  For the Docker
-                # Compose setup, that would mean basing it on the admin user,
-                # whose name doesn't validate under dandischema.
                 "contributor": [
                     {
                         "schemaKey": "Person",


### PR DESCRIPTION
This avoids creating dandisets with invalid metadata, which is caused by [this bugfix PR](https://github.com/dandi/dandi-archive/pull/2377). Please see the description of that one for details.
     ie contributor name = ", "

@yarikoptic this is ready for review, but I am leaving as a draft because:
 - this should not merge unless dandi-archive/2377 merges
 - these tests are failing because they are using dandi-archive image without the bugfix. (I could easily add cross-repo PR checkout logic for PRs like I did in the dandi-archive PR)
     
- [x] Remove failfast hack