### PR TITLE
Add dependency versions to pytest header output

### DIFF
--- a/dandi/pytest_plugin.py
+++ b/dandi/pytest_plugin.py
@@ -52,7 +52,7 @@ def pytest_report_header(config: Config) -> list[str]:
         try:
             version_str = f"-{version(pkg)}"
         except PackageNotFoundError:
-            version_str = " missing"
+            version_str = " NOT INSTALLED"
         versions.append(f"{pkg}{version_str}")
 
     return [f"dependencies: {', '.join(versions)}"] if versions else []


### PR DESCRIPTION
Prompted by inability to understand what is going on in dandi-archive testing against dandi-cli ATM -- my suspect using old image of some kind.

@dandi/archive-maintainers may be we should adopt such construct project wide? 
As all projects depend on dandi-schema, may be that is where I should move it (and may be other helpers for testing?) then?

Display versions of all project dependencies in pytest test session header, similar to how plugins are displayed. Shows packages in sorted order with their installed versions, or " missing" if declared but not installed.

Uses importlib.metadata to discover dependencies from package metadata, with fallback to key packages (dandischema, h5py, hdmf) if metadata unavailable. Fixed typing to handle None return from requires().

🤖 Generated with [Claude Code](https://claude.com/claude-code)