### PR TITLE
Add filtering of issues by type/ID or by file location

### DIFF
--- a/dandi/cli/base.py
+++ b/dandi/cli/base.py
@@ -175,7 +175,7 @@ def _compile_regex(regex: str) -> re.Pattern:
 
 def parse_regexes(
     _ctx: click.Context, _param: click.Parameter, value: Optional[str]
-) -> Optional[list[re.Pattern]]:
+) -> Optional[set[re.Pattern]]:
     """
     Callback to parse a string of comma-separated regex patterns
 
@@ -193,8 +193,8 @@ def parse_regexes(
 
     Returns
     -------
-    list[re.Pattern]
-        A list of compiled regex patterns.
+    set[re.Pattern]
+        A set of compiled regex patterns.
 
     Notes
     -----
@@ -206,4 +206,4 @@ def parse_regexes(
 
     regexes = set(value.split(","))
 
-    return [_compile_regex(regex) for regex in regexes]
+    return {_compile_regex(regex) for regex in regexes}

--- a/dandi/cli/cmd_validate.py
+++ b/dandi/cli/cmd_validate.py
@@ -108,7 +108,7 @@ def validate_bids(
 def validate(
     paths: tuple[str, ...],
     ignore: str | None,
-    match: Optional[list[re.Pattern]],
+    match: Optional[set[re.Pattern]],
     grouping: str,
     min_severity: str,
     schema: str | None = None,
@@ -158,7 +158,7 @@ def _process_issues(
     validator_result: Iterable[ValidationResult],
     grouping: str,
     ignore: str | None = None,
-    match: Optional[list[re.Pattern]] = None,
+    match: Optional[set[re.Pattern]] = None,
 ) -> None:
     issues = [i for i in validator_result if i.severity is not None]
     if ignore is not None:

--- a/dandi/cli/cmd_validate.py
+++ b/dandi/cli/cmd_validate.py
@@ -4,13 +4,18 @@ from collections.abc import Iterable
 import logging
 import os
 import re
-from typing import cast
+from typing import Optional, cast
 import warnings
 
 import click
 
-from .base import devel_debug_option, devel_option, map_to_click_exceptions
-from ..utils import pluralize
+from .base import (
+    devel_debug_option,
+    devel_option,
+    map_to_click_exceptions,
+    parse_regexes,
+)
+from ..utils import filter_by_id_patterns, pluralize
 from ..validate import validate as validate_
 from ..validate_types import Severity, ValidationResult
 
@@ -81,6 +86,17 @@ def validate_bids(
 )
 @click.option("--ignore", metavar="REGEX", help="Regex matching error IDs to ignore")
 @click.option(
+    "--match",
+    metavar="REGEX,REGEX,...",
+    help=(
+        "Comma-separated regex patterns used to filter issues in validation results "
+        "by their ID. Only issues with an ID matching at least one of the given "
+        "patterns are included in the eventual result. "
+        "(No pattern should contain a comma.)"
+    ),
+    callback=parse_regexes,
+)
+@click.option(
     "--min-severity",
     help="Only display issues with severities above this level.",
     type=click.Choice([i.name for i in Severity], case_sensitive=True),
@@ -92,6 +108,7 @@ def validate_bids(
 def validate(
     paths: tuple[str, ...],
     ignore: str | None,
+    match: Optional[list[re.Pattern]],
     grouping: str,
     min_severity: str,
     schema: str | None = None,
@@ -134,17 +151,23 @@ def validate(
         if i.severity is not None and i.severity.value >= min_severity_value
     ]
 
-    _process_issues(filtered_results, grouping, ignore)
+    _process_issues(filtered_results, grouping, ignore, match)
 
 
 def _process_issues(
     validator_result: Iterable[ValidationResult],
     grouping: str,
     ignore: str | None = None,
+    match: Optional[list[re.Pattern]] = None,
 ) -> None:
     issues = [i for i in validator_result if i.severity is not None]
     if ignore is not None:
         issues = [i for i in issues if not re.search(ignore, i.id)]
+
+    # Filter issues by ID patterns if provided
+    if match is not None:
+        issues = filter_by_id_patterns(issues, match)
+
     purviews = [i.purview for i in issues]
     if grouping == "none":
         display_errors(

--- a/dandi/cli/cmd_validate.py
+++ b/dandi/cli/cmd_validate.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 import logging
 import os
+from pathlib import Path
 import re
 from typing import Optional, cast
 import warnings
@@ -15,7 +16,7 @@ from .base import (
     map_to_click_exceptions,
     parse_regexes,
 )
-from ..utils import filter_by_id_patterns, pluralize
+from ..utils import filter_by_id_patterns, filter_by_paths, pluralize
 from ..validate import validate as validate_
 from ..validate_types import Severity, ValidationResult
 
@@ -97,6 +98,15 @@ def validate_bids(
     callback=parse_regexes,
 )
 @click.option(
+    "--include-path",
+    multiple=True,
+    type=click.Path(exists=True, resolve_path=True, path_type=Path),
+    help=(
+        "Filter issues in the validation results to only those associated with the "
+        "given path(s). This option can be specified multiple times."
+    ),
+)
+@click.option(
     "--min-severity",
     help="Only display issues with severities above this level.",
     type=click.Choice([i.name for i in Severity], case_sensitive=True),
@@ -109,6 +119,7 @@ def validate(
     paths: tuple[str, ...],
     ignore: str | None,
     match: Optional[set[re.Pattern]],
+    include_path: tuple[Path, ...],
     grouping: str,
     min_severity: str,
     schema: str | None = None,
@@ -151,7 +162,7 @@ def validate(
         if i.severity is not None and i.severity.value >= min_severity_value
     ]
 
-    _process_issues(filtered_results, grouping, ignore, match)
+    _process_issues(filtered_results, grouping, ignore, match, include_path)
 
 
 def _process_issues(
@@ -159,6 +170,7 @@ def _process_issues(
     grouping: str,
     ignore: str | None = None,
     match: Optional[set[re.Pattern]] = None,
+    include_path: tuple[Path, ...] = (),
 ) -> None:
     issues = [i for i in validator_result if i.severity is not None]
     if ignore is not None:
@@ -167,6 +179,10 @@ def _process_issues(
     # Filter issues by ID patterns if provided
     if match is not None:
         issues = filter_by_id_patterns(issues, match)
+
+    # Filter issues by included paths if provided
+    if include_path:
+        issues = filter_by_paths(issues, include_path)
 
     purviews = [i.purview for i in issues]
     if grouping == "none":

--- a/dandi/cli/tests/test_base.py
+++ b/dandi/cli/tests/test_base.py
@@ -53,7 +53,9 @@ class TestParseRegexes:
             ("foo,foo,bar", {"foo", "bar"}),
         ],
     )
-    def test_parse_patterns(self, value: str, expected_patterns_in_strs: set[str]):
+    def test_parse_patterns(
+        self, value: str, expected_patterns_in_strs: set[str]
+    ) -> None:
         result = parse_regexes(DUMMY_CTX, DUMMY_PARAM, value)
         assert isinstance(result, set)
 
@@ -62,6 +64,8 @@ class TestParseRegexes:
     @pytest.mark.parametrize(
         "value, bad_pattern", [("(", "("), ("foo,(", "("), ("good,[a-z", "[a-z")]
     )
-    def test_invalid_pattern_raises_bad_parameter(self, value: str, bad_pattern: str):
+    def test_invalid_pattern_raises_bad_parameter(
+        self, value: str, bad_pattern: str
+    ) -> None:
         with pytest.raises(click.BadParameter, match=re.escape(bad_pattern)):
             parse_regexes(DUMMY_CTX, DUMMY_PARAM, value)

--- a/dandi/cli/tests/test_base.py
+++ b/dandi/cli/tests/test_base.py
@@ -1,0 +1,82 @@
+import re
+
+import click
+import pytest
+
+from dandi.cli.base import _compile_regex, parse_regexes
+
+DUMMY_CTX = click.Context(click.Command("dummy"))
+DUMMY_PARAM = click.Option(["--dummy"])
+
+
+class TestCompileRegex:
+    @pytest.mark.parametrize(
+        "pattern",
+        [
+            "abc",
+            "[a-z]+",
+            "^start$",
+            r"a\.b",
+        ],
+    )
+    def test_valid_patterns_return_pattern(self, pattern):
+        compiled = _compile_regex(pattern)
+        assert isinstance(compiled, re.Pattern)
+        assert compiled.pattern == pattern
+
+    @pytest.mark.parametrize("pattern", ["(", "[a-z", "\\"])
+    def test_invalid_patterns_raise_bad_parameter(self, pattern):
+        with pytest.raises(click.BadParameter) as exc_info:
+            _compile_regex(pattern)
+        msg = str(exc_info.value)
+        assert "Invalid regex pattern" in msg
+        assert repr(pattern) in msg
+
+
+class TestParseRegexes:
+    def test_none_returns_none(self):
+        assert parse_regexes(DUMMY_CTX, DUMMY_PARAM, None) is None
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "abc",
+            "[a-z]+",
+            r"a\.b",
+            r"",
+        ],
+    )
+    def test_single_pattern(self, value):
+
+        result = parse_regexes(DUMMY_CTX, DUMMY_PARAM, value)
+        assert isinstance(result, list)
+        assert len(result) == 1
+
+        (compiled,) = result
+        assert isinstance(compiled, re.Pattern)
+        assert compiled.pattern == value
+
+    @pytest.mark.parametrize(
+        "value, expected_patterns_in_strs",
+        [
+            ("foo,,bar", ["foo", "", "bar"]),
+            ("^start$,end$", ["^start$", "end$"]),
+            (r"a\.b,c+d", [r"a\.b", r"c+d"]),
+            # duplicates should be collapsed by the internal set()
+            ("foo,foo,bar", ["foo", "bar"]),
+        ],
+    )
+    def test_multiple_patterns(self, value: str, expected_patterns_in_strs: list[str]):
+        result = parse_regexes(DUMMY_CTX, DUMMY_PARAM, value)
+        assert isinstance(result, list)
+
+        # Order is not guaranteed due to de-duplication via set
+        # So we just check that all expected patterns are present
+        assert {p.pattern for p in result} == set(expected_patterns_in_strs)
+
+    @pytest.mark.parametrize(
+        "value, bad_pattern", [("(", "("), ("foo,(", "("), ("good,[a-z", "[a-z")]
+    )
+    def test_invalid_pattern_raises_bad_parameter(self, value: str, bad_pattern: str):
+        with pytest.raises(click.BadParameter, match=re.escape(bad_pattern)):
+            parse_regexes(DUMMY_CTX, DUMMY_PARAM, value)

--- a/dandi/cli/tests/test_base.py
+++ b/dandi/cli/tests/test_base.py
@@ -38,27 +38,14 @@ class TestParseRegexes:
         assert parse_regexes(DUMMY_CTX, DUMMY_PARAM, None) is None
 
     @pytest.mark.parametrize(
-        "value",
-        [
-            "abc",
-            "[a-z]+",
-            r"a\.b",
-            r"",
-        ],
-    )
-    def test_single_pattern(self, value):
-
-        result = parse_regexes(DUMMY_CTX, DUMMY_PARAM, value)
-        assert isinstance(result, set)
-        assert len(result) == 1
-
-        (compiled,) = result
-        assert isinstance(compiled, re.Pattern)
-        assert compiled.pattern == value
-
-    @pytest.mark.parametrize(
         "value, expected_patterns_in_strs",
         [
+            # Single patterns
+            ("abc", {"abc"}),
+            ("[a-z]+", {"[a-z]+"}),
+            (r"a\.b", {r"a\.b"}),
+            (r"", {r""}),
+            # Multiple patterns
             ("foo,,bar", {"foo", "", "bar"}),
             ("^start$,end$", {"^start$", "end$"}),
             (r"a\.b,c+d", {r"a\.b", r"c+d"}),
@@ -66,7 +53,7 @@ class TestParseRegexes:
             ("foo,foo,bar", {"foo", "bar"}),
         ],
     )
-    def test_multiple_patterns(self, value: str, expected_patterns_in_strs: set[str]):
+    def test_parse_patterns(self, value: str, expected_patterns_in_strs: set[str]):
         result = parse_regexes(DUMMY_CTX, DUMMY_PARAM, value)
         assert isinstance(result, set)
 

--- a/dandi/cli/tests/test_base.py
+++ b/dandi/cli/tests/test_base.py
@@ -49,7 +49,7 @@ class TestParseRegexes:
     def test_single_pattern(self, value):
 
         result = parse_regexes(DUMMY_CTX, DUMMY_PARAM, value)
-        assert isinstance(result, list)
+        assert isinstance(result, set)
         assert len(result) == 1
 
         (compiled,) = result
@@ -59,20 +59,18 @@ class TestParseRegexes:
     @pytest.mark.parametrize(
         "value, expected_patterns_in_strs",
         [
-            ("foo,,bar", ["foo", "", "bar"]),
-            ("^start$,end$", ["^start$", "end$"]),
-            (r"a\.b,c+d", [r"a\.b", r"c+d"]),
+            ("foo,,bar", {"foo", "", "bar"}),
+            ("^start$,end$", {"^start$", "end$"}),
+            (r"a\.b,c+d", {r"a\.b", r"c+d"}),
             # duplicates should be collapsed by the internal set()
-            ("foo,foo,bar", ["foo", "bar"]),
+            ("foo,foo,bar", {"foo", "bar"}),
         ],
     )
-    def test_multiple_patterns(self, value: str, expected_patterns_in_strs: list[str]):
+    def test_multiple_patterns(self, value: str, expected_patterns_in_strs: set[str]):
         result = parse_regexes(DUMMY_CTX, DUMMY_PARAM, value)
-        assert isinstance(result, list)
+        assert isinstance(result, set)
 
-        # Order is not guaranteed due to de-duplication via set
-        # So we just check that all expected patterns are present
-        assert {p.pattern for p in result} == set(expected_patterns_in_strs)
+        assert {p.pattern for p in result} == expected_patterns_in_strs
 
     @pytest.mark.parametrize(
         "value, bad_pattern", [("(", "("), ("foo,(", "("), ("good,[a-z", "[a-z")]

--- a/dandi/cli/tests/test_cmd_validate.py
+++ b/dandi/cli/tests/test_cmd_validate.py
@@ -207,7 +207,7 @@ class TestValidateMatchOption:
             # Single pattern matching specific validation ID
             (
                 r"BIDS\.DATATYPE_MISMATCH",
-                [r"BIDS\.DATATYPE_MISMATCH"],
+                {r"BIDS\.DATATYPE_MISMATCH"},
                 ["BIDS.DATATYPE_MISMATCH"],
                 [
                     "BIDS.EXTENSION_MISMATCH",
@@ -218,28 +218,28 @@ class TestValidateMatchOption:
             # Single pattern matching by prefix
             (
                 r"^BIDS\.",
-                [r"^BIDS\."],
+                {r"^BIDS\."},
                 ["BIDS.DATATYPE_MISMATCH", "BIDS.EXTENSION_MISMATCH"],
                 ["DANDI.NO_DANDISET_FOUND", "NWBI.check_data_orientation"],
             ),
             # Single pattern that matches nothing (should show "No errors found")
             (
                 r"NONEXISTENT_ID",
-                [r"NONEXISTENT_ID"],
+                {r"NONEXISTENT_ID"},
                 ["No errors found"],
                 ["BIDS", "DANDI", "NWBI"],
             ),
             # Multiple patterns separated by comma
             (
                 r"BIDS\.DATATYPE_MISMATCH,BIDS\.EXTENSION_MISMATCH",
-                [r"BIDS\.DATATYPE_MISMATCH", r"BIDS\.EXTENSION_MISMATCH"],
+                {r"BIDS\.DATATYPE_MISMATCH", r"BIDS\.EXTENSION_MISMATCH"},
                 ["BIDS.DATATYPE_MISMATCH", "BIDS.EXTENSION_MISMATCH"],
                 ["DANDI.NO_DANDISET_FOUND", "NWBI.check_data_orientation"],
             ),
             # Multiple patterns with wildcard
             (
                 r"BIDS\.\S+,DANDI\.\S+",
-                [r"BIDS\.\S+", r"DANDI\.\S+"],
+                {r"BIDS\.\S+", r"DANDI\.\S+"},
                 [
                     "BIDS.DATATYPE_MISMATCH",
                     "BIDS.EXTENSION_MISMATCH",
@@ -253,7 +253,7 @@ class TestValidateMatchOption:
         self,
         tmp_path: Path,
         match_patterns: str,
-        parsed_patterns: list[str],
+        parsed_patterns: set[str],
         should_contain: list[str],
         should_not_contain: list[str],
         monkeypatch: pytest.MonkeyPatch,
@@ -279,8 +279,7 @@ class TestValidateMatchOption:
         assert (
             passed_patterns is not None
         ), "No match patterns were passed to _process_issues"
-        # We don't really care about the order of the patterns
-        assert {p.pattern for p in passed_patterns} == set(parsed_patterns)
+        assert {p.pattern for p in passed_patterns} == parsed_patterns
 
         for text in should_contain:
             assert text in r.output, f"Expected '{text}' in output but not found"

--- a/dandi/cli/tests/test_cmd_validate.py
+++ b/dandi/cli/tests/test_cmd_validate.py
@@ -355,7 +355,7 @@ class TestValidateIncludePathOption:
         mocker: pytest_mock.MockerFixture,
     ) -> None:
         """
-        Test that the validated arguments for --include-path correct
+        Test that the validated arguments for --include-path are correct
         """
         from .. import cmd_validate
 

--- a/dandi/cli/tests/test_cmd_validate.py
+++ b/dandi/cli/tests/test_cmd_validate.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from click.testing import CliRunner
 import pytest
+import pytest_mock
 
 from ..cmd_validate import _process_issues, validate
 from ...tests.xfail import mark_xfail_windows_python313_posixsubprocess
@@ -149,3 +150,172 @@ def test_validate_bids_error_grouping_notification(
     # Does it notify the user correctly?
     notification_substring = "Invalid value for '--grouping'"
     assert notification_substring in r.output
+
+
+class TestValidateMatchOption:
+    """Test the --match option for filtering validation results."""
+
+    @staticmethod
+    def _mock_validate(*paths, **kwargs):
+        """Mock validation function that returns controlled ValidationResult objects."""
+        origin = Origin(
+            type=OriginType.VALIDATION,
+            validator=Validator.dandi,
+            validator_version="test",
+        )
+
+        # Return a set of validation results with different IDs
+        results = [
+            ValidationResult(
+                id="BIDS.DATATYPE_MISMATCH",
+                origin=origin,
+                severity=Severity.ERROR,
+                scope=Scope.FILE,
+                message="Datatype mismatch error",
+                path=Path(paths[0]) / "file1.nii",
+            ),
+            ValidationResult(
+                id="BIDS.EXTENSION_MISMATCH",
+                origin=origin,
+                severity=Severity.ERROR,
+                scope=Scope.FILE,
+                message="Extension mismatch error",
+                path=Path(paths[0]) / "file2.jpg",
+            ),
+            ValidationResult(
+                id="DANDI.NO_DANDISET_FOUND",
+                origin=origin,
+                severity=Severity.ERROR,
+                scope=Scope.DANDISET,
+                message="No dandiset found",
+                path=Path(paths[0]),
+            ),
+            ValidationResult(
+                id="NWBI.check_data_orientation",
+                origin=origin,
+                severity=Severity.WARNING,
+                scope=Scope.FILE,
+                message="Data orientation warning",
+                path=Path(paths[0]) / "file3.nwb",
+            ),
+        ]
+        return iter(results)
+
+    @pytest.mark.parametrize(
+        "match_patterns,parsed_patterns,should_contain,should_not_contain",
+        [
+            # Single pattern matching specific validation ID
+            (
+                r"BIDS\.DATATYPE_MISMATCH",
+                [r"BIDS\.DATATYPE_MISMATCH"],
+                ["BIDS.DATATYPE_MISMATCH"],
+                [
+                    "BIDS.EXTENSION_MISMATCH",
+                    "DANDI.NO_DANDISET_FOUND",
+                    "NWBI.check_data_orientation",
+                ],
+            ),
+            # Single pattern matching by prefix
+            (
+                r"^BIDS\.",
+                [r"^BIDS\."],
+                ["BIDS.DATATYPE_MISMATCH", "BIDS.EXTENSION_MISMATCH"],
+                ["DANDI.NO_DANDISET_FOUND", "NWBI.check_data_orientation"],
+            ),
+            # Single pattern that matches nothing (should show "No errors found")
+            (
+                r"NONEXISTENT_ID",
+                [r"NONEXISTENT_ID"],
+                ["No errors found"],
+                ["BIDS", "DANDI", "NWBI"],
+            ),
+            # Multiple patterns separated by comma
+            (
+                r"BIDS\.DATATYPE_MISMATCH,BIDS\.EXTENSION_MISMATCH",
+                [r"BIDS\.DATATYPE_MISMATCH", r"BIDS\.EXTENSION_MISMATCH"],
+                ["BIDS.DATATYPE_MISMATCH", "BIDS.EXTENSION_MISMATCH"],
+                ["DANDI.NO_DANDISET_FOUND", "NWBI.check_data_orientation"],
+            ),
+            # Multiple patterns with wildcard
+            (
+                r"BIDS\.\S+,DANDI\.\S+",
+                [r"BIDS\.\S+", r"DANDI\.\S+"],
+                [
+                    "BIDS.DATATYPE_MISMATCH",
+                    "BIDS.EXTENSION_MISMATCH",
+                    "DANDI.NO_DANDISET_FOUND",
+                ],
+                ["NWBI"],
+            ),
+        ],
+    )
+    def test_match_patterns(
+        self,
+        tmp_path: Path,
+        match_patterns: str,
+        parsed_patterns: list[str],
+        should_contain: list[str],
+        should_not_contain: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+        mocker: pytest_mock.MockerFixture,
+    ) -> None:
+        """Test --match option with single or multiple comma-separated patterns."""
+        from .. import cmd_validate
+
+        # Use to monitor what compiled patterns are passed by the CLI
+        process_issues_spy = mocker.spy(cmd_validate, "_process_issues")
+
+        monkeypatch.setattr(cmd_validate, "validate_", self._mock_validate)
+
+        r = CliRunner().invoke(validate, [f"--match={match_patterns}", str(tmp_path)])
+
+        process_issues_spy.assert_called_once()
+        call_args = process_issues_spy.call_args
+
+        # Ensure the patterns are parsed and passed correctly
+        passed_patterns = call_args.kwargs.get(
+            "match", call_args.args[3] if len(call_args.args) > 3 else None
+        )
+        assert (
+            passed_patterns is not None
+        ), "No match patterns were passed to _process_issues"
+        # We don't really care about the order of the patterns
+        assert {p.pattern for p in passed_patterns} == set(parsed_patterns)
+
+        for text in should_contain:
+            assert text in r.output, f"Expected '{text}' in output but not found"
+
+        for text in should_not_contain:
+            assert text not in r.output, f"Expected '{text}' NOT in output but found"
+
+    def test_match_invalid_regex(self, tmp_path: Path) -> None:
+        """Test --match option with invalid regex pattern."""
+        # Invalid regex pattern with unmatched parenthesis
+        r = CliRunner(mix_stderr=False).invoke(
+            validate, [r"--match=(INVALID", str(tmp_path)], catch_exceptions=False
+        )
+
+        # Should fail with an error about invalid regex
+        assert r.exit_code != 0
+        assert "error" in r.stderr.lower() and "--match" in r.stderr
+
+    def test_match_with_ignore_combination(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test --match and --ignore options used together."""
+        from .. import cmd_validate
+
+        monkeypatch.setattr(cmd_validate, "validate_", self._mock_validate)
+
+        # Then use both match and ignore
+        r = CliRunner().invoke(
+            validate,
+            [
+                r"--match=BIDS\.DATATYPE_MISMATCH",
+                r"--ignore=DATATYPE_MISMATCH",
+                str(tmp_path),
+            ],
+        )
+
+        assert "BIDS.DATATYPE_MISMATCH" not in r.output
+        assert "No errors found" in r.output

--- a/dandi/tests/test_utils.py
+++ b/dandi/tests/test_utils.py
@@ -719,14 +719,14 @@ class TestFilterByIdPatterns:
         expected_ids: list[str],
     ) -> None:
         """Test filtering with various pattern combinations and edge cases."""
-        patterns = [re.compile(p) for p in pattern_strs]
+        patterns = {re.compile(p) for p in pattern_strs}
         filtered = filter_by_id_patterns(sample_validation_results, patterns)
         filtered_ids = [result.id for result in filtered]
         assert filtered_ids == expected_ids
 
     def test_empty_validation_results(self) -> None:
         """Test filtering with an empty validation results list."""
-        patterns = [re.compile(r".*")]
+        patterns = {re.compile(r".*")}
         filtered = filter_by_id_patterns([], patterns)
         assert filtered == []
 
@@ -734,6 +734,6 @@ class TestFilterByIdPatterns:
         self, sample_validation_results: list[ValidationResult]
     ) -> None:
         """Test that filtering preserves the original order of results."""
-        patterns = [re.compile(r".*")]
+        patterns = {re.compile(r".*")}
         filtered = filter_by_id_patterns(sample_validation_results, patterns)
         assert filtered == sample_validation_results

--- a/dandi/tests/test_utils.py
+++ b/dandi/tests/test_utils.py
@@ -603,7 +603,7 @@ def test_post_upload_size_check_erroring(
 
 
 class TestFilterByIdPatterns:
-    """Test the _filter_by_id_patterns function."""
+    """Test the filter_by_id_patterns function."""
 
     @pytest.fixture
     def sample_validation_results(self) -> list[ValidationResult]:

--- a/dandi/utils.py
+++ b/dandi/utils.py
@@ -24,7 +24,7 @@ import sys
 from time import sleep
 import traceback
 import types
-from typing import IO, Any, List, Optional, Protocol, TypeVar, Union
+from typing import IO, TYPE_CHECKING, Any, List, Optional, Protocol, TypeVar, Union
 
 import dateutil.parser
 from multidict import MultiDict  # dependency of yarl
@@ -37,6 +37,9 @@ from yarl import URL
 from . import __version__, get_logger
 from .consts import DandiInstance, known_instances, known_instances_rev
 from .exceptions import BadCliVersionError, CliVersionTooOldError
+
+if TYPE_CHECKING:
+    from .validate_types import ValidationResult
 
 AnyPath = Union[str, Path]
 
@@ -972,3 +975,29 @@ class StrEnum(str, Enum):
     @staticmethod
     def _generate_next_value_(name, _start, _count, _last_values):
         return name
+
+
+def filter_by_id_patterns(
+    validation_results: Iterable[ValidationResult], patterns: list[re.Pattern[str]]
+) -> list[ValidationResult]:
+    """
+    Filter validation results by matching their IDs against provided regex patterns.
+
+    Parameters
+    ----------
+    validation_results : Iterable[ValidationResult]
+        The iterable of validation results to filter.
+    patterns : list[re.Pattern[str]]
+        The list of regex patterns to match validation result IDs against.
+
+    Returns
+    -------
+    list[ValidationResult]
+        The filtered list of validation results whose IDs match any of the provided patterns.
+    """
+
+    filtered_results = []
+    for result in validation_results:
+        if any(re.search(pattern, result.id) for pattern in patterns):
+            filtered_results.append(result)
+    return filtered_results

--- a/dandi/utils.py
+++ b/dandi/utils.py
@@ -978,7 +978,7 @@ class StrEnum(str, Enum):
 
 
 def filter_by_id_patterns(
-    validation_results: Iterable[ValidationResult], patterns: list[re.Pattern[str]]
+    validation_results: Iterable[ValidationResult], patterns: set[re.Pattern]
 ) -> list[ValidationResult]:
     """
     Filter validation results by matching their IDs against provided regex patterns.
@@ -987,8 +987,8 @@ def filter_by_id_patterns(
     ----------
     validation_results : Iterable[ValidationResult]
         The iterable of validation results to filter.
-    patterns : list[re.Pattern[str]]
-        The list of regex patterns to match validation result IDs against.
+    patterns : set[re.Pattern]
+        The set of regex patterns to match validation result IDs against.
 
     Returns
     -------

--- a/docs/source/cmdline/validate.rst
+++ b/docs/source/cmdline/validate.rst
@@ -22,6 +22,13 @@ Options
     Ignore any validation errors & warnings whose ID matches the given regular
     expression
 
+.. option:: --match REGEX,REGEX,...
+
+    Comma-separated regex patterns used to filter issues in validation results by their
+    ID. Only issues with an ID matching at least one of the given patterns are included
+    in the eventual result. Note: The separator used to separate the patterns is a
+    comma (`,`), so no pattern should contain a comma.
+
 .. option:: --min-severity [HINT|WARNING|ERROR]
 
     Only display issues with severities above this level (HINT by default)

--- a/docs/source/cmdline/validate.rst
+++ b/docs/source/cmdline/validate.rst
@@ -33,7 +33,7 @@ Options
 
     Filter issues in the validation results to only those associated with the
     given path(s). A validation issue is associated with a path if its associated
-    path(s) are the same as or falls under the provided path. This option can be
+    path(s) are the same as or fall under the provided path. This option can be
     specified multiple times to include multiple paths.
 
 .. option:: --min-severity [HINT|WARNING|ERROR]

--- a/docs/source/cmdline/validate.rst
+++ b/docs/source/cmdline/validate.rst
@@ -29,6 +29,13 @@ Options
     in the eventual result. Note: The separator used to separate the patterns is a
     comma (`,`), so no pattern should contain a comma.
 
+.. option:: --include-path PATH
+
+    Filter issues in the validation results to only those associated with the
+    given path(s). A validation issue is associated with a path if its associated
+    path(s) are the same as or falls under the provided path. This option can be
+    specified multiple times to include multiple paths.
+
 .. option:: --min-severity [HINT|WARNING|ERROR]
 
     Only display issues with severities above this level (HINT by default)


### PR DESCRIPTION
This addresses checkpoint 2 of https://github.com/dandi/dandi-cli/issues/1597. It adds two options to `dandi validate` specified in the "Release Notes" section below.

TODO:

- [x] Decide whether to add or `minor` or `patch` label.
- [ ] ATM awaits for https://github.com/dandi/dandi-cli/pull/1822 to be merged first so it could operate on reloaded entrries


## Release Notes
The `dandi validate` now has two additional options

1. `--match` which takes in a list of comma-separated regex patterns to filter issues in validation results by their ID.
2. `--include-path` which takes in multiple paths to filter issues in the validation results to those associated with the paths.
