### PR TITLE
organize: operate on unique file-paths in case of multiple paths leading to the same file(s)

### DIFF
--- a/dandi/organize.py
+++ b/dandi/organize.py
@@ -33,6 +33,7 @@ from .utils import (
     is_url,
     load_jsonl,
     move_file,
+    pluralize,
     yaml_load,
 )
 from .validate_types import (
@@ -838,7 +839,18 @@ def organize(
         metadata = load_jsonl(paths[0])
         link_test_file = metadata[0]["path"]
     else:
-        paths = list(set(find_files(r"\.nwb\Z", paths=paths)))
+        paths = list(find_files(r"\.nwb\Z", paths=paths))
+        duplicates = [path for path, count in Counter(paths).items() if count > 1]
+        if duplicates:
+            msg = ", ".join(duplicates[:3])
+            if len(duplicates) > 3:
+                msg += ", ..."
+            lgr.warning(
+                "%s specified more than once: %s. Taking only unique paths",
+                pluralize(1, "file path"),
+                msg,
+            )
+            paths = list(set(paths))
         link_test_file = paths[0] if paths else None
         lgr.info("Loading metadata from %d files", len(paths))
         # Done here so we could still reuse cached 'get_metadata'


### PR DESCRIPTION
Originally reported in the slack #debug channel with an odd error message being displayed which looked like the one in the test in case we remove use of set():

    dandi.exceptions.OrganizeImpossibleError: Two files ('/home/yoh/.tmp/pytest-of-yoh/pytest-130/simple20/simple2.nwb' and '/home/yoh/.tmp/pytest-of-yoh/pytest-130/simple20/simple2.nwb') have the same object_id 2c6c16ec-43cd-4be5-ac3f-2c4d8a117138. Must not happen. Either files are duplicates (remove one) or were not saved correctly using NWB>=2.1.0 standard (supported by pynwb>=1.1.0).

With use of set() we would overall avoid having multiple instances of the same path being mentioned even if provided args point to the same file (directly or via folder) multiple times.