### PR TITLE
Allow test server to be provided externally

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -156,6 +156,13 @@ for a rendered example.
   tests will not pull the latest needed Docker images at the start of a run if
   older versions of the images are already present.
 
+- `DANDI_TESTS_API_URL` -- When set, the integration tests will run against this
+  externally-managed dandi-archive API URL instead of starting a local Docker
+  Compose stack.  Requires `DANDI_TESTS_DJANGO_API_KEY` to also be set.
+
+- `DANDI_TESTS_DJANGO_API_KEY` -- Admin DRF token for the externally-managed
+  server pointed to by `DANDI_TESTS_API_URL`; required when the latter is set.
+
 - `DANDI_TESTS_NO_VCR` — When set, the use of vcrpy to playback captured HTTP
   requests during testing will be disabled
 

--- a/dandi/tests/fixtures.py
+++ b/dandi/tests/fixtures.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterator
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 import logging
 import os
@@ -373,6 +373,20 @@ LOCAL_DOCKER_ENV = LOCAL_DOCKER_DIR.name
 @pytest.fixture(scope="session")
 def docker_compose_setup() -> Iterator[dict[str, str]]:
     skipif.no_network()
+
+    if external_url := os.environ.get("DANDI_TESTS_API_URL"):
+        api_key = os.environ.get("DANDI_TESTS_DJANGO_API_KEY")
+        if not api_key:
+            raise RuntimeError(
+                "DANDI_TESTS_API_URL is set but DANDI_TESTS_DJANGO_API_KEY is not; "
+                "set it to a valid admin DRF token for the externally-managed server."
+            )
+        known_instances["dandi-api-local-docker-tests"] = replace(
+            known_instances["dandi-api-local-docker-tests"], api=external_url
+        )
+        yield {"django_api_key": api_key}
+        return
+
     skipif.no_docker_engine()
 
     # Check that we're running on a Unix-based system (Linux or macOS), as the


### PR DESCRIPTION
This adds support for an optional `DANDI_TESTS_API_URL` environment variable, which if set, will cause the integration test suite to connect to that external server and not boot up a Docker Compose stack. If `DANDI_TESTS_API_URL` is set, then `DANDI_TESTS_DJANGO_API_KEY` must also be set.

This makes it possible to run the CLI integration tests more without having to build a Docker image of the API server, allowing simpler validation of any existing running server against the CLI.