### PR TITLE
Run dandi-archive celery worker with `uv`

### DIFF
--- a/dandi/tests/data/dandiarchive-docker/docker-compose.yml
+++ b/dandi/tests/data/dandiarchive-docker/docker-compose.yml
@@ -42,6 +42,8 @@ services:
   celery:
     image: dandiarchive/dandiarchive-api
     command: [
+      "uv",
+      "run",
       "celery",
       "--app", "dandiapi.celery",
       "worker",


### PR DESCRIPTION
Follow up to #1687. 

We are in the process of switching `dandi-archive` to `uv`. This change is required for celery to run; see https://github.com/dandi/dandi-archive/pull/2502