### PR TITLE
feat: add session end time extraction from NWB files

### DIFF
--- a/dandi/metadata/util.py
+++ b/dandi/metadata/util.py
@@ -588,6 +588,7 @@ def extract_session(metadata: dict) -> list[models.Session] | None:
             name=session_id or "Acquisition session",
             description=metadata.get("session_description"),
             startDate=metadata.get("session_start_time"),
+            endDate=metadata.get("session_end_time"),
             used=probes,
         )
     ]


### PR DESCRIPTION
fix #1713 

- Calculate session duration from NWB TimeSeries and DynamicTable timestamps
- Add new `_get_session_duration()` function to extract min/max timestamps
- Compute session end time by adding duration to session start time
- Include endDate field in Session metadata extraction
- Add comprehensive tests for session duration calculation

This enhancement improves metadata completeness by automatically determining when recording sessions ended based on the actual data timestamps in NWB files, rather than relying solely on manually-provided metadata.