### PR TITLE
Populate per-asset dataStandard for BIDS, HED, NWB, and extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ sandbox/
 venv/
 venvs/
 .DS_Store
+uv.lock

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Prefer specific exceptions over generic ones
 - For CLI, use click library patterns
 - Imports organized: stdlib, third-party, local (alphabetical within groups)
+- **Imports must be at the top of the file** — do NOT place imports inside
+  functions or methods unless there is a concrete reason (circular dependency,
+  or heavy transitive imports like `pynwb`/`h5py`/`nwbinspector` that would
+  slow down module load for unrelated code paths).  When deferring an import
+  for weight, add the comment `# Avoid heavy import by importing within function:`.
 
 ## Documentation
 - Keep docstrings updated when changing function signatures

--- a/dandi/files/bases.py
+++ b/dandi/files/bases.py
@@ -505,7 +505,28 @@ class NWBAsset(LocalFileAsset):
                 raise
         metadata.path = self.path
         if "dataStandard" in BareAsset.model_fields:
-            nwb = StandardsType(**nwb_standard)
+            kwargs: dict[str, Any] = dict(nwb_standard)
+            # Populate NWB extensions (ndx-*) if the schema supports it
+            if "extensions" in StandardsType.model_fields:
+                from dandi.pynwb_utils import get_nwb_extensions
+
+                try:
+                    nwb_exts = get_nwb_extensions(self.filepath)
+                except Exception:
+                    lgr.debug(
+                        "Failed to extract NWB extensions from %s",
+                        self.filepath,
+                        exc_info=True,
+                    )
+                    nwb_exts = {}
+                if nwb_exts:
+                    kwargs["extensions"] = [
+                        StandardsType(name=name, version=ver).model_dump(
+                            mode="json", exclude_none=True
+                        )
+                        for name, ver in sorted(nwb_exts.items())
+                    ]
+            nwb = StandardsType(**kwargs)
             if metadata.dataStandard is None:
                 metadata.dataStandard = [nwb]
             elif nwb not in metadata.dataStandard:

--- a/dandi/files/bases.py
+++ b/dandi/files/bases.py
@@ -21,6 +21,20 @@ from dandischema.models import Dandiset as DandisetMeta
 from dandischema.models import StandardsType, get_schema_version, nwb_standard
 from packaging.version import Version
 from pydantic import ValidationError
+
+# True when the installed dandischema exposes the per-asset dataStandard field
+# and related StandardsType enhancements (version, extensions).  All these
+# fields ship together starting with dandischema 0.12.2.
+# TODO: remove this guard (and all branches that check it) once the minimum
+# required dandischema version is >= 0.12.2.
+_SCHEMA_BAREASSET_HAS_DATASTANDARD = "dataStandard" in BareAsset.model_fields
+if not _SCHEMA_BAREASSET_HAS_DATASTANDARD and Version(
+    dandischema.__version__
+) >= Version("0.12.2"):
+    raise RuntimeError(
+        f"dandischema {dandischema.__version__} should have "
+        f"'dataStandard' field on BareAsset"
+    )
 from pydantic_core import ErrorDetails
 import requests
 
@@ -504,28 +518,27 @@ class NWBAsset(LocalFileAsset):
             else:
                 raise
         metadata.path = self.path
-        if "dataStandard" in BareAsset.model_fields:
+        if _SCHEMA_BAREASSET_HAS_DATASTANDARD:
             kwargs: dict[str, Any] = dict(nwb_standard)
-            # Populate NWB extensions (ndx-*) if the schema supports it
-            if "extensions" in StandardsType.model_fields:
-                from dandi.pynwb_utils import get_nwb_extensions
+            # Populate NWB extensions (ndx-*) from the h5 specifications group
+            from dandi.pynwb_utils import get_nwb_extensions
 
-                try:
-                    nwb_exts = get_nwb_extensions(self.filepath)
-                except Exception:
-                    lgr.debug(
-                        "Failed to extract NWB extensions from %s",
-                        self.filepath,
-                        exc_info=True,
+            try:
+                nwb_exts = get_nwb_extensions(self.filepath)
+            except Exception:
+                lgr.debug(
+                    "Failed to extract NWB extensions from %s",
+                    self.filepath,
+                    exc_info=True,
+                )
+                nwb_exts = {}
+            if nwb_exts:
+                kwargs["extensions"] = [
+                    StandardsType(name=name, version=ver).model_dump(
+                        mode="json", exclude_none=True
                     )
-                    nwb_exts = {}
-                if nwb_exts:
-                    kwargs["extensions"] = [
-                        StandardsType(name=name, version=ver).model_dump(
-                            mode="json", exclude_none=True
-                        )
-                        for name, ver in sorted(nwb_exts.items())
-                    ]
+                    for name, ver in sorted(nwb_exts.items())
+                ]
             nwb = StandardsType(**kwargs)
             if metadata.dataStandard is None:
                 metadata.dataStandard = [nwb]

--- a/dandi/files/bases.py
+++ b/dandi/files/bases.py
@@ -18,7 +18,7 @@ from dandischema.consts import DANDI_SCHEMA_VERSION
 from dandischema.digests.dandietag import DandiETag
 from dandischema.models import BareAsset, CommonModel
 from dandischema.models import Dandiset as DandisetMeta
-from dandischema.models import get_schema_version
+from dandischema.models import StandardsType, get_schema_version, nwb_standard
 from packaging.version import Version
 from pydantic import ValidationError
 from pydantic_core import ErrorDetails
@@ -504,6 +504,12 @@ class NWBAsset(LocalFileAsset):
             else:
                 raise
         metadata.path = self.path
+        if "dataStandard" in BareAsset.model_fields:
+            nwb = StandardsType(**nwb_standard)
+            if metadata.dataStandard is None:
+                metadata.dataStandard = [nwb]
+            elif nwb not in metadata.dataStandard:
+                metadata.dataStandard.append(nwb)
         return metadata
 
     # TODO: @validate_cache.memoize_path

--- a/dandi/files/bases.py
+++ b/dandi/files/bases.py
@@ -520,7 +520,7 @@ class NWBAsset(LocalFileAsset):
         metadata.path = self.path
         if _SCHEMA_BAREASSET_HAS_DATASTANDARD:
             kwargs: dict[str, Any] = dict(nwb_standard)
-            # Populate NWB extensions (ndx-*) from the h5 specifications group
+            # Avoid heavy import by importing within function:
             from dandi.pynwb_utils import get_nwb_extensions
 
             try:

--- a/dandi/files/bases.py
+++ b/dandi/files/bases.py
@@ -521,8 +521,10 @@ class NWBAsset(LocalFileAsset):
         if _SCHEMA_BAREASSET_HAS_DATASTANDARD:
             kwargs: dict[str, Any] = dict(nwb_standard)
             # Avoid heavy import by importing within function:
-            from dandi.pynwb_utils import get_nwb_extensions
+            from dandi.pynwb_utils import get_nwb_extensions, get_nwb_version
 
+            if nwb_ver := get_nwb_version(self.filepath):
+                kwargs["version"] = nwb_ver
             try:
                 nwb_exts = get_nwb_extensions(self.filepath)
             except Exception:

--- a/dandi/files/bases.py
+++ b/dandi/files/bases.py
@@ -21,20 +21,6 @@ from dandischema.models import Dandiset as DandisetMeta
 from dandischema.models import StandardsType, get_schema_version, nwb_standard
 from packaging.version import Version
 from pydantic import ValidationError
-
-# True when the installed dandischema exposes the per-asset dataStandard field
-# and related StandardsType enhancements (version, extensions).  All these
-# fields ship together starting with dandischema 0.12.2.
-# TODO: remove this guard (and all branches that check it) once the minimum
-# required dandischema version is >= 0.12.2.
-_SCHEMA_BAREASSET_HAS_DATASTANDARD = "dataStandard" in BareAsset.model_fields
-if not _SCHEMA_BAREASSET_HAS_DATASTANDARD and Version(
-    dandischema.__version__
-) >= Version("0.12.2"):
-    raise RuntimeError(
-        f"dandischema {dandischema.__version__} should have "
-        f"'dataStandard' field on BareAsset"
-    )
 from pydantic_core import ErrorDetails
 import requests
 
@@ -54,6 +40,20 @@ from dandi.validate._types import (
     ValidationResult,
     Validator,
 )
+
+# True when the installed dandischema exposes the per-asset dataStandard field
+# and related StandardsType enhancements (version, extensions).  All these
+# fields ship together starting with dandischema 0.12.2.
+# TODO: remove this guard (and all branches that check it) once the minimum
+# required dandischema version is >= 0.12.2.
+_SCHEMA_BAREASSET_HAS_DATASTANDARD = "dataStandard" in BareAsset.model_fields
+if not _SCHEMA_BAREASSET_HAS_DATASTANDARD and Version(
+    dandischema.__version__
+) >= Version("0.12.2"):
+    raise RuntimeError(
+        f"dandischema {dandischema.__version__} should have "
+        f"'dataStandard' field on BareAsset"
+    )
 
 lgr = dandi.get_logger()
 
@@ -534,16 +534,18 @@ class NWBAsset(LocalFileAsset):
                 nwb_exts = {}
             if nwb_exts:
                 kwargs["extensions"] = [
-                    StandardsType(name=name, version=ver).model_dump(
+                    StandardsType(name=name, version=ver).model_dump(  # type: ignore[call-arg]
                         mode="json", exclude_none=True
                     )
                     for name, ver in sorted(nwb_exts.items())
                 ]
             nwb = StandardsType(**kwargs)
-            if metadata.dataStandard is None:
-                metadata.dataStandard = [nwb]
-            elif nwb not in metadata.dataStandard:
-                metadata.dataStandard.append(nwb)
+            # TODO: use metadata.dataStandard directly once min dandischema >= 0.12.2
+            cur = getattr(metadata, "dataStandard", None)
+            if cur is None:
+                setattr(metadata, "dataStandard", [nwb])
+            elif nwb not in cur:
+                cur.append(nwb)
         return metadata
 
     # TODO: @validate_cache.memoize_path

--- a/dandi/files/bids.py
+++ b/dandi/files/bids.py
@@ -12,7 +12,6 @@ from dandischema.models import (
     BareAsset,
     StandardsType,
     bids_standard,
-    hed_standard,
     ome_ngff_standard,
 )
 
@@ -20,6 +19,11 @@ import dandi
 from dandi.bids_validator_deno import bids_validate
 
 from .bases import GenericAsset, LocalFileAsset, NWBAsset, _SCHEMA_BAREASSET_HAS_DATASTANDARD
+
+if _SCHEMA_BAREASSET_HAS_DATASTANDARD:
+    from dandischema.models import hed_standard
+else:
+    hed_standard = None  # type: ignore[assignment]
 from .zarr import ZarrAsset
 from ..consts import ZARR_MIME_TYPE, dandiset_metadata_file
 from ..metadata.core import add_common_metadata, prepare_metadata
@@ -234,7 +238,7 @@ class BIDSDatasetDescriptionAsset(LocalFileAsset):
             _add_standard(metadata, bids_standard)
             return metadata
         _add_standard(metadata, bids_standard, version=desc.get("BIDSVersion"))
-        if hed_version := desc.get("HEDVersion"):
+        if hed_standard and (hed_version := desc.get("HEDVersion")):
             # HEDVersion can be a string or list.
             # List form: ["8.2.0", "sc:1.0.0"] where first element is base
             # HED version and subsequent "prefix:version" entries are library

--- a/dandi/files/bids.py
+++ b/dandi/files/bids.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from threading import Lock
 import weakref
 
-from dandischema import __version__ as dandischema_version
 from dandischema.models import (
     BareAsset,
     StandardsType,
@@ -16,12 +15,11 @@ from dandischema.models import (
     hed_standard,
     ome_ngff_standard,
 )
-from packaging.version import Version
 
 import dandi
 from dandi.bids_validator_deno import bids_validate
 
-from .bases import GenericAsset, LocalFileAsset, NWBAsset
+from .bases import GenericAsset, LocalFileAsset, NWBAsset, _SCHEMA_BAREASSET_HAS_DATASTANDARD
 from .zarr import ZarrAsset
 from ..consts import ZARR_MIME_TYPE, dandiset_metadata_file
 from ..metadata.core import add_common_metadata, prepare_metadata
@@ -38,24 +36,17 @@ lgr = dandi.get_logger()
 BIDS_ASSET_ERRORS = ("BIDS.NON_BIDS_PATH_PLACEHOLDER",)
 BIDS_DATASET_ERRORS = ("BIDS.MANDATORY_FILE_MISSING_PLACEHOLDER",)
 
-_HAS_DATA_STANDARD = "dataStandard" in BareAsset.model_fields
-if not _HAS_DATA_STANDARD and Version(dandischema_version) >= Version("0.12.2"):
-    raise RuntimeError(
-        f"dandischema {dandischema_version} should have "
-        f"'dataStandard' field on BareAsset"
-    )
-
 
 def _add_standard(
-    metadata: BareAsset,
+    metadata,  # type: ignore[no-untyped-def]
     standard_dict: dict,
     version: str | None = None,
 ) -> None:
     """Add a data standard to asset metadata if the field is available."""
-    if not _HAS_DATA_STANDARD:
+    if not _SCHEMA_BAREASSET_HAS_DATASTANDARD:
         return
     kwargs = dict(standard_dict)
-    if version and "version" in StandardsType.model_fields:
+    if version:
         kwargs["version"] = version
     standard = StandardsType(**kwargs)
     if metadata.dataStandard is None:
@@ -255,12 +246,9 @@ class BIDSDatasetDescriptionAsset(LocalFileAsset):
                 version = hed_version
                 library_entries = []
             kwargs: dict = dict(hed_standard)
-            if version and "version" in StandardsType.model_fields:
+            if version:
                 kwargs["version"] = version
-            if (
-                library_entries
-                and "extensions" in StandardsType.model_fields
-            ):
+            if library_entries:
                 extensions = []
                 for entry in library_entries:
                     # Format is "prefix:version" (e.g. "sc:1.0.0")

--- a/dandi/files/bids.py
+++ b/dandi/files/bids.py
@@ -244,12 +244,37 @@ class BIDSDatasetDescriptionAsset(LocalFileAsset):
             return metadata
         _add_standard(metadata, bids_standard, version=desc.get("BIDSVersion"))
         if hed_version := desc.get("HEDVersion"):
-            # HEDVersion can be a string or list; use first element as version
+            # HEDVersion can be a string or list.
+            # List form: ["8.2.0", "sc:1.0.0"] where first element is base
+            # HED version and subsequent "prefix:version" entries are library
+            # schemas recorded as extensions.
             if isinstance(hed_version, list):
                 version = hed_version[0] if hed_version else None
+                library_entries = hed_version[1:]
             else:
                 version = hed_version
-            _add_standard(metadata, hed_standard, version=version)
+                library_entries = []
+            kwargs: dict = dict(hed_standard)
+            if version and "version" in StandardsType.model_fields:
+                kwargs["version"] = version
+            if (
+                library_entries
+                and "extensions" in StandardsType.model_fields
+            ):
+                extensions = []
+                for entry in library_entries:
+                    # Format is "prefix:version" (e.g. "sc:1.0.0")
+                    if ":" in str(entry):
+                        lib_name, lib_ver = str(entry).split(":", 1)
+                    else:
+                        lib_name, lib_ver = str(entry), None
+                    ext = StandardsType(name=lib_name, version=lib_ver)
+                    extensions.append(
+                        ext.model_dump(mode="json", exclude_none=True)
+                    )
+                if extensions:
+                    kwargs["extensions"] = extensions
+            _add_standard(metadata, kwargs)
         return metadata
 
 

--- a/dandi/files/bids.py
+++ b/dandi/files/bids.py
@@ -18,10 +18,15 @@ from dandischema.models import (
 import dandi
 from dandi.bids_validator_deno import bids_validate
 
-from .bases import GenericAsset, LocalFileAsset, NWBAsset, _SCHEMA_BAREASSET_HAS_DATASTANDARD
+from .bases import (
+    _SCHEMA_BAREASSET_HAS_DATASTANDARD,
+    GenericAsset,
+    LocalFileAsset,
+    NWBAsset,
+)
 
 if _SCHEMA_BAREASSET_HAS_DATASTANDARD:
-    from dandischema.models import hed_standard
+    from dandischema.models import hed_standard  # type: ignore[attr-defined]
 else:
     hed_standard = None  # type: ignore[assignment]
 from .zarr import ZarrAsset
@@ -42,7 +47,7 @@ BIDS_DATASET_ERRORS = ("BIDS.MANDATORY_FILE_MISSING_PLACEHOLDER",)
 
 
 def _add_standard(
-    metadata,  # type: ignore[no-untyped-def]
+    metadata: BareAsset,
     standard_dict: dict,
     version: str | None = None,
 ) -> None:
@@ -53,10 +58,12 @@ def _add_standard(
     if version:
         kwargs["version"] = version
     standard = StandardsType(**kwargs)
-    if metadata.dataStandard is None:
-        metadata.dataStandard = [standard]
-    elif standard not in metadata.dataStandard:
-        metadata.dataStandard.append(standard)
+    # TODO: use metadata.dataStandard directly once min dandischema >= 0.12.2
+    cur = getattr(metadata, "dataStandard", None)
+    if cur is None:
+        setattr(metadata, "dataStandard", [standard])
+    elif standard not in cur:
+        cur.append(standard)
 
 
 @dataclass
@@ -260,10 +267,8 @@ class BIDSDatasetDescriptionAsset(LocalFileAsset):
                         lib_name, lib_ver = str(entry).split(":", 1)
                     else:
                         lib_name, lib_ver = str(entry), None
-                    ext = StandardsType(name=lib_name, version=lib_ver)
-                    extensions.append(
-                        ext.model_dump(mode="json", exclude_none=True)
-                    )
+                    ext = StandardsType(name=lib_name, version=lib_ver)  # type: ignore[call-arg]
+                    extensions.append(ext.model_dump(mode="json", exclude_none=True))
                 if extensions:
                     kwargs["extensions"] = extensions
             _add_standard(metadata, kwargs)

--- a/dandi/files/bids.py
+++ b/dandi/files/bids.py
@@ -3,12 +3,22 @@ from __future__ import annotations
 from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime
+import json
 from pathlib import Path
 from threading import Lock
 import weakref
 
-from dandischema.models import BareAsset
+from dandischema import __version__ as dandischema_version
+from dandischema.models import (
+    BareAsset,
+    StandardsType,
+    bids_standard,
+    hed_standard,
+    ome_ngff_standard,
+)
+from packaging.version import Version
 
+import dandi
 from dandi.bids_validator_deno import bids_validate
 
 from .bases import GenericAsset, LocalFileAsset, NWBAsset
@@ -23,8 +33,35 @@ from ..validate._types import (
     ValidationResult,
 )
 
+lgr = dandi.get_logger()
+
 BIDS_ASSET_ERRORS = ("BIDS.NON_BIDS_PATH_PLACEHOLDER",)
 BIDS_DATASET_ERRORS = ("BIDS.MANDATORY_FILE_MISSING_PLACEHOLDER",)
+
+_HAS_DATA_STANDARD = "dataStandard" in BareAsset.model_fields
+if not _HAS_DATA_STANDARD and Version(dandischema_version) >= Version("0.12.2"):
+    raise RuntimeError(
+        f"dandischema {dandischema_version} should have "
+        f"'dataStandard' field on BareAsset"
+    )
+
+
+def _add_standard(
+    metadata: BareAsset,
+    standard_dict: dict,
+    version: str | None = None,
+) -> None:
+    """Add a data standard to asset metadata if the field is available."""
+    if not _HAS_DATA_STANDARD:
+        return
+    kwargs = dict(standard_dict)
+    if version and "version" in StandardsType.model_fields:
+        kwargs["version"] = version
+    standard = StandardsType(**kwargs)
+    if metadata.dataStandard is None:
+        metadata.dataStandard = [standard]
+    elif standard not in metadata.dataStandard:
+        metadata.dataStandard.append(standard)
 
 
 @dataclass
@@ -192,7 +229,28 @@ class BIDSDatasetDescriptionAsset(LocalFileAsset):
         assert self._dataset_errors is not None
         return self._dataset_errors.copy()
 
-    # get_metadata(): inherit use of default metadata from LocalFileAsset
+    def get_metadata(
+        self,
+        digest: Digest | None = None,
+        ignore_errors: bool = True,
+    ) -> BareAsset:
+        metadata = super().get_metadata(digest=digest, ignore_errors=ignore_errors)
+        try:
+            with open(self.filepath) as f:
+                desc = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            lgr.warning("Failed to read %s: %s", self.filepath, e)
+            _add_standard(metadata, bids_standard)
+            return metadata
+        _add_standard(metadata, bids_standard, version=desc.get("BIDSVersion"))
+        if hed_version := desc.get("HEDVersion"):
+            # HEDVersion can be a string or list; use first element as version
+            if isinstance(hed_version, list):
+                version = hed_version[0] if hed_version else None
+            else:
+                version = hed_version
+            _add_standard(metadata, hed_standard, version=version)
+        return metadata
 
 
 @dataclass
@@ -312,6 +370,8 @@ class ZarrBIDSAsset(ZarrAsset, BIDSAsset):
         add_common_metadata(metadata, self.filepath, start_time, end_time, digest)
         metadata.path = self.path
         metadata.encodingFormat = ZARR_MIME_TYPE
+        if Path(self.path).suffixes == [".ome", ".zarr"]:
+            _add_standard(metadata, ome_ngff_standard)
         return metadata
 
 

--- a/dandi/pynwb_utils.py
+++ b/dandi/pynwb_utils.py
@@ -152,6 +152,49 @@ def get_nwb_version(
     return None
 
 
+# Namespaces bundled with NWB/HDMF core — not extensions
+_NWB_CORE_NAMESPACES = frozenset({"core", "hdmf-common", "hdmf-experimental"})
+
+
+def get_nwb_extensions(filepath: str | Path | Readable) -> dict[str, str]:
+    """Return NWB extensions embedded in an HDF5 file.
+
+    Reads the ``specifications`` group of an NWB HDF5 file and returns a
+    mapping of extension namespace names to their latest embedded version,
+    excluding core NWB/HDMF namespaces.
+
+    Parameters
+    ----------
+    filepath
+        Path to an NWB ``.nwb`` HDF5 file, or a :class:`Readable`.
+
+    Returns
+    -------
+    dict[str, str]
+        ``{namespace_name: latest_version}`` for each non-core namespace
+        found in the file's ``specifications`` group.  Empty dict if no
+        extensions are present or the group does not exist.
+    """
+    extensions: dict[str, str] = {}
+    with open_readable(filepath) as fp, h5py.File(fp, "r") as h5file:
+        specs = h5file.get("specifications")
+        if specs is None:
+            return extensions
+        for name in specs:
+            if name in _NWB_CORE_NAMESPACES:
+                continue
+            ns_group = specs[name]
+            if not isinstance(ns_group, h5py.Group):
+                continue
+            try:
+                sorted_versions = sorted(ns_group, key=Version)
+                if sorted_versions:
+                    extensions[name] = sorted_versions[-1]
+            except Exception:
+                lgr.debug("Failed to parse versions for NWB extension %s", name)
+    return extensions
+
+
 def get_neurodata_types_to_modalities_map() -> dict[str, str]:
     """Return a dict to map neurodata types known to pynwb to "modalities"
 

--- a/dandi/tests/test_files.py
+++ b/dandi/tests/test_files.py
@@ -684,3 +684,33 @@ class TestBIDSDatasetDescriptionDataStandard:
         )
         names = self._standard_names(asset.get_metadata())
         assert "Hierarchical Event Descriptors (HED)" in names
+
+    def test_hed_library_schemas_as_extensions(self, tmp_path: Path) -> None:
+        """HED library schemas in list HEDVersion populate extensions."""
+        from dandischema.models import BareAsset, StandardsType
+
+        if "extensions" not in StandardsType.model_fields:
+            pytest.skip("dandischema too old, no extensions on StandardsType")
+        if "dataStandard" not in BareAsset.model_fields:
+            pytest.skip("dandischema too old, no dataStandard on BareAsset")
+        asset = self._make_bids_dd(
+            tmp_path,
+            {
+                "Name": "Test",
+                "BIDSVersion": "1.9.0",
+                "HEDVersion": ["8.2.0", "sc:1.0.0", "lang:1.1.0"],
+            },
+        )
+        metadata = asset.get_metadata()
+        hed_standards = [
+            s for s in (metadata.dataStandard or [])
+            if s.name == "Hierarchical Event Descriptors (HED)"
+        ]
+        assert len(hed_standards) == 1
+        hed = hed_standards[0]
+        assert hed.version == "8.2.0"
+        assert hed.extensions is not None
+        ext_names = {e.name for e in hed.extensions}
+        assert ext_names == {"sc", "lang"}
+        ext_map = {e.name: e.version for e in hed.extensions}
+        assert ext_map == {"sc": "1.0.0", "lang": "1.1.0"}

--- a/dandi/tests/test_files.py
+++ b/dandi/tests/test_files.py
@@ -641,9 +641,9 @@ class TestBIDSDatasetDescriptionDataStandard:
 
     @staticmethod
     def _standard_names(metadata):  # type: ignore[no-untyped-def]
-        from dandischema.models import BareAsset
+        from ..files.bases import _SCHEMA_BAREASSET_HAS_DATASTANDARD
 
-        if "dataStandard" not in BareAsset.model_fields:
+        if not _SCHEMA_BAREASSET_HAS_DATASTANDARD:
             pytest.skip("dandischema too old, no dataStandard on BareAsset")
         return [s.name for s in (metadata.dataStandard or [])]
 
@@ -687,11 +687,9 @@ class TestBIDSDatasetDescriptionDataStandard:
 
     def test_hed_library_schemas_as_extensions(self, tmp_path: Path) -> None:
         """HED library schemas in list HEDVersion populate extensions."""
-        from dandischema.models import BareAsset, StandardsType
+        from ..files.bases import _SCHEMA_BAREASSET_HAS_DATASTANDARD
 
-        if "extensions" not in StandardsType.model_fields:
-            pytest.skip("dandischema too old, no extensions on StandardsType")
-        if "dataStandard" not in BareAsset.model_fields:
+        if not _SCHEMA_BAREASSET_HAS_DATASTANDARD:
             pytest.skip("dandischema too old, no dataStandard on BareAsset")
         asset = self._make_bids_dd(
             tmp_path,

--- a/dandi/tests/test_files.py
+++ b/dandi/tests/test_files.py
@@ -621,3 +621,66 @@ def test_validate_invalid_zarr3(path: str, expected_result_ids: set[str]) -> Non
 
     result_ids = {r.id for r in zf.get_validation_errors()}
     assert result_ids == expected_result_ids
+
+
+@pytest.mark.ai_generated
+class TestBIDSDatasetDescriptionDataStandard:
+    """Tests for per-asset dataStandard population from dataset_description.json"""
+
+    @staticmethod
+    def _make_bids_dd(tmp_path: Path, content: dict) -> BIDSDatasetDescriptionAsset:
+        import json
+
+        dd_path = tmp_path / "dataset_description.json"
+        dd_path.write_text(json.dumps(content))
+        return BIDSDatasetDescriptionAsset(
+            filepath=dd_path,
+            path="dataset_description.json",
+            dandiset_path=tmp_path,
+        )
+
+    @staticmethod
+    def _standard_names(metadata):  # type: ignore[no-untyped-def]
+        from dandischema.models import BareAsset
+
+        if "dataStandard" not in BareAsset.model_fields:
+            pytest.skip("dandischema too old, no dataStandard on BareAsset")
+        return [s.name for s in (metadata.dataStandard or [])]
+
+    def test_bids_always_set(self, tmp_path: Path) -> None:
+        asset = self._make_bids_dd(
+            tmp_path,
+            {"Name": "Test", "BIDSVersion": "1.9.0"},
+        )
+        names = self._standard_names(asset.get_metadata())
+        assert "Brain Imaging Data Structure (BIDS)" in names
+
+    def test_hed_detected_when_hedversion_present(self, tmp_path: Path) -> None:
+        asset = self._make_bids_dd(
+            tmp_path,
+            {"Name": "Test", "BIDSVersion": "1.9.0", "HEDVersion": "8.2.0"},
+        )
+        names = self._standard_names(asset.get_metadata())
+        assert "Hierarchical Event Descriptors (HED)" in names
+        assert "Brain Imaging Data Structure (BIDS)" in names
+
+    def test_hed_not_detected_when_hedversion_absent(self, tmp_path: Path) -> None:
+        asset = self._make_bids_dd(
+            tmp_path,
+            {"Name": "Test", "BIDSVersion": "1.9.0"},
+        )
+        names = self._standard_names(asset.get_metadata())
+        assert "Hierarchical Event Descriptors (HED)" not in names
+
+    def test_hed_detected_with_list_hedversion(self, tmp_path: Path) -> None:
+        """HEDVersion can be a list of strings per BIDS spec."""
+        asset = self._make_bids_dd(
+            tmp_path,
+            {
+                "Name": "Test",
+                "BIDSVersion": "1.9.0",
+                "HEDVersion": ["8.2.0", "sc:1.0.0"],
+            },
+        )
+        names = self._standard_names(asset.get_metadata())
+        assert "Hierarchical Event Descriptors (HED)" in names

--- a/dandi/tests/test_files.py
+++ b/dandi/tests/test_files.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from operator import attrgetter
 import os
 from pathlib import Path
@@ -16,6 +17,7 @@ from .. import get_logger
 from ..consts import ZARR_MIME_TYPE, dandiset_metadata_file
 from ..dandiapi import AssetType, RemoteZarrAsset
 from ..exceptions import UnknownAssetError
+from ..files.bases import _SCHEMA_BAREASSET_HAS_DATASTANDARD
 from ..files import (
     BIDSDatasetDescriptionAsset,
     DandisetMetadataFile,
@@ -629,8 +631,6 @@ class TestBIDSDatasetDescriptionDataStandard:
 
     @staticmethod
     def _make_bids_dd(tmp_path: Path, content: dict) -> BIDSDatasetDescriptionAsset:
-        import json
-
         dd_path = tmp_path / "dataset_description.json"
         dd_path.write_text(json.dumps(content))
         return BIDSDatasetDescriptionAsset(
@@ -641,8 +641,6 @@ class TestBIDSDatasetDescriptionDataStandard:
 
     @staticmethod
     def _standard_names(metadata):  # type: ignore[no-untyped-def]
-        from ..files.bases import _SCHEMA_BAREASSET_HAS_DATASTANDARD
-
         if not _SCHEMA_BAREASSET_HAS_DATASTANDARD:
             pytest.skip("dandischema too old, no dataStandard on BareAsset")
         return [s.name for s in (metadata.dataStandard or [])]
@@ -687,8 +685,6 @@ class TestBIDSDatasetDescriptionDataStandard:
 
     def test_hed_library_schemas_as_extensions(self, tmp_path: Path) -> None:
         """HED library schemas in list HEDVersion populate extensions."""
-        from ..files.bases import _SCHEMA_BAREASSET_HAS_DATASTANDARD
-
         if not _SCHEMA_BAREASSET_HAS_DATASTANDARD:
             pytest.skip("dandischema too old, no dataStandard on BareAsset")
         asset = self._make_bids_dd(

--- a/dandi/tests/test_files.py
+++ b/dandi/tests/test_files.py
@@ -17,7 +17,6 @@ from .. import get_logger
 from ..consts import ZARR_MIME_TYPE, dandiset_metadata_file
 from ..dandiapi import AssetType, RemoteZarrAsset
 from ..exceptions import UnknownAssetError
-from ..files.bases import _SCHEMA_BAREASSET_HAS_DATASTANDARD
 from ..files import (
     BIDSDatasetDescriptionAsset,
     DandisetMetadataFile,
@@ -31,6 +30,7 @@ from ..files import (
     dandi_file,
     find_dandi_files,
 )
+from ..files.bases import _SCHEMA_BAREASSET_HAS_DATASTANDARD
 
 lgr = get_logger()
 
@@ -697,7 +697,9 @@ class TestBIDSDatasetDescriptionDataStandard:
         )
         metadata = asset.get_metadata()
         hed_standards = [
-            s for s in (metadata.dataStandard or [])
+            # TODO: use metadata.dataStandard directly once min dandischema >= 0.12.2
+            s
+            for s in (getattr(metadata, "dataStandard", None) or [])
             if s.name == "Hierarchical Event Descriptors (HED)"
         ]
         assert len(hed_standards) == 1

--- a/dandi/tests/test_pynwb_utils.py
+++ b/dandi/tests/test_pynwb_utils.py
@@ -103,3 +103,42 @@ def test_nwb_has_external_links(tmp_path):
 
     assert not nwb_has_external_links(filename1)
     assert nwb_has_external_links(filename4)
+
+
+def test_get_nwb_extensions(tmp_path: Path) -> None:
+    """Test extraction of NWB extensions from HDF5 specifications group."""
+    import h5py
+
+    from ..pynwb_utils import get_nwb_extensions
+
+    h5path = tmp_path / "test.nwb"
+    with h5py.File(h5path, "w") as f:
+        specs = f.create_group("specifications")
+        # Core namespaces should be excluded
+        core_grp = specs.create_group("core")
+        core_grp.create_group("2.7.0")
+        hdmf_grp = specs.create_group("hdmf-common")
+        hdmf_grp.create_group("1.8.0")
+        # An extension namespace should be included, latest version used
+        ndx_ecog = specs.create_group("ndx-ecog")
+        ndx_ecog.create_group("0.1.0")
+        ndx_ecog.create_group("0.2.0")
+        # Another extension
+        ndx_events = specs.create_group("ndx-events")
+        ndx_events.create_group("0.3.0")
+
+    result = get_nwb_extensions(h5path)
+    assert result == {"ndx-ecog": "0.2.0", "ndx-events": "0.3.0"}
+
+
+def test_get_nwb_extensions_no_specs(tmp_path: Path) -> None:
+    """No specifications group returns empty dict."""
+    import h5py
+
+    from ..pynwb_utils import get_nwb_extensions
+
+    h5path = tmp_path / "test.nwb"
+    with h5py.File(h5path, "w") as f:
+        f.attrs["nwb_version"] = "2.7.0"
+
+    assert get_nwb_extensions(h5path) == {}

--- a/dandi/tests/test_pynwb_utils.py
+++ b/dandi/tests/test_pynwb_utils.py
@@ -6,10 +6,11 @@ from pathlib import Path
 import re
 from typing import Any, NoReturn
 
+import h5py
 import numpy as np
 from pynwb import NWBHDF5IO, NWBFile, TimeSeries
 
-from ..pynwb_utils import _sanitize_nwb_version, nwb_has_external_links
+from ..pynwb_utils import _sanitize_nwb_version, get_nwb_extensions, nwb_has_external_links
 
 
 def test_pynwb_io(simple1_nwb: Path) -> None:
@@ -107,10 +108,6 @@ def test_nwb_has_external_links(tmp_path):
 
 def test_get_nwb_extensions(tmp_path: Path) -> None:
     """Test extraction of NWB extensions from HDF5 specifications group."""
-    import h5py
-
-    from ..pynwb_utils import get_nwb_extensions
-
     h5path = tmp_path / "test.nwb"
     with h5py.File(h5path, "w") as f:
         specs = f.create_group("specifications")
@@ -133,10 +130,6 @@ def test_get_nwb_extensions(tmp_path: Path) -> None:
 
 def test_get_nwb_extensions_no_specs(tmp_path: Path) -> None:
     """No specifications group returns empty dict."""
-    import h5py
-
-    from ..pynwb_utils import get_nwb_extensions
-
     h5path = tmp_path / "test.nwb"
     with h5py.File(h5path, "w") as f:
         f.attrs["nwb_version"] = "2.7.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     # >=8.2.0: https://github.com/pallets/click/issues/2911
     "click >= 7.1, <8.2.0",
     "click-didyoumean",
-    "dandischema ~= 0.12.0",
+    "dandischema @ git+https://github.com/dandi/dandi-schema.git@enh-hed",
     "etelemetry >= 0.2.2",
 
     "fasteners",


### PR DESCRIPTION
## Summary

- Populate per-asset `dataStandard` field (new in dandischema) for all standards:
  - **BIDS**: from `dataset_description.json` with `BIDSVersion`
  - **HED**: from `HEDVersion` in `dataset_description.json`, including library schemas (e.g. `"sc:1.0.0"`) as `extensions`
  - **NWB**: from NWB file metadata, with ndx-* extensions extracted from `h5file["specifications"]` group
  - **OME/NGFF**: for `.ome.zarr` assets in BIDS datasets
- Centralize backward-compat guard as `_SCHEMA_BAREASSET_HAS_DATASTANDARD` in `bases.py` — single bool gates all new dandischema features (dataStandard, version, extensions), with RuntimeError if dandischema >= 0.12.2 unexpectedly lacks the field
- Add `get_nwb_extensions()` to `pynwb_utils.py` — reads HDF5 `specifications` group, filters core namespaces, returns `{name: latest_version}` for each extension
- All new code is no-op against released dandischema (< 0.12.2)

## Test plan

- [x] `TestBIDSDatasetDescriptionDataStandard` — 5 tests covering BIDS always set, HED detected/absent, HED list form, HED library schemas as extensions
- [x] `test_get_nwb_extensions` — verifies ndx-* extraction with version sorting, core namespace filtering
- [x] `test_get_nwb_extensions_no_specs` — empty dict when no specifications group
- [x] 460 tests pass with dev dandischema, 426 pass with released dandischema 0.12.1 (new feature tests correctly skip)
- [ ] TODO1: add matrix run to test against dandi-schema#371, and then remove that or do it properly as a dedicated run based on description here annotation

PR in dandi-schema:
- https://github.com/dandi/dandi-schema/pull/371

🤖 Generated with [Claude Code](https://claude.com/claude-code)
