### PR TITLE
Cap zarr to < 3 until zarr 3 support is implemented

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ dependencies = [
     # possibly silently incomplete downloads: https://github.com/dandi/dandi-cli/issues/1500
     "urllib3 >= 2.0.0",
     "yarl ~= 1.9",
-    "zarr >= 2.10, <= 3.1.5",
+    "zarr >= 2.10, < 3",
     "zarr_checksum ~= 0.4.0",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
## Summary

The codebase uses zarr 2.x APIs (e.g. `zarr.errors.PathNotFoundError` in `dandi/files/zarr.py:460`). The dependency cap `zarr <= 3.1.5` advertised zarr 3 support that does not actually exist in the code.

Until 2026-05-19 this was masked because `hdmf-zarr` (pulled in transitively via `nwbinspector`) pinned `zarr < 3`. `nwbinspector` 0.7.2, released 2026-05-19, moved `hdmf-zarr` into an optional `[zarr]` extra. The resolver then began honoring this project's own (too-loose) cap and installed `zarr 3.1.5`, surfacing the latent incompatibility as 11 failing tests on the daily scheduled run (e.g. [job 76815825089](https://github.com/dandi/dandi-cli/actions/runs/26081951651/job/76815825089)).

This PR tightens the cap to match what the code actually supports. A follow-up issue will track proper zarr 3 support.

## Test plan

- [x] Identify the regression range via comparison of `Successfully installed` lines between the last green and first red scheduled runs (zarr 2.18.7 → 3.1.5; nwbinspector 0.7.1 → 0.7.2)
- [ ] CI passes on this PR
