### PR TITLE
Make pytest output more verbose

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ commands =
     # Using pytest-cov instead of using coverage directly leaves a bunch of
     # .coverage.$HOSTNAME.#.# files lying around for some reason
     coverage erase
-    coverage run -m pytest -v {posargs} dandi
+    coverage run -m pytest -vv {posargs} dandi
     coverage combine
     coverage report
 


### PR DESCRIPTION
This PR makes pytest output more verbose so that failure of comparison between model objects and their expected output can be meaningfully depicted. This PR and https://github.com/dandi/dandi-schema/pull/341 together form a solution to address the issue described at https://github.com/dandi/dandi-cli/pull/1716#discussion_r2406763697.