### PR TITLE
Improve help message for the `--validation` option in `dandi upload`

### DIFF
--- a/dandi/cli/cmd_upload.py
+++ b/dandi/cli/cmd_upload.py
@@ -39,7 +39,11 @@ from ..upload import UploadExisting, UploadValidation
 )
 @click.option(
     "--validation",
-    help="Data must pass validation before the upload.  Use of this option is highly discouraged.",
+    help="Controls validation requirements before upload. (Setting this option to a "
+    "value other than 'require' is highly discouraged.) "
+    "'require' - data must pass validation before upload; "
+    "'skip' - no validation is performed on data before upload; "
+    "'ignore' - data is validated but upload proceeds regardless of validation results.",
     type=click.Choice(list(UploadValidation)),
     default="require",
     show_default=True,


### PR DESCRIPTION
This PR improves help message for the `--validation` option in `dandi upload`.

### Reviewer notes:

The meaning of the choice to [ignore](https://github.com/dandi/dandi-cli/blob/35011905a73d86aa13a54eb5fc1d1a038cc792ae/dandi/upload.py#L88) validation is unclear. In fact, the [choice](https://github.com/dandi/dandi-cli/blob/35011905a73d86aa13a54eb5fc1d1a038cc792ae/dandi/upload.py#L88) is not used in the production code. I made an educated guess on the meaning of the choice in constructing the help message.

