### PR TITLE
Remove no-op `DANDI_ALLOW_LOCALHOST_URLS` from test configs

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,7 +22,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       NO_ET: 1
-      DANDI_ALLOW_LOCALHOST_URLS: "1"
       DANDI_PAGINATION_DISABLE_FALLBACK: "1"
       DANDI_TESTS_PERSIST_DOCKER_COMPOSE: "1"
     strategy:

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ envlist = lint,typing,py3
 
 [testenv]
 setenv =
-    DANDI_ALLOW_LOCALHOST_URLS=1
     DANDI_PAGINATION_DISABLE_FALLBACK=1
 passenv = DANDI_*,USER,DBUS_SESSION_BUS_ADDRESS
 extras =


### PR DESCRIPTION
## Summary

- `DANDI_ALLOW_LOCALHOST_URLS` was consumed by the dandi-archive Django
  server to permit `localhost` URLs in asset `contentUrl` fields during
  testing (where assets are stored in a local MinIO instance).
- It was removed from the test `docker-compose.yml` in commit 09c1b758
  when dandi-archive switched to `dandiapi.settings.development`, which
  allows localhost URLs by default — making this variable a no-op.
- Removes the now-dead setting from `tox.ini` and
  `.github/workflows/run-tests.yml`.

## Test plan

- [x] Verified the variable is no longer referenced in
  `docker-compose.yml` (removed in 09c1b758)
- [x] CI passes without the variable set

🤖 Generated with [Claude Code](https://claude.com/claude-code)