### PR TITLE
BF: strip away any prefix before ":" while determining numeric dandiset identifier

### DIFF
--- a/dandi/dandiset.py
+++ b/dandi/dandiset.py
@@ -141,7 +141,7 @@ class Dandiset:
             assert isinstance(id_, str)
             # result of https://github.com/dandi/dandi-cli/pull/348 which ???
             # TODO: RF to avoid this evil!!!
-            id_ = id_.split(":")[-1]
+            id_ = id_.split(":", maxsplit=1)[-1]
 
         assert id_ is None or isinstance(id_, str)
         return id_


### PR DESCRIPTION
We have it confusing, as the identifier in the client model is just the numeric part. We should have called it differently from the metadata model identifier. 

That original code which added those divergences though seemed tried to make meditor possible:
- https://github.com/dandi/dandi-cli/pull/348

Without this fix, we get confusing

```shell
❯ dandi upload -i dandi-sandbox
2025-11-21 14:52:43,287 [    INFO] Logs saved in /home/yoh/.local/state/dandi-cli/log/2025.11.21-19.52.42Z-110471.log
Error: Dandiset identifier DANDI-SANDBOX:217838 does not follow expected convention '^[0-9]{6}$'.
```

which accents such divergence of definition of "identifier".  If we just remove stripping away the prefix, then upload stalls while retrying and getting 500s from the server (nothing in dandi-cli logs was useful to point to the issue).

TODOs:
- [x] figure out why it was not failing before on our original tests against client?