### PR TITLE
Revert back to use of GITHUB_TOKEN for actual push of PR to be merged with changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
           ~/auto shipit -vv $opts
         env:
           PROTECTED_BRANCH_REVIEWER_TOKEN: ${{ secrets.GH_TOKEN }}
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
 


### PR DESCRIPTION
See details of analysis in
 https://github.com/dandi/dandi-cli/pull/1686#issuecomment-3214652629

I think we need two tokens now -- one to submit PR (default token should be enough) and then another to approve PR and get it merged...

This whole dance somehow for protected branch handling... last attempt!