### PR TITLE
RF: Derive LocalZarrEntry.filepath from zarr_basepath and parts

### DIFF
--- a/dandi/files/zarr.py
+++ b/dandi/files/zarr.py
@@ -275,10 +275,13 @@ def _ts_validate_zarr3_array(
 class LocalZarrEntry(BasePath):
     """A file or directory within a `ZarrAsset`"""
 
-    #: The path to the actual file or directory on disk
-    filepath: Path
     #: The path to the root of the Zarr file tree
     zarr_basepath: Path
+
+    @property
+    def filepath(self) -> Path:
+        """The path to the actual file or directory on disk"""
+        return self.zarr_basepath.joinpath(*self.parts)
 
     def _get_subpath(self, name: str) -> LocalZarrEntry:
         if not name or "/" in name:
@@ -288,16 +291,14 @@ class LocalZarrEntry(BasePath):
         elif name == "..":
             return self.parent
         else:
-            return replace(
-                self, filepath=self.filepath / name, parts=self.parts + (name,)
-            )
+            return replace(self, parts=self.parts + (name,))
 
     @property
     def parent(self) -> LocalZarrEntry:
         if self.is_root():
             return self
         else:
-            return replace(self, filepath=self.filepath.parent, parts=self.parts[:-1])
+            return replace(self, parts=self.parts[:-1])
 
     def exists(self) -> bool:
         return os.path.lexists(self.filepath)
@@ -390,9 +391,7 @@ class ZarrAsset(LocalDirectoryAsset[LocalZarrEntry]):
         The `LocalZarrEntry` for the root of the hierarchy of files within the
         Zarr asset
         """
-        return LocalZarrEntry(
-            filepath=self.filepath, zarr_basepath=self.filepath, parts=()
-        )
+        return LocalZarrEntry(zarr_basepath=self.filepath, parts=())
 
     def stat(self) -> ZarrStat:
         """Return various details about the Zarr asset"""


### PR DESCRIPTION
## Summary

`LocalZarrEntry` previously stored both `filepath` and `(zarr_basepath, parts)` — two representations of the entry's position within the zarr, kept in sync only by convention inside `_get_subpath` and `parent`. This PR makes `filepath` a `@property` derived as `zarr_basepath.joinpath(*parts)`, so the two states can no longer disagree. Internally the only direct construction site, `ZarrAsset.filetree`, drops its now-redundant `filepath=` argument.

## Compatibility

`LocalZarrEntry` is exported in `dandi.files`, so external code could in principle depend on `filepath` being a dataclass field. A GitHub code search suggests this is unlikely in practice:

- `gh search code 'LocalZarrEntry'` returns only one match outside this repo (`tushkum34-cloud/pylibsmeta`), and it is an auto-generated JSON snapshot of public-symbol metadata — not source code that uses the class.
- `gh search code 'LocalZarrEntry('` finds zero direct constructor calls outside this repo.
- Attribute reads (`entry.filepath`) remain source-compatible with a property; only callers that pass `filepath=` to the constructor or use `dataclasses.replace(entry, filepath=...)` would be affected, and none were found.

Private/unindexed code cannot be ruled out, but the realistic exposure surface is very small.

## Verification

- `tox -e lint,typing` — pass.
- `hatch run test:run dandi/tests/test_files.py -k "zarr or Zarr"` — 14 passed.

## Release Notes

Refactor `LocalZarrEntry` so `filepath` is derived from `zarr_basepath` and `parts` instead of being stored separately, eliminating the possibility of internal inconsistency between the two representations.