### PR TITLE
Update EMBER-DANDI Sandbox API URL

### DIFF
--- a/dandi/cli/tests/test_instances.py
+++ b/dandi/cli/tests/test_instances.py
@@ -24,7 +24,7 @@ def test_cmd_instances(monkeypatch):
         "  gui: https://dandi.emberarchive.org\n"
         "ember-dandi-sandbox:\n"
         "  api: https://api-dandi.sandbox.emberarchive.org/api\n"
-        "  gui: https://apl-setup--ember-dandi-archive.netlify.app/\n"
+        "  gui: https://apl-setup--ember-dandi-archive.netlify.app\n"
         "linc:\n"
         "  api: https://api.lincbrain.org/api\n"
         "  gui: https://lincbrain.org\n"

--- a/dandi/cli/tests/test_instances.py
+++ b/dandi/cli/tests/test_instances.py
@@ -23,7 +23,7 @@ def test_cmd_instances(monkeypatch):
         "  api: https://api-dandi.emberarchive.org/api\n"
         "  gui: https://dandi.emberarchive.org\n"
         "ember-dandi-sandbox:\n"
-        "  api: https://api-dandi-sandbox.emberarchive.org/api\n"
+        "  api: https://api-dandi.sandbox.emberarchive.org/api\n"
         "  gui: https://apl-setup--ember-dandi-archive.netlify.app/\n"
         "linc:\n"
         "  api: https://api.lincbrain.org/api\n"

--- a/dandi/consts.py
+++ b/dandi/consts.py
@@ -150,7 +150,7 @@ known_instances = {
     ),
     "ember-dandi-sandbox": DandiInstance(
         "ember-dandi-sandbox",
-        "https://apl-setup--ember-dandi-archive.netlify.app/",
+        "https://apl-setup--ember-dandi-archive.netlify.app",
         "https://api-dandi.sandbox.emberarchive.org/api",
     ),
 }

--- a/dandi/consts.py
+++ b/dandi/consts.py
@@ -151,7 +151,7 @@ known_instances = {
     "ember-dandi-sandbox": DandiInstance(
         "ember-dandi-sandbox",
         "https://apl-setup--ember-dandi-archive.netlify.app/",
-        "https://api-dandi-sandbox.emberarchive.org/api",
+        "https://api-dandi.sandbox.emberarchive.org/api",
     ),
 }
 # to map back url: name

--- a/docs/source/cmdline/instances.rst
+++ b/docs/source/cmdline/instances.rst
@@ -29,7 +29,7 @@ Example output:
       api: https://api.lincbrain.org/api
       gui: https://lincbrain.org
     ember-dandi-sandbox:
-      api: https://api-dandi-sandbox.emberarchive.org/api
+      api: https://api-dandi.sandbox.emberarchive.org/api
       gui: https://apl-setup--ember-dandi-archive.netlify.app/
     ember-dandi:
       api: https://api-dandi.emberarchive.org/api

--- a/docs/source/cmdline/instances.rst
+++ b/docs/source/cmdline/instances.rst
@@ -30,7 +30,7 @@ Example output:
       gui: https://lincbrain.org
     ember-dandi-sandbox:
       api: https://api-dandi.sandbox.emberarchive.org/api
-      gui: https://apl-setup--ember-dandi-archive.netlify.app/
+      gui: https://apl-setup--ember-dandi-archive.netlify.app
     ember-dandi:
       api: https://api-dandi.emberarchive.org/api
       gui: https://dandi.emberarchive.org


### PR DESCRIPTION
Previously was https://api-dandi-sandbox.emberarchive.org/  
Now is https://api-dandi.sandbox.emberarchive.org/