### PR TITLE
Add support for updated error text upon Zarr name conflicts

### DIFF
--- a/dandi/files/zarr.py
+++ b/dandi/files/zarr.py
@@ -590,7 +590,10 @@ class ZarrAsset(LocalDirectoryAsset[LocalZarrEntry]):
                     json={"name": asset_path, "dandiset": dandiset.identifier},
                 )
             except requests.HTTPError as e:
-                if e.response is not None and "Zarr already exists" in e.response.text:
+                if e.response is not None and (
+                    "Zarr already exists" in e.response.text
+                    or "dandiset, name must make a unique set" in e.response.text
+                ):
                     lgr.warning(
                         "%s: Found pre-existing Zarr at same path not"
                         " associated with any asset; reusing",


### PR DESCRIPTION
Newer versions of the DANDI API will return a different error text when a duplicate Zarr (same name, same dandiset) is created. This is due to more rigorous early checking by Django Rest Framework and cannot easily be changed.

This ensures that any version of the API is supported, as the old error text is still matched too.