### PR TITLE
Fix type annotation in upload sync path prefix calculation

### DIFF
--- a/dandi/upload.py
+++ b/dandi/upload.py
@@ -4,7 +4,6 @@ from collections import defaultdict
 from collections.abc import Iterator, Sequence
 from contextlib import ExitStack
 from enum import Enum
-from functools import reduce
 import io
 import os.path
 from pathlib import Path
@@ -493,7 +492,7 @@ def upload(
             for p in paths:
                 rp = os.path.relpath(p, dandiset.path)
                 relpaths.append("" if rp == "." else rp)
-            path_prefix = reduce(os.path.commonprefix, relpaths)  # type: ignore[arg-type]
+            path_prefix = os.path.commonprefix(relpaths)
             to_delete = []
             for asset in remote_dandiset.get_assets_with_path_prefix(path_prefix):
                 if any(


### PR DESCRIPTION
Fixes incorrect use of reduce() in upload.py by using os.path.commonprefix() directly, improving code clarity and removing unnecessary type: ignore comment.

## Problem
The code used `reduce(os.path.commonprefix, relpaths)` which is incorrect because:
- `reduce` expects a binary function that takes two arguments
- `os.path.commonprefix` already accepts a list/sequence of paths

## Solution
Replace with direct call: `os.path.commonprefix(relpaths)`

This is the correct usage since os.path.commonprefix is designed to take a list of paths and return the longest common prefix.

## Changes
- Removed incorrect `reduce()` usage
- Removed `from functools import reduce` (no longer needed)
- Removed `# type: ignore[arg-type]` comment

## Benefits
- Clearer, more correct code
- Removes one unnecessary type: ignore comment
- Uses standard library function as intended

## Files Changed
- `dandi/upload.py`

## Testing
Verified with full test suite: 548 passed, 0 failed.
Sync functionality tested in integration tests (require Docker).

Note: This PR may have minor conflicts with #<PR4> and #<PR9> if those haven't merged yet. All three modify upload.py but in different sections.

See commit: 649d7565

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
