### PR TITLE
BF: Add timeout to follow_redirect HEAD requests; retry on Timeout

### DIFF
--- a/dandi/consts.py
+++ b/dandi/consts.py
@@ -236,5 +236,10 @@ REQUEST_RETRIES = 12
 
 DOWNLOAD_TIMEOUT = 30
 
+#: Per-request timeout (seconds) for HEAD requests issued by
+#: ``follow_redirect`` while resolving a redirect chain.  Without it,
+#: requests hangs indefinitely on a stalled hop (observed on Windows CI).
+REDIRECT_HEAD_TIMEOUT = 30
+
 #: Suffix used for temporary download directories
 DOWNLOAD_SUFFIX = ".dandidownload"

--- a/dandi/dandiarchive.py
+++ b/dandi/dandiarchive.py
@@ -44,6 +44,7 @@ from . import get_logger
 from .consts import (
     DANDISET_ID_REGEX,
     PUBLISHED_VERSION_REGEX,
+    REDIRECT_HEAD_TIMEOUT,
     RETRY_STATUSES,
     VERSION_REGEX,
     DandiInstance,
@@ -896,12 +897,18 @@ class _dandi_url_parser:
         """
         max_attempts = 5
 
-        connection_error: requests.ConnectionError | None = None
+        # ConnectionError covers DNS / TCP-level failures (and ConnectTimeout);
+        # Timeout additionally covers ReadTimeout, which we observe on Windows
+        # CI when a hop in the redirect chain accepts the connection but never
+        # responds.  Without this, requests.head() blocks indefinitely.
+        connection_error: requests.RequestException | None = None
         resp: requests.Response | None = None
         for attempt_idx in range(max_attempts):
             try:
-                resp = requests.head(url, allow_redirects=True)
-            except requests.ConnectionError as e:
+                resp = requests.head(
+                    url, allow_redirects=True, timeout=REDIRECT_HEAD_TIMEOUT
+                )
+            except (requests.ConnectionError, requests.Timeout) as e:
                 # we frequently get those on Windows for some reason
 
                 lgr.warning(

--- a/dandi/tests/test_dandiarchive.py
+++ b/dandi/tests/test_dandiarchive.py
@@ -456,7 +456,7 @@ def test_follow_redirect_retry_on_connection_error() -> None:
     # Mock requests.head to raise ConnectionError first 2 times, then succeed
     call_count = 0
 
-    def mock_head(url, allow_redirects=True):
+    def mock_head(url, allow_redirects=True, timeout=None):
         nonlocal call_count
         call_count += 1
         if call_count <= 2:
@@ -479,13 +479,44 @@ def test_follow_redirect_exhausted_retries_on_connection_error() -> None:
     test_url = "https://example.com/test"
 
     # Mock requests.head to always raise ConnectionError
-    def mock_head(url, allow_redirects=True):
+    def mock_head(url, allow_redirects=True, timeout=None):
         raise requests.ConnectionError("Connection failed")
 
     with patch("dandi.dandiarchive.requests.head", side_effect=mock_head):
         with patch("dandi.dandiarchive.sleep"):  # Mock sleep to speed up test
             with pytest.raises(FailedToConnectError, match=r"failed with \d+ attempts"):
                 follow_redirect(test_url)
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        requests.ReadTimeout("Read timed out"),
+        requests.ConnectTimeout("Connect timed out"),
+    ],
+)
+def test_follow_redirect_retry_on_timeout(exc: requests.Timeout) -> None:
+    """Test that follow_redirect retries on requests.Timeout and eventually succeeds."""
+    test_url = "https://example.com/test"
+    expected_url = "https://example.com/redirected"
+
+    call_count = 0
+
+    def mock_head(url, allow_redirects=True, timeout=None):
+        nonlocal call_count
+        call_count += 1
+        if call_count <= 2:
+            raise exc
+        response = requests.Response()
+        response.status_code = 200
+        response.url = expected_url
+        return response
+
+    with patch("dandi.dandiarchive.requests.head", side_effect=mock_head):
+        with patch("dandi.dandiarchive.sleep"):
+            result = follow_redirect(test_url)
+            assert result == expected_url
+            assert call_count == 3
 
 
 @responses.activate


### PR DESCRIPTION
Original motivator from me:  we had windows keep failing here and there with getting stuck on redirects in test_follow_redirect  and potentially others.  So it made sense to add explicit timeout and retry on it. 

claude summary of agreed upon changes:

`follow_redirect()` calls `requests.head(url, allow_redirects=True)` to resolve a redirect chain.  No timeout was passed, so a stalled hop (e.g. a third-party shortener like bit.ly that accepts the TCP/TLS handshake but never sends a response) blocks the call indefinitely.  This has been observed in `test_follow_redirect` on the Windows CI runner — pytest's fault-handler stack ends in `socket.recv_into() -> ssl.read()` inside `requests.sessions.resolve_redirects`.

The retry wrapper around `requests.head()` only caught `requests.ConnectionError`, which does not include `requests.ReadTimeout` — so even adding a timeout would have surfaced as a hard failure rather than the existing transient-error retry path.

Changes:
- Add `REDIRECT_HEAD_TIMEOUT = 30` constant in `dandi/consts.py`.
- Pass it as `timeout=` to the `requests.head()` call.
- Catch `requests.Timeout` in addition to `requests.ConnectionError` inside the retry loop, so `ReadTimeout` and `ConnectTimeout` are now retried with the same exponential backoff.
- Widen the `connection_error` annotation to `requests.RequestException | None` to accommodate both exception types.
- Add `test_follow_redirect_retry_on_timeout` parametrized over `ReadTimeout` and `ConnectTimeout`, mirroring the existing `test_follow_redirect_retry_on_connection_error`.
- Update mock signatures in the existing tests to accept the new `timeout=` kwarg.


