### PR TITLE
BF: Pin rabbitmq image to 4.2-management in test docker-compose

### DIFF
--- a/dandi/tests/data/dandiarchive-docker/docker-compose.yml
+++ b/dandi/tests/data/dandiarchive-docker/docker-compose.yml
@@ -105,6 +105,6 @@ services:
       retries: 5
 
   rabbitmq:
-    image: rabbitmq:management
+    image: rabbitmq:4.2-management
     expose:
       - "5672"


### PR DESCRIPTION
The dandiarchive test stack used the floating tag `rabbitmq:management`, which began resolving to RabbitMQ 4.3.0 on 2026-04-24. CI runs started to fail. Workaround -- pin to 4.2-management to restore the previously-green behavior.

Claude's unverified analytics:

RabbitMQ 4.3.0 no longer permits `transient_nonexcl_queues` by default, which celery/kombu still relies on. The celery container crash-looped, assets stayed in "Pending" validation, and all Linux test jobs failed (e.g. test_publish_and_manipulate, test_get_dandiset_published*) even on unchanged master commits.