### PR TITLE
Fix git-bug sync workflow: bridge configure → bridge new

### DIFF
--- a/.github/workflows/sync-git-bug.yml
+++ b/.github/workflows/sync-git-bug.yml
@@ -35,12 +35,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git-bug bridge configure \
+          git-bug bridge new \
             --name=github \
             --target=github \
             --owner=dandi \
             --project=dandi-cli \
-            --token="$GH_TOKEN"
+            --token="$GH_TOKEN" \
+            --non-interactive
 
       - name: Pull issues from GitHub
         run: git-bug bridge pull github


### PR DESCRIPTION
The `bridge configure` subcommand was renamed to `bridge new` in git-bug v0.10.x. Also add --non-interactive flag for CI.