### PR TITLE
Revert "Demand prior releases of h5py for OSX on non-arm"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,9 +53,6 @@ dependencies = [
 
     "fasteners",
     "fscacher >= 0.3.0",
-    # Workaround for no wheels for intel OSX as of 3.15
-    "h5py<3.15 ; sys_platform == 'darwin' and platform_machine != 'arm64'",
-    "h5py ; sys_platform != 'darwin' or platform_machine == 'arm64'",
     # 3.14.4: https://github.com/hdmf-dev/hdmf/issues/1186
     "hdmf != 3.5.0,!=3.14.4",
     "humanize",


### PR DESCRIPTION
This reverts commit cd5fbb0a08dad43854f6e29189b91ccca0fb78c9.

This reverts the constraint added in cd5fbb0a which restricted h5py to versions <3.15 on Intel macOS based on the assumption that "no whls [were] built any longer".

However, h5py 3.15.0 (released Oct 13, 2025) and 3.15.1 (released Oct 16, 2025) both include pre-built wheels for Intel macOS (x86_64) for all supported Python versions (3.10-3.14).

The overly restrictive constraint caused CI test failures starting Jan 19, 2026 when the macos-15-intel GitHub Actions runner image was updated (version 20260120.0127.1). The same commit (ccdb659) passed on Jan 18 but failed on Jan 19, indicating an environmental incompatibility with the old h5py versions on the new runner.

Fixes failing CI build #21127100740 (macos-15-intel CI failures)