### PR TITLE
Upgrade Windows image for test CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - windows-2019
+          - windows-latest
           - ubuntu-latest
           - macos-latest
         python:


### PR DESCRIPTION
Looks like the Windows 2019 image will be unsupported by the end of the month - https://github.com/actions/runner-images/issues/12045.