### PR TITLE
BF: announce two tests xfail on windows python 3.13

### DIFF
--- a/dandi/cli/tests/test_cmd_validate.py
+++ b/dandi/cli/tests/test_cmd_validate.py
@@ -1,10 +1,10 @@
 from pathlib import Path
-import sys
 
 from click.testing import CliRunner
 import pytest
 
 from ..cmd_validate import _process_issues, validate
+from ...tests.xfail import mark_xfail_windows_python313_posixsubprocess
 from ...validate_types import (
     Origin,
     OriginType,
@@ -78,12 +78,7 @@ def test_validate_ignore(simple2_nwb: Path) -> None:
     assert "DANDI.NO_DANDISET_FOUND" not in r.output
 
 
-@pytest.mark.xfail(
-    condition=sys.platform == "win32" and sys.version_info >= (3, 13),
-    reason="Fails on Windows with Python 3.13 due to _posixsubprocess module error",
-    raises=AssertionError,
-    strict=False,
-)
+@mark_xfail_windows_python313_posixsubprocess
 def test_validate_nwb_path_grouping(organized_nwb_dir4: Path) -> None:
     """
     Does grouping of issues by path work?

--- a/dandi/cli/tests/test_cmd_validate.py
+++ b/dandi/cli/tests/test_cmd_validate.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import sys
 
 from click.testing import CliRunner
 import pytest
@@ -77,6 +78,12 @@ def test_validate_ignore(simple2_nwb: Path) -> None:
     assert "DANDI.NO_DANDISET_FOUND" not in r.output
 
 
+@pytest.mark.xfail(
+    condition=sys.platform == "win32" and sys.version_info >= (3, 13),
+    reason="Fails on Windows with Python 3.13 due to _posixsubprocess module error",
+    raises=AssertionError,
+    strict=False,
+)
 def test_validate_nwb_path_grouping(organized_nwb_dir4: Path) -> None:
     """
     Does grouping of issues by path work?

--- a/dandi/tests/test_fixtures.py
+++ b/dandi/tests/test_fixtures.py
@@ -2,11 +2,20 @@
 # and possibly go through their internal asserts
 
 from pathlib import Path
+import sys
+
+import pytest
 
 
 def test_organized_nwb_dir(organized_nwb_dir: Path) -> None:
     pass  # Just a smoke test to trigger fixture's asserts
 
 
+@pytest.mark.xfail(
+    condition=sys.platform == "win32" and sys.version_info >= (3, 13),
+    reason="Fails on Windows with Python 3.13 due to _posixsubprocess module error",
+    raises=AssertionError,
+    strict=False,
+)
 def test_organized_nwb_dir2(organized_nwb_dir2: Path) -> None:
     pass  # Just a smoke test to trigger fixture's asserts

--- a/dandi/tests/test_fixtures.py
+++ b/dandi/tests/test_fixtures.py
@@ -2,20 +2,14 @@
 # and possibly go through their internal asserts
 
 from pathlib import Path
-import sys
 
-import pytest
+from .xfail import mark_xfail_windows_python313_posixsubprocess
 
 
 def test_organized_nwb_dir(organized_nwb_dir: Path) -> None:
     pass  # Just a smoke test to trigger fixture's asserts
 
 
-@pytest.mark.xfail(
-    condition=sys.platform == "win32" and sys.version_info >= (3, 13),
-    reason="Fails on Windows with Python 3.13 due to _posixsubprocess module error",
-    raises=AssertionError,
-    strict=False,
-)
+@mark_xfail_windows_python313_posixsubprocess
 def test_organized_nwb_dir2(organized_nwb_dir2: Path) -> None:
     pass  # Just a smoke test to trigger fixture's asserts

--- a/dandi/tests/test_organize.py
+++ b/dandi/tests/test_organize.py
@@ -11,6 +11,7 @@ from pynwb import NWBHDF5IO
 import pytest
 import ruamel.yaml
 
+from .xfail import mark_xfail_windows_python313_posixsubprocess
 from ..cli.cmd_organize import organize
 from ..consts import dandiset_metadata_file
 from ..organize import (
@@ -114,6 +115,7 @@ if not on_windows:
     no_move_modes.append("symlink-relative")
 
 
+@mark_xfail_windows_python313_posixsubprocess
 @pytest.mark.integration
 @pytest.mark.parametrize("mode", no_move_modes)
 @pytest.mark.parametrize("jobs", (1, -1))
@@ -207,6 +209,7 @@ def test_organize_nwb_test_data(
         assert not any(op.islink(p) for p in produced_paths)
 
 
+@mark_xfail_windows_python313_posixsubprocess
 def test_ambiguous(
     simple2_nwb: Path, tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
@@ -319,6 +322,7 @@ def test_detect_link_type(
     assert detect_link_type(p, tmp_path) == result
 
 
+@mark_xfail_windows_python313_posixsubprocess
 @pytest.mark.parametrize("mode", [FileOperationMode.COPY, FileOperationMode.MOVE])
 @pytest.mark.parametrize("video_mode", list(CopyMode))
 def test_video_organize(
@@ -360,6 +364,7 @@ def test_video_organize(
     assert len(video_files_list) == len(video_files_organized)
 
 
+@mark_xfail_windows_python313_posixsubprocess
 @pytest.mark.parametrize("video_mode,rc", [(CopyMode.COPY, 0), (CopyMode.MOVE, 1)])
 def test_video_organize_common(
     video_mode: CopyMode, rc: int, nwbfiles_video_common: Path
@@ -406,6 +411,7 @@ def test_validate_organized_path(path: str, error_ids: list[str]) -> None:
     assert [e.id for e in errors] == error_ids
 
 
+@mark_xfail_windows_python313_posixsubprocess
 def test_organize_required_field(simple2_nwb: Path, tmp_path: Path) -> None:
     (tmp_path / dandiset_metadata_file).write_text("{}\n")
     r = CliRunner().invoke(

--- a/dandi/tests/xfail.py
+++ b/dandi/tests/xfail.py
@@ -1,0 +1,24 @@
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See LICENSE file distributed along with the dandi-cli package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Define reusable xfail markers for tests.
+
+This module provides commonly used xfail markers that can be shared across
+multiple test modules to avoid duplication.
+"""
+import sys
+
+import pytest
+
+# Reusable xfail markers
+
+mark_xfail_windows_python313_posixsubprocess = pytest.mark.xfail(
+    condition=sys.platform == "win32" and sys.version_info >= (3, 13),
+    reason="Fails on Windows with Python 3.13 due to multiprocessing _posixsubprocess module error",
+    strict=False,
+    raises=AssertionError,
+)


### PR DESCRIPTION
See e.g.

https://github.com/dandi/dandi-cli/actions/runs/17147460699/job/48646355661

    ERROR dandi/cli/tests/test_cmd_validate.py::test_validate_nwb_path_grouping - AssertionError: Error: No module named '_posixsubprocess'
    ERROR dandi/tests/test_fixtures.py::test_organized_nwb_dir2 - AssertionError: Error: No module named '_posixsubprocess'

where it is due to not us but 'multiprocessing'

      File "C:\hostedtoolcache\windows\Python\3.13.7\x64\Lib\multiprocessing\resource_tracker.py", line 261, in _send
        self._ensure_running_and_write(msg)
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^
      File "C:\hostedtoolcache\windows\Python\3.13.7\x64\Lib\multiprocessing\resource_tracker.py", line 220, in _ensure_running_and_write
        self._launch()
        ~~~~~~~~~~~~^^
      File "C:\hostedtoolcache\windows\Python\3.13.7\x64\Lib\multiprocessing\resource_tracker.py", line 185, in _launch
        pid = util.spawnv_passfds(exe, args, fds_to_pass)
      File "C:\hostedtoolcache\windows\Python\3.13.7\x64\Lib\multiprocessing\util.py", line 515, in spawnv_passfds
        import _posixsubprocess
    ModuleNotFoundError: No module named '_posixsubprocess'

I think it is this upstream

https://github.com/python/cpython/issues/138031