### PR TITLE
bf(tests): pass DBUS_SESSION_BUS_ADDRESS env var for docker

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = lint,typing,py3
 setenv =
     DANDI_ALLOW_LOCALHOST_URLS=1
     DANDI_PAGINATION_DISABLE_FALLBACK=1
-passenv = DANDI_*,USER
+passenv = DANDI_*,USER,DBUS_SESSION_BUS_ADDRESS
 extras =
     extras
     test


### PR DESCRIPTION
Otherwise we observe

  error getting credentials - err: exit status 1, out: `Cannot autolaunch D-Bus without X11 $DISPLAY`

when running undex tox.

FWIW, shouldn't help 

- #1762 

since that one is not done via tox.