### PR TITLE
Set `dandischema` dependency to `0.12.0` and beyond

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     # >=8.2.0: https://github.com/pallets/click/issues/2911
     "click >= 7.1, <8.2.0",
     "click-didyoumean",
-    "dandischema >= 0.12.0, < 0.13.0",
+    "dandischema ~= 0.12.0",
     "etelemetry >= 0.2.2",
     # For pydantic to be able to use type annotations like `X | None`
     "eval_type_backport; python_version < '3.10'",


### PR DESCRIPTION
See individual commit message for details.

The CIs can only pass only if 
- [x] https://github.com/dandi/dandi-schema/pull/294 is released
- [ ] https://github.com/dandi/dandi-archive/pull/2584 is released