### PR TITLE
Improve terminal output when uploading existing Zarr

### DIFF
--- a/dandi/upload.py
+++ b/dandi/upload.py
@@ -515,7 +515,7 @@ def check_replace_asset(
 ) -> tuple[bool, dict[str, str]]:
     # Returns a (replace asset, message to yield) tuple
     if isinstance(local_asset, ZarrAsset):
-        return (True, {"message": "exists - reuploading"})
+        return (True, {"message": "file exists"})
     assert local_etag is not None
     metadata = remote_asset.get_raw_metadata()
     local_mtime = local_asset.modified


### PR DESCRIPTION
I uploaded Zarr assets yesterday and the DANDI Hub terminated overnight, so I re-ran the upload this morning to make sure everything transferred.  It turns out that all the data was already transferred but the terminal output was a bit confusing:

```bash
12:08 $ DANDI_DEVEL=1 dandi upload --allow-any-path --validation ignore .
2025-09-19 12:08:48,388 [    INFO] Found 15 files to consider
PATH                                              SIZE     ERRORS PROGRESS STATUS                         MESSAGE                  
dandiset.yaml                                     1.3 kB                   skipped                        should be edited online  
.../micr/sub-I74_sample-IC_acq-overview_XPCT.json 77 Bytes   0             skipped                        file exists              
...r/sub-I74_sample-IC_acq-overview_XPCT.ome.zarr 89.9 GB    0             done                           exists - reuploading     
.../sub-I74_sample-IC_acq-zoom_chunk-01_XPCT.json 74 Bytes   0             skipped                        file exists              
...-I74_sample-IC_acq-zoom_chunk-01_XPCT.ome.zarr            0             comparing against remote Zarr  exists - reuploading     
.../sub-I74_sample-IC_acq-zoom_chunk-02_XPCT.json 74 Bytes   0             skipped                        file exists              
...-I74_sample-IC_acq-zoom_chunk-02_XPCT.ome.zarr            0             comparing against remote Zarr  exists - reuploading     
.../sub-I74_sample-IC_acq-zoom_chunk-03_XPCT.json 74 Bytes   0             skipped                        file exists              
...-I74_sample-IC_acq-zoom_chunk-03_XPCT.ome.zarr 134.7 GB   0             done                           exists - reuploading     
...icr/sub-I74_sample-hemi_acq-overview_XPCT.json 77 Bytes   0             skipped                        file exists              
...sub-I74_sample-hemi_acq-overview_XPCT.ome.zarr            0             comparing against remote Zarr  exists - reuploading     
...ub-I74_sample-hemi_acq-zoom_chunk-01_XPCT.json 74 Bytes   0             skipped                        file exists              
...74_sample-hemi_acq-zoom_chunk-01_XPCT.ome.zarr            0             comparing against remote Zarr  exists - reuploading     
...ub-I74_sample-hemi_acq-zoom_chunk-02_XPCT.json 74 Bytes   0             skipped                        file exists              
...74_sample-hemi_acq-zoom_chunk-02_XPCT.ome.zarr                          pre-validating                                          
Summary:                                          224.6 GB                 8 skipped                      1 should be edited online
                                                                           2 done                         7 file exists            
                                                                           4 comparing against remote ... 6 exists - reuploading   
                                                                           1 pre-validating
```

Specifically I would suggest the following changes:
- `exists - reuploading` should be changed to `file exists`.  I have submitted the change here.
- `done` should be changed to `skipped`.   I am not sure where the most appropriate place in the `zarr.py` module would be for the change to take place.