### PR TITLE
Update GitHub CI MacOS intel runner

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -33,7 +33,7 @@ jobs:
           - windows-latest
           - ubuntu-latest
           - macos-latest  # M1 architecture
-          - macos-13  # non-M1 architecture
+          - macos-15-intel  # non-M1 architecture
         python:
           - 3.9  # Reaching EOL in October 2025
           - '3.10'  # Needs quotes so YAML doesn't think it's 3.1


### PR DESCRIPTION
The `macos-13` runner, an Intel architecture runner, is [deprecated](https://github.com/actions/runner-images). This commit replace it with the latest Intel architecture runner for MacOS.

As of now, jobs assigned to a `macos-13` are cancelled.

<img width="1265" height="639" alt="Screenshot 2025-11-18 at 10 46 47 PM" src="https://github.com/user-attachments/assets/a844fd3d-128b-4a67-886d-81e204c3580c" />

