### PR TITLE
Don't include `x-amz-acl` header in zarr upload

### DIFF
--- a/dandi/files/zarr.py
+++ b/dandi/files/zarr.py
@@ -732,10 +732,10 @@ class ZarrAsset(LocalDirectoryAsset[LocalZarrEntry]):
             yield {"status": "initiating upload", "size": total_size}
             lgr.debug("%s: Beginning upload", asset_path)
             changed = False
-            with RESTFullAPIClient(
-                "http://nil.nil",
-                headers={"X-Amz-ACL": "bucket-owner-full-control"},
-            ) as storage, closing(to_upload.get_items()) as upload_items:
+            with (
+                RESTFullAPIClient("http://nil.nil") as storage,
+                closing(to_upload.get_items()) as upload_items,
+            ):
                 bytes_uploaded = 0
                 for i, items in enumerate(
                     chunked(upload_items, ZARR_UPLOAD_BATCH_SIZE), start=1


### PR DESCRIPTION
Closes #1709

This should fix zarr upload in the wake of https://github.com/dandi/dandi-infrastructure/pull/245 being merged.