### PR TITLE
Replace imports of pure click with rich-click

### DIFF
--- a/dandi/cli/base.py
+++ b/dandi/cli/base.py
@@ -1,7 +1,7 @@
 from functools import wraps
 import os
 
-import click
+import rich_click as click
 
 from .. import get_logger
 

--- a/dandi/cli/cmd_delete.py
+++ b/dandi/cli/cmd_delete.py
@@ -1,4 +1,4 @@
-import click
+import rich_click as click
 
 from .base import devel_debug_option, instance_option, map_to_click_exceptions
 

--- a/dandi/cli/cmd_digest.py
+++ b/dandi/cli/cmd_digest.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import click
+import rich_click as click
 
 from .base import map_to_click_exceptions
 

--- a/dandi/cli/cmd_download.py
+++ b/dandi/cli/cmd_download.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 import os
 
-import click
+import rich_click as click
 
 from .base import ChoiceList, IntColonInt, instance_option, map_to_click_exceptions
 from ..dandiarchive import _dandi_url_parser, parse_dandi_url

--- a/dandi/cli/cmd_instances.py
+++ b/dandi/cli/cmd_instances.py
@@ -1,7 +1,7 @@
 from dataclasses import asdict
 import sys
 
-import click
+import rich_click as click
 import ruamel.yaml
 
 from .base import map_to_click_exceptions

--- a/dandi/cli/cmd_ls.py
+++ b/dandi/cli/cmd_ls.py
@@ -2,8 +2,8 @@ from collections import defaultdict
 import os
 import os.path as op
 
-import click
 from dandischema import models
+import rich_click as click
 
 from .base import devel_option, lgr, map_to_click_exceptions
 from .formatter import JSONFormatter, JSONLinesFormatter, PYOUTFormatter, YAMLFormatter

--- a/dandi/cli/cmd_move.py
+++ b/dandi/cli/cmd_move.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import click
+import rich_click as click
 
 from .base import devel_debug_option, instance_option, map_to_click_exceptions
 from ..move import MoveExisting, MoveWorkOn

--- a/dandi/cli/cmd_organize.py
+++ b/dandi/cli/cmd_organize.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import click
+import rich_click as click
 
 from .base import dandiset_path_option, devel_debug_option, map_to_click_exceptions
 from ..consts import dandi_layout_fields

--- a/dandi/cli/cmd_service_scripts.py
+++ b/dandi/cli/cmd_service_scripts.py
@@ -12,11 +12,11 @@ from typing import Any, TypeVar
 import urllib.parse
 from uuid import uuid4
 
-import click
 from dandischema.consts import DANDI_SCHEMA_VERSION
 from packaging.version import Version
 from requests.auth import HTTPBasicAuth
 from requests.exceptions import HTTPError
+import rich_click as click
 
 from .base import ChoiceList, instance_option, map_to_click_exceptions
 from .. import __version__, lgr

--- a/dandi/cli/cmd_shell_completion.py
+++ b/dandi/cli/cmd_shell_completion.py
@@ -1,8 +1,8 @@
 import os
 from os.path import basename, normcase, splitext
 
-import click
 from packaging.version import Version
+import rich_click as click
 
 SHELLS = ["bash", "zsh", "fish"]
 

--- a/dandi/cli/cmd_upload.py
+++ b/dandi/cli/cmd_upload.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import click
+import rich_click as click
 
 from .base import (
     IntColonInt,

--- a/dandi/cli/cmd_validate.py
+++ b/dandi/cli/cmd_validate.py
@@ -7,7 +7,7 @@ import re
 from typing import cast
 import warnings
 
-import click
+import rich_click as click
 
 from .base import devel_debug_option, devel_option, map_to_click_exceptions
 from ..utils import pluralize

--- a/dandi/cli/command.py
+++ b/dandi/cli/command.py
@@ -9,9 +9,9 @@ import os.path
 import sys
 from types import SimpleNamespace
 
-import click
 from click_didyoumean import DYMGroup
 import platformdirs
+import rich_click as click
 
 from .base import lgr, map_to_click_exceptions
 from .. import __version__, set_logger_level

--- a/dandi/cli/tests/test_download.py
+++ b/dandi/cli/tests/test_download.py
@@ -1,9 +1,9 @@
 import os
 from pathlib import Path
 
-import click
 from click.testing import CliRunner
 import pytest
+import rich_click as click
 
 from ..cmd_download import download
 from ...consts import dandiset_metadata_file, known_instances

--- a/dandi/cli/tests/test_move.py
+++ b/dandi/cli/tests/test_move.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from typing import Any
 
-import click
 from click.testing import CliRunner
 import pytest
 from pytest_mock import MockerFixture
+import rich_click as click
 
 from ..cmd_move import move
 

--- a/dandi/dandiapi.py
+++ b/dandi/dandiapi.py
@@ -16,10 +16,10 @@ from time import sleep, time
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-import click
 from dandischema import models
 from pydantic import BaseModel, Field, PrivateAttr
 import requests
+import rich_click as click
 import tenacity
 from yarl import URL
 

--- a/dandi/delete.py
+++ b/dandi/delete.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 from operator import attrgetter
 from pathlib import Path
 
-import click
+import rich_click as click
 from yarl import URL
 
 from .consts import DRAFT, ZARR_EXTENSIONS, DandiInstance, dandiset_metadata_file

--- a/dandi/keyring.py
+++ b/dandi/keyring.py
@@ -5,12 +5,12 @@ import os.path as op
 from pathlib import Path
 from typing import TypeVar
 
-import click
 from keyring.backend import KeyringBackend, get_all_keyring
 from keyring.core import get_keyring, load_config, load_env
 from keyring.errors import KeyringError
 from keyring.util.platform_ import config_root
 from keyrings.alt.file import EncryptedKeyring
+import rich_click as click
 
 from . import get_logger
 

--- a/dandi/tests/test_dandiapi.py
+++ b/dandi/tests/test_dandiapi.py
@@ -10,12 +10,12 @@ from shutil import rmtree
 from typing import Any
 
 import anys
-import click
 from dandischema.models import UUID_PATTERN, DigestType, get_schema_version
 import pytest
 from pytest_mock import MockerFixture
 import requests
 import responses
+import rich_click as click
 
 from .fixtures import DandiAPI, SampleDandiset, SampleDandisetFactory
 from .skip import mark

--- a/dandi/upload.py
+++ b/dandi/upload.py
@@ -14,8 +14,8 @@ from time import sleep
 from typing import Any, TypedDict, cast
 from unittest.mock import patch
 
-import click
 from packaging.version import Version
+import rich_click as click
 
 from . import __version__, lgr
 from .consts import (

--- a/tools/migrate-dandisets.py
+++ b/tools/migrate-dandisets.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-import click
 import requests
+import rich_click as click
 
 from dandi.dandiapi import DandiAPIClient
 from dandi.dandiset import APIDandiset

--- a/tools/s3-gc-stats
+++ b/tools/s3-gc-stats
@@ -20,8 +20,8 @@ from urllib.parse import urlparse
 import boto3
 from botocore import UNSIGNED
 from botocore.client import Config
-import click
 from humanize import naturalsize
+import rich_click as click
 
 
 class Version(NamedTuple):

--- a/tools/update-assets-on-server
+++ b/tools/update-assets-on-server
@@ -12,9 +12,9 @@ import logging
 import os
 import sys
 
-import click
 from dandischema.consts import DANDI_SCHEMA_VERSION
 import requests
+import rich_click as click
 
 from dandi.dandiapi import DandiAPIClient
 from dandi.metadata import get_default_metadata, nwb2asset


### PR DESCRIPTION
Should provide better handling for wider terminals, add some colors etc

TODOs:
- [ ] fix up tests
- [ ] potentially see additional improvements, like better listing of "Choices" values like for `download --existing` which transpired this PR
- [ ] fix up entries for listing instances, apparently works out the `\b` a little different

<img width="2267" height="1453" alt="image" src="https://github.com/user-attachments/assets/dffb6d2a-edbb-42f8-87c3-5af57712476f" />

@dandi/dandi-cli @dandi/archive-maintainers anyone used this https://github.com/ewels/rich-click ?