### PR TITLE
RF: in our example skip going through all dandisets/assets!

### DIFF
--- a/docs/source/examples/dandiapi-example.py
+++ b/docs/source/examples/dandiapi-example.py
@@ -4,6 +4,11 @@ from dandi.dandiapi import DandiAPIClient
 
 with DandiAPIClient.for_dandi_instance("dandi") as client:
     for dandiset in client.get_dandisets():
+        # Note: for demo purposes we go only through a few dandisets, and skip all others
+        # so comment out/remove this condition if you would like to go through all.
+        if not (35 < int(dandiset.identifier) < 40):
+            print(f"For demo purposes skipping {dandiset}")
+            continue
         if dandiset.most_recent_published_version is None:
             continue
         latest_dandiset = dandiset.for_version(dandiset.most_recent_published_version)
@@ -16,3 +21,8 @@ with DandiAPIClient.for_dandi_instance("dandi") as client:
                 print(json.dumps(metadata.json_dict(), indent=4))
                 # Can be used to also download the asset:
                 # asset.download(pathlib.Path(dandiset.identifier, asset.path))
+                # Note: for demonstration purposes we stop at a single asset found
+                print(
+                    f"Was found in dandiset {dandiset}. For demo purposes skipping other assets"
+                )
+                break


### PR DESCRIPTION
As archive grew, it became silly (if not stupid) to always go through all the assets of all dandisets. And we run this example for dandi-cli across all pythons/OSes.  It started to time out for some (OSX) since runs now nearly 6 hours.

With this change, which do not reduce the value of the example, but it runs in just a few seconds from home network:

    python docs/source/examples/dandiapi-example.py  0.67s user 0.05s system 10% cpu 6.973 total

Now we will still list all dandisets (but that is quick), but explore assets only of a few (5) dandisets, where some are known to have desired assets.  Comments are added so people could adjust accordingly.

This might also positively affect our server performance since we would reduce its bombardment with requests from CI!