### PR TITLE
bf: pass aiohttp timeouts to fsspec to fix test hang

### DIFF
--- a/dandi/tests/test_metadata.py
+++ b/dandi/tests/test_metadata.py
@@ -1145,6 +1145,7 @@ def test_nwb2asset(simple2_nwb: Path) -> None:
     )
 
 
+@pytest.mark.timeout(120)
 @pytest.mark.xfail(reason="https://github.com/dandi/dandi-cli/issues/1450")
 def test_nwb2asset_remote_asset(nwb_dandiset: SampleDandiset) -> None:
     pytest.importorskip("fsspec")


### PR DESCRIPTION
## Summary

Fix the indefinite hang in `test_nwb2asset_remote_asset` that has been blocking dandi-archive CLI integration tests since November 24, 2025.

## Root cause

`RemoteReadableAsset.open()` calls `fsspec.open(url)` with **no socket-level timeouts**.  When h5py reads an NWB file through fsspec's HTTP backend, the call chain is:

```
nwb2asset() → get_metadata() → _get_pynwb_metadata()
  → open_readable() → RemoteReadableAsset.open()
    → fsspec.open(url).open()          # aiohttp, no timeout
      → h5py.File(fp) + NWBHDF5IO     # holds HDF5 global lock
```

This creates conditions for a deadlock documented in h5py/h5py#2019:
- h5py holds a **global lock** while reading from the Python file object
- fsspec's `sync()` blocks the calling thread in `threading.Event.wait()` waiting for the aiohttp coroutine
- aiohttp has **no default socket timeout** (aio-libs/aiohttp#11740), so a stalled connection blocks forever
- GC running during this window can deadlock with h5py's lock

## Why it surfaced on November 24

Analysis of [tinuous CI logs](https://github.com/con/tinuous/) for dandi-archive showed:

| Date | dandi-cli | dandischema | test result |
|------|-----------|-------------|-------------|
| Nov 21 | 0.73.2+5 (8492260) | `>= 0.11.1, < 0.12.0` | **XFAIL in 0.4s** |
| Nov 24 | 0.73.2+11 (fa3ce1e) | `~= 0.12.0` | **hung 6 hours** |

With dandischema 0.11.x, the test hit a quick model validation mismatch (XFAIL before reaching fsspec).  PR #1744 updated to dandischema 0.12.0 (vendor-configurable models, schema 0.7.0), which fixed that mismatch — so the test now reaches the fsspec HTTP read, which hangs.

Additionally, dandi-cli's `tox.ini` global `--timeout=300` is **not read** when tests run from the dandi-archive rootdir via `pytest --pyargs dandi`.

## Changes

- a6109be `bf: pass aiohttp timeouts to fsspec in RemoteReadableAsset.open()`
  - Passes `ClientTimeout(total=120, sock_read=60, sock_connect=30)` so stalled connections raise `TimeoutError` instead of blocking forever
- 166324a `bf(test): add timeout to test_nwb2asset_remote_asset to prevent CI hang`
  - Adds `@pytest.mark.timeout(120)` as belt-and-suspenders (works regardless of rootdir config)

## Companion change

dandi-archive `cli-integration.yml` will also add `--timeout=300` to the pytest command line and remove the `-k "not test_nwb2asset_remote_asset"` exclusion — but that needs a **new dandi-cli release** containing these fixes for the `release` matrix variant to pick them up.

## References

- #1762 — Archive-CLI integration tests hanging forever
- #1450 — test_nwb2asset_remote_asset timed out
- https://github.com/fsspec/filesystem_spec/issues/1666 — BytesCache fetcher stall
- h5py/h5py#2019 — Deadlock from h5py + GC + file-like objects
- aio-libs/aiohttp#11740 — ClientSession hanging despite timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)
