### PR TITLE
Remove `ValidationResult.path_regex` as possible return of `purview()`

### DIFF
--- a/dandi/validate_types.py
+++ b/dandi/validate_types.py
@@ -219,8 +219,6 @@ class ValidationResult(BaseModel):
     def purview(self) -> str | None:
         if self.path is not None:
             return str(self.path)
-        elif self.path_regex is not None:
-            return self.path_regex
         elif self.dataset_path is not None:
             return str(self.dataset_path)
         else:


### PR DESCRIPTION
A purview is expected to be the string expression of a path or `None` in its only usages in `_process_issues()` as indicated in the comments shown below, so it is inappropriate to return `ValidationResult.path_regex` which is a regex.

https://github.com/dandi/dandi-cli/blob/e734c68994f1a0e8c4826c6ae041bf6fc0d57e25/dandi/cli/cmd_validate.py#L157-L158

Note: This change will pave the way to implement a solution for https://github.com/dandi/dandi-cli/issues/1597.

