### PR TITLE
Fix bug when running metadata extraction on BIDS with NWB

### DIFF
--- a/dandi/metadata/nwb.py
+++ b/dandi/metadata/nwb.py
@@ -72,7 +72,7 @@ def get_metadata(
             path_metadata = df.get_metadata(digest=digest)
             meta["bids_version"] = df.get_validation_bids_version()
             # there might be a more elegant way to do this:
-            if path_metadata.wasAttributedTo is not None:
+            if path_metadata.wasAttributedTo is not None and len(path_metadata.wasAttributedTo) > 0:
                 attributed = path_metadata.wasAttributedTo[0]
                 for key in metadata_all_fields:
                     try:

--- a/dandi/metadata/nwb.py
+++ b/dandi/metadata/nwb.py
@@ -72,7 +72,7 @@ def get_metadata(
             path_metadata = df.get_metadata(digest=digest)
             meta["bids_version"] = df.get_validation_bids_version()
             # there might be a more elegant way to do this:
-            if path_metadata.wasAttributedTo is not None and len(path_metadata.wasAttributedTo) > 0:
+            if path_metadata.wasAttributedTo:
                 attributed = path_metadata.wasAttributedTo[0]
                 for key in metadata_all_fields:
                     try:


### PR DESCRIPTION
Took a while to pin down the problem when uploading the BEP32 example data

I think there is still some recursion that occurs bouncing between NWB and BIDS validation, but it safely terminates without issue

Should still try to remove it, but the outright blocking issue was this line