### PR TITLE
Fix broken external_file paths when organizing on Windows

### DIFF
--- a/dandi/organize.py
+++ b/dandi/organize.py
@@ -18,6 +18,7 @@ from copy import deepcopy
 from enum import Enum
 import os
 import os.path as op
+import posixpath
 from pathlib import Path, PurePosixPath
 import re
 import traceback
@@ -275,7 +276,7 @@ def _create_external_file_names(metadata: list[dict]) -> list[dict]:
             renamed_path_list = []
             uuid_str = ext_file_dict.get("id", str(uuid.uuid4()))
             for no, ext_file in enumerate(ext_file_dict["external_files"]):
-                renamed = op.join(
+                renamed = posixpath.join(
                     nwb_folder_name, f"{uuid_str}_external_file_{no}{ext_file.suffix}"
                 )
                 renamed_path_list.append(renamed)

--- a/dandi/pynwb_utils.py
+++ b/dandi/pynwb_utils.py
@@ -408,8 +408,8 @@ def _get_image_series(nwb: pynwb.NWBFile) -> list[dict]:
             if isinstance(ob, pynwb.image.ImageSeries) and ob.external_file is not None:
                 out_dict = dict(id=ob.object_id, name=ob.name, external_files=[])
                 for ext_file in ob.external_file:
-                    if PurePosixPath(ext_file).suffix in VIDEO_FILE_EXTENSIONS:
-                        out_dict["external_files"].append(PurePosixPath(ext_file))
+                    if (path := PurePosixPath(ext_file)).suffix in VIDEO_FILE_EXTENSIONS:
+                        out_dict["external_files"].append(path)
                     else:
                         lgr.warning(
                             "external file %s should be one of: %s",

--- a/dandi/pynwb_utils.py
+++ b/dandi/pynwb_utils.py
@@ -17,7 +17,7 @@ from datetime import timedelta
 import inspect
 import os
 import os.path as op
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 import re
 from typing import IO, Any, TypeVar, cast
 import warnings
@@ -408,8 +408,8 @@ def _get_image_series(nwb: pynwb.NWBFile) -> list[dict]:
             if isinstance(ob, pynwb.image.ImageSeries) and ob.external_file is not None:
                 out_dict = dict(id=ob.object_id, name=ob.name, external_files=[])
                 for ext_file in ob.external_file:
-                    if Path(ext_file).suffix in VIDEO_FILE_EXTENSIONS:
-                        out_dict["external_files"].append(Path(ext_file))
+                    if PurePosixPath(ext_file).suffix in VIDEO_FILE_EXTENSIONS:
+                        out_dict["external_files"].append(PurePosixPath(ext_file))
                     else:
                         lgr.warning(
                             "external file %s should be one of: %s",

--- a/dandi/tests/test_organize.py
+++ b/dandi/tests/test_organize.py
@@ -353,6 +353,10 @@ def test_video_organize(
             for ext_file_ob in ext_file_objects:
                 for no, name in enumerate(ext_file_ob["external_files"]):
                     video_files_organized.append(name)
+                    # Regression: external_file paths are DANDI/S3 keys,
+                    # must use forward slashes even on Windows.
+                    # See https://github.com/catalystneuro/nwb-video-widgets/issues/33
+                    assert "\\" not in str(name)
                     # check if external_file arguments are correctly named according to convention:
                     filename = Path(
                         f"{vid_folder.name}/{ext_file_ob['id']}_external_file_{no}"


### PR DESCRIPTION
When `dandi organize --update-external-file-paths` runs on Windows, the `external_file` paths written into NWB files use backslashes instead of forward slashes.

Expected:
```
ses-2026-02-12-1_image/21b52ce3_external_file_0.mp4
```

On Windows before this fix:
```
ses-2026-02-12-1_image\21b52ce3_external_file_0.mp4
```

Downstream tools expecting forward slashes (as DANDI/S3 asset keys always use) fail silently when resolving these paths against the archive. This was observed in Dandiset 001771 and reported in [catalystneuro/nwb-video-widgets#33](https://github.com/catalystneuro/nwb-video-widgets/issues/33), where `get_dandi_video_info()` returned empty results. A defensive workaround was merged in [catalystneuro/nwb-video-widgets#38](https://github.com/catalystneuro/nwb-video-widgets/pull/38), but the root cause is here in `dandi organize`.

The fix has two parts:

- **Write side** (`organize.py`): `_create_external_file_names()` used `os.path.join` to build external file paths. On Windows that produces backslashes. Replaced with `posixpath.join` since these are DANDI/S3 keys, not local filesystem paths.
- **Read side** (`pynwb_utils.py`): `_get_image_series()` wrapped external file strings in `Path()`, which on Windows converts forward slashes back to backslashes. Replaced with `PurePosixPath`.

I have also added a regression assertion in `test_video_organize` that `external_file` values never contain backslashes. The initial push included only the write-side fix; Windows CI caught that `Path()` on the read side was re-introducing backslashes, confirming the assertion works as intended.
