### PR TITLE
BF: fix incompatibility with click >= 8.2.0

### DIFF
--- a/dandi/cli/base.py
+++ b/dandi/cli/base.py
@@ -25,7 +25,7 @@ class IntColonInt(click.ParamType):
         else:
             return value
 
-    def get_metavar(self, param):
+    def get_metavar(self, param, ctx=None):
         return "N[:M]"
 
 
@@ -51,7 +51,7 @@ class ChoiceList(click.ParamType):
                 )
         return selected
 
-    def get_metavar(self, param):
+    def get_metavar(self, param, ctx=None):
         return "[" + ",".join(self.values) + ",all]"
 
 

--- a/dandi/cli/command.py
+++ b/dandi/cli/command.py
@@ -38,7 +38,7 @@ class LogLevel(click.ParamType):
             else:
                 self.fail(f"{value!r}: invalid log level", param, ctx)
 
-    def get_metavar(self, param):
+    def get_metavar(self, param, ctx=None):
         return "[" + "|".join(self.levels) + "]"
 
 


### PR DESCRIPTION
Otherwise was failing as

      File "/home/yoh/proj/dandi/dandi-cli-enh-get-bibliography/.venv/lib/python3.11/site-packages/click/core.py", line 2215, in make_metavar
        metavar = self.type.get_metavar(param=self, ctx=ctx)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    TypeError: LogLevel.get_metavar() got an unexpected keyword argument 'ctx'