### PR TITLE
Expand Zarr dependency to include version 3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,7 @@ install_requires =
     # possibly silently incomplete downloads: https://github.com/dandi/dandi-cli/issues/1500
     urllib3 >= 2.0.0
     yarl ~= 1.9
-    zarr ~= 2.10
+    zarr >= 2.10, <= 3.0.8
     zarr_checksum ~= 0.4.0
 zip_safe = False
 packages = find_namespace:

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ install_requires =
     pycryptodomex  # for EncryptedKeyring backend in keyrings.alt
     pydantic ~= 2.0
     pynwb >= 1.0.3,!=1.1.0,!=2.3.0
+    numcodecs < 0.16
     nwbinspector >= 0.4.28,!=0.4.32
     pyout >=0.5, !=0.6.0
     python-dateutil


### PR DESCRIPTION
For a different repository we need to use Zarr v3 and the `dandi-cli`.  Now that #1609 is resolved, could we unpin the Zarr dependency here?

cc @balbasty @calvinchai @satra @ayendiki