### PR TITLE
doc: enforce 80-char line wrap in Markdown docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,24 +1,30 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Claude Code (claude.ai/code) when working
+with code in this repository.
 
 ## Build/Test Commands
-- Run tests: `tox -e py3` but should also work with just `python -m pytest dandi` if in a venv
-- Tests which require an instance of the archive, would use a fixture to start on using docker-compose.
-- Set env var `DANDI_TESTS_PULL_DOCKER_COMPOSE=""` (to empty value) to avoid `docker compose pull` to speed up repetitive runs
-- Run single test: `tox r -e py3 -- dandi/tests/test_file.py::test_function -v`
+- Run tests: `tox -e py3` but should also work with just
+  `python -m pytest dandi` if in a venv
+- Tests which require an instance of the archive, would use a fixture to
+  start on using docker-compose.
+- Set env var `DANDI_TESTS_PULL_DOCKER_COMPOSE=""` (to empty value) to
+  avoid `docker compose pull` to speed up repetitive runs
+- Run single test:
+  `tox r -e py3 -- dandi/tests/test_file.py::test_function -v`
 - Lint and type checking: `tox -e lint,typing`
-- Install pre-commit hooks (if not installed as could be indicated by absence of
-  `.git/hooks/pre-commit`): `pre-commit install`
+- Install pre-commit hooks (if not installed as could be indicated by
+  absence of `.git/hooks/pre-commit`): `pre-commit install`
 
 ## Committing
-- Due to use of `pre-commit` with black and other commands which auto-fix, if changes
-  were reported to be done, just rerun commit again 2nd time, and if only then if still
-  does not commit analyze output more
+- Due to use of `pre-commit` with black and other commands which auto-fix,
+  if changes were reported to be done, just rerun commit again 2nd time,
+  and if only then if still does not commit analyze output more
 
 ## Test Markers
 - When adding AI-generated tests, mark them with `@pytest.mark.ai_generated`
-- Any new pytest markers must be registered in `pytest_configure` function of `dandi/pytest_plugin.py`
+- Any new pytest markers must be registered in `pytest_configure` function
+  of `dandi/pytest_plugin.py`
 
 ## Code Style
 - Code is formatted with Black (line length 100)
@@ -35,15 +41,17 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Documentation
 - Keep docstrings updated when changing function signatures
 - CLI help text should be clear and include examples where appropriate
+- Wrap all Markdown and other human-readable documentation files at
+  80 characters per line
 
 ## Issue Tracking with git-bug
-This project has GitHub issues synced locally via git-bug.  Use these commands
-to get issue context without needing GitHub API access:
+This project has GitHub issues synced locally via git-bug.  Use these
+commands to get issue context without needing GitHub API access:
 - `git bug ls status:open` - list open issues
 - `git bug show <id-prefix>` - show issue details and comments
 - `git bug ls "title:keyword"` - search issues by title
 - `git bug ls "label:bug"` - filter by label
 - `git bug bridge pull` - sync latest issues from GitHub
 
-When working on a bug fix or feature, check `git bug ls` for related issues
-to understand context and prior discussion.
+When working on a bug fix or feature, check `git bug ls` for related
+issues to understand context and prior discussion.


### PR DESCRIPTION
## Summary

- Add instruction to CLAUDE.md to wrap all Markdown and human-readable
  documentation files at 80 characters per line, for better readability
  in terminals, editors, and side-by-side diffs.
- Reformat CLAUDE.md itself to comply with the new rule.

## Test plan

- [x] CLAUDE.md updated with the new documentation guideline
- [x] CLAUDE.md reformatted to 80-char line width

🤖 Generated with [Claude Code](https://claude.com/claude-code)