### PR TITLE
BF: Make Zarr validation/digest tests work with zarr-python 2.x and 3.x

### DIFF
--- a/dandi/cli/tests/test_digest.py
+++ b/dandi/cli/tests/test_digest.py
@@ -8,7 +8,7 @@ import pytest
 import zarr
 
 from ..cmd_digest import digest
-from ...files.zarr import get_zarr_format_version
+from ...tests.test_files import zarr_format_of
 
 # The on-disk Zarr serialisation format changed between V2 (``.zgroup`` /
 # ``.zarray``) and V3 (``zarr.json``, ``c/<chunk>`` layout, different default
@@ -64,8 +64,9 @@ def test_digest_zarr():
         zarr.save(
             "sample.zarr", np.arange(1000, dtype=dt), np.arange(1000, 0, -1, dtype=dt)
         )
-        fmt = get_zarr_format_version(Path("sample.zarr"))
-        expected = _EXPECTED_SAMPLE_ZARR_DIGEST_BY_FORMAT[fmt]
+        expected = _EXPECTED_SAMPLE_ZARR_DIGEST_BY_FORMAT[
+            zarr_format_of(Path("sample.zarr"))
+        ]
         r = runner.invoke(digest, ["--digest", "zarr-checksum", "sample.zarr"])
         assert r.exit_code == 0
         assert r.output == f"sample.zarr: {expected}\n"
@@ -88,8 +89,9 @@ def test_digest_zarr_with_excluded_dotfiles():
         zarr.save(
             "sample.zarr", np.arange(1000, dtype=dt), np.arange(1000, 0, -1, dtype=dt)
         )
-        fmt = get_zarr_format_version(Path("sample.zarr"))
-        expected = _EXPECTED_SAMPLE_ZARR_DIGEST_BY_FORMAT[fmt]
+        expected = _EXPECTED_SAMPLE_ZARR_DIGEST_BY_FORMAT[
+            zarr_format_of(Path("sample.zarr"))
+        ]
         subprocess.run(["git", "init"], cwd="sample.zarr", check=True)
         os.mkdir("sample.zarr/.dandi")
         Path("sample.zarr", ".dandi", "somefile.txt").touch()

--- a/dandi/cli/tests/test_digest.py
+++ b/dandi/cli/tests/test_digest.py
@@ -8,7 +8,7 @@ import pytest
 import zarr
 
 from ..cmd_digest import digest
-from ...tests.test_files import zarr_format_of
+from ...tests.test_helpers import zarr_format_of
 
 # The on-disk Zarr serialisation format changed between V2 (``.zgroup`` /
 # ``.zarray``) and V3 (``zarr.json``, ``c/<chunk>`` layout, different default

--- a/dandi/cli/tests/test_digest.py
+++ b/dandi/cli/tests/test_digest.py
@@ -8,6 +8,18 @@ import pytest
 import zarr
 
 from ..cmd_digest import digest
+from ...files.zarr import get_zarr_format_version
+
+# The on-disk Zarr serialisation format changed between V2 (``.zgroup`` /
+# ``.zarray``) and V3 (``zarr.json``, ``c/<chunk>`` layout, different default
+# compressor), so the digest of "the same" Zarr data differs. Key expected
+# values on the format that was *actually* produced rather than on
+# ``zarr.__version__`` — zarr-python 3.x can still write V2 via
+# ``zarr_format=2``.
+_EXPECTED_SAMPLE_ZARR_DIGEST_BY_FORMAT = {
+    "2": "4313ab36412db2981c3ed391b38604d6-5--1516",
+    "3": "00157f091c9a6295e89eb3c4c2efaeff-5--3935",
+}
 
 
 def test_digest_default():
@@ -44,16 +56,19 @@ def test_digest(alg, filehash):
 
 
 def test_digest_zarr():
-    # This test assumes that the Zarr serialization format never changes
+    # Expected digest is selected by the Zarr serialisation format that
+    # ``zarr.save`` actually produced (V2 vs V3 layouts have different digests).
     runner = CliRunner()
     with runner.isolated_filesystem():
         dt = np.dtype("<i8")
         zarr.save(
             "sample.zarr", np.arange(1000, dtype=dt), np.arange(1000, 0, -1, dtype=dt)
         )
+        fmt = get_zarr_format_version(Path("sample.zarr"))
+        expected = _EXPECTED_SAMPLE_ZARR_DIGEST_BY_FORMAT[fmt]
         r = runner.invoke(digest, ["--digest", "zarr-checksum", "sample.zarr"])
         assert r.exit_code == 0
-        assert r.output == "sample.zarr: 4313ab36412db2981c3ed391b38604d6-5--1516\n"
+        assert r.output == f"sample.zarr: {expected}\n"
 
 
 def test_digest_empty_zarr(tmp_path: Path) -> None:
@@ -66,13 +81,15 @@ def test_digest_empty_zarr(tmp_path: Path) -> None:
 
 
 def test_digest_zarr_with_excluded_dotfiles():
-    # This test assumes that the Zarr serialization format never changes
+    # See comment in `test_digest_zarr` regarding V2 vs V3 serialisation.
     runner = CliRunner()
     with runner.isolated_filesystem():
         dt = np.dtype("<i8")
         zarr.save(
             "sample.zarr", np.arange(1000, dtype=dt), np.arange(1000, 0, -1, dtype=dt)
         )
+        fmt = get_zarr_format_version(Path("sample.zarr"))
+        expected = _EXPECTED_SAMPLE_ZARR_DIGEST_BY_FORMAT[fmt]
         subprocess.run(["git", "init"], cwd="sample.zarr", check=True)
         os.mkdir("sample.zarr/.dandi")
         Path("sample.zarr", ".dandi", "somefile.txt").touch()
@@ -82,4 +99,4 @@ def test_digest_zarr_with_excluded_dotfiles():
         Path("sample.zarr", "arr_1", ".datalad", "config").touch()
         r = runner.invoke(digest, ["--digest", "zarr-checksum", "sample.zarr"])
         assert r.exit_code == 0
-        assert r.output == "sample.zarr: 4313ab36412db2981c3ed391b38604d6-5--1516\n"
+        assert r.output == f"sample.zarr: {expected}\n"

--- a/dandi/files/zarr.py
+++ b/dandi/files/zarr.py
@@ -1048,7 +1048,10 @@ class UploadItem:
 
     @classmethod
     def from_entry(cls, e: LocalZarrEntry, digest: str) -> UploadItem:
-        if e.name in {".zarray", ".zattrs", ".zgroup", ".zmetadata"}:
+        # JSON metadata files. ``.zarray`` / ``.zattrs`` / ``.zgroup`` /
+        # ``.zmetadata`` are the V2 names; ``zarr.json`` is the V3 name (a
+        # single file per group/array containing all metadata).
+        if e.name in {".zarray", ".zattrs", ".zgroup", ".zmetadata", "zarr.json"}:
             try:
                 with e.filepath.open("rb") as fp:
                     json.load(fp)

--- a/dandi/files/zarr.py
+++ b/dandi/files/zarr.py
@@ -285,7 +285,8 @@ def _is_empty_group(group: Any) -> bool:
     """
     try:
         return len(group) == 0
-    except Exception:
+    except Exception as exc:
+        lgr.debug("Could not determine emptiness of Zarr group %r: %s", group, exc)
         return False
 
 
@@ -490,30 +491,22 @@ class ZarrAsset(LocalDirectoryAsset[LocalZarrEntry]):
             except Exception as e:
                 if devel_debug:
                     raise
-                if format_version is None:
-                    errors.append(
-                        ValidationResult(
-                            id="zarr.cannot_open",
-                            origin=origin_internal_zarr,
-                            scope=Scope.FILE,
-                            origin_result=e,
-                            severity=Severity.ERROR,
-                            message="Error opening file and Zarr format cannot be determined",
-                            path=self.filepath,
-                        )
+                message = (
+                    "Error opening file and Zarr format cannot be determined"
+                    if format_version is None
+                    else "Error opening file."
+                )
+                errors.append(
+                    ValidationResult(
+                        id="zarr.cannot_open",
+                        origin=origin_internal_zarr,
+                        scope=Scope.FILE,
+                        origin_result=e,
+                        severity=Severity.ERROR,
+                        message=message,
+                        path=self.filepath,
                     )
-                else:
-                    errors.append(
-                        ValidationResult(
-                            origin=origin_internal_zarr,
-                            severity=Severity.ERROR,
-                            id="zarr.cannot_open",
-                            scope=Scope.FILE,
-                            origin_result=e,
-                            path=self.filepath,
-                            message="Error opening file.",
-                        )
-                    )
+                )
                 data = None
             if isinstance(data, zarr.Group) and _is_empty_group(data):
                 errors.append(

--- a/dandi/files/zarr.py
+++ b/dandi/files/zarr.py
@@ -271,6 +271,24 @@ def _ts_validate_zarr3_array(
     return results
 
 
+def _is_empty_group(group: Any) -> bool:
+    """
+    Return whether a `zarr.Group` has no child arrays or groups.
+
+    In zarr-python 2.x ``bool(group)`` / ``len(group)`` is a cheap check, but in
+    zarr-python 3.x both eagerly iterate the group's members, which raises if
+    the underlying directory contains non-Zarr files (e.g. an arbitrary
+    ``a/b/c/...`` tree) or arrays with metadata that the new library can't
+    parse (e.g. legacy ``>u1`` dtypes). Treat any such failure as "not empty"
+    — there is *some* content there, even if it's not a valid Zarr member —
+    so we don't spuriously report ``dandi_zarr.empty_group``.
+    """
+    try:
+        return len(group) == 0
+    except Exception:
+        return False
+
+
 @dataclass
 class LocalZarrEntry(BasePath):
     """A file or directory within a `ZarrAsset`"""
@@ -455,67 +473,49 @@ class ZarrAsset(LocalDirectoryAsset[LocalZarrEntry]):
             standard=Standard.ZARR,
         )
 
-        try:
-            data = zarr.open(str(self.filepath), mode="r")
-        except zarr.errors.PathNotFoundError as e:
-            # The asset is potentially in Zarr V3 format, which is not support by
-            # zarr-python 2.x. Before upgrade to zarr-python 3.x, use tensorstore to
-            # open it.
-
-            format_version = get_zarr_format_version(self.filepath)
-
-            if format_version is None:
-                # === The Zarr format can't be determined ===
-                if devel_debug:
-                    raise
-                errors.append(
-                    ValidationResult(
-                        id="zarr.cannot_open",
-                        origin=origin_internal_zarr,
-                        scope=Scope.FILE,
-                        origin_result=e,
-                        severity=Severity.ERROR,
-                        message="Error opening file and Zarr format cannot be determined",
-                        path=self.filepath,
-                    )
-                )
-            elif format_version == "3":
-                # === The Zarr format is V3 ===
-                errors.extend(_ts_validate_zarr3(self.filepath, devel_debug))
-            else:
-                # === A Zarr format should be supported by `zarr.open()` ===
-                if devel_debug:
-                    raise
-                errors.append(
-                    ValidationResult(
-                        id="zarr.cannot_open",
-                        origin=origin_internal_zarr,
-                        scope=Scope.FILE,
-                        origin_result=e,
-                        severity=Severity.ERROR,
-                        message="Error opening file.",
-                        path=self.filepath,
-                    )
-                )
-
-            # code for temporary workaround for Zarr format V3 with tensorstore ends
-
-        except Exception as e:
-            if devel_debug:
-                raise
-            errors.append(
-                ValidationResult(
-                    origin=origin_internal_zarr,
-                    severity=Severity.ERROR,
-                    id="zarr.cannot_open",
-                    scope=Scope.FILE,
-                    origin_result=e,
-                    path=self.filepath,
-                    message="Error opening file.",
-                )
-            )
+        # Zarr V3 stores are validated by `_ts_validate_zarr3` regardless of
+        # zarr-python version. With zarr-python 2.x, `zarr.open()` cannot
+        # handle V3 at all (raises `PathNotFoundError`); with zarr-python 3.x
+        # it can sometimes partially open malformed V3 stores (e.g. valid
+        # root metadata, bad child metadata), which would cause us to miss
+        # the `_ts_validate_zarr3` path. Detecting the format up front keeps
+        # the validation behaviour consistent across versions.
+        format_version = get_zarr_format_version(self.filepath)
+        if format_version == "3":
+            errors.extend(_ts_validate_zarr3(self.filepath, devel_debug))
+            data = None
         else:
-            if isinstance(data, zarr.Group) and not data:
+            try:
+                data = zarr.open(str(self.filepath), mode="r")
+            except Exception as e:
+                if devel_debug:
+                    raise
+                if format_version is None:
+                    errors.append(
+                        ValidationResult(
+                            id="zarr.cannot_open",
+                            origin=origin_internal_zarr,
+                            scope=Scope.FILE,
+                            origin_result=e,
+                            severity=Severity.ERROR,
+                            message="Error opening file and Zarr format cannot be determined",
+                            path=self.filepath,
+                        )
+                    )
+                else:
+                    errors.append(
+                        ValidationResult(
+                            origin=origin_internal_zarr,
+                            severity=Severity.ERROR,
+                            id="zarr.cannot_open",
+                            scope=Scope.FILE,
+                            origin_result=e,
+                            path=self.filepath,
+                            message="Error opening file.",
+                        )
+                    )
+                data = None
+            if isinstance(data, zarr.Group) and _is_empty_group(data):
                 errors.append(
                     ValidationResult(
                         origin=ORIGIN_VALIDATION_DANDI_ZARR,

--- a/dandi/tests/test_download.py
+++ b/dandi/tests/test_download.py
@@ -27,8 +27,7 @@ import zarr
 
 from .fixtures import SampleDandiset, SampleDandisetFactory
 from .skip import mark
-from .test_files import _TWO_ARRAY_ZARR_LAYOUT, zarr_format_of
-from .test_helpers import assert_dirtrees_eq
+from .test_helpers import TWO_ARRAY_ZARR_LAYOUT, assert_dirtrees_eq, zarr_format_of
 from ..consts import DRAFT, dandiset_metadata_file
 from ..dandiarchive import DandisetURL
 from ..download import (
@@ -464,9 +463,7 @@ def test_download_different_zarr_onto_excluded_dotfiles(
     # `zarr_dandiset` was uploaded with default ``zarr.save`` — its on-disk
     # layout (and therefore the layout we expect to see after download) is
     # V2 for zarr-python 2.x, V3 for zarr-python 3.x.
-    layout = _TWO_ARRAY_ZARR_LAYOUT[
-        zarr_format_of(zarr_dandiset.dspath / "sample.zarr")
-    ]
+    layout = TWO_ARRAY_ZARR_LAYOUT[zarr_format_of(zarr_dandiset.dspath / "sample.zarr")]
     (zarr_path / ".git").touch()
     (zarr_path / ".dandi").mkdir()
     (zarr_path / ".dandi" / "somefile.txt").touch()
@@ -499,12 +496,16 @@ def test_download_different_zarr_delete_dir(
     d = new_dandiset.dandiset
     dspath = new_dandiset.dspath
     zarr.save(dspath / "sample.zarr", np.eye(5))
-    # The single-array ``np.eye(5)`` Zarr is flat (no subdirs) in V2; V3
-    # adds a ``c/`` chunk directory. The two-array Zarr below always has
-    # ``arr_0/`` and ``arr_1/`` subdirs in both V2 and V3, which is the
-    # contrast this test exercises.
+    # The single-array ``np.eye(5)`` Zarr has a flatter layout than the
+    # two-array Zarr below: in V2 no subdirs at all; in V3 only ``c/``
+    # (the chunk container) rather than ``arr_0/`` and ``arr_1/``. This
+    # is the contrast the test exercises — downloading the smaller Zarr
+    # must delete the extra ``arr_*`` subdirs of the bigger one.
+    initial_subdirs = {p.name for p in (dspath / "sample.zarr").iterdir() if p.is_dir()}
     if zarr_format_of(dspath / "sample.zarr") == "2":
-        assert not any(p.is_dir() for p in (dspath / "sample.zarr").iterdir())
+        assert initial_subdirs == set()
+    else:
+        assert initial_subdirs == {"c"}
     new_dandiset.upload()
     dd = tmp_path / d.identifier
     dd.mkdir(parents=True, exist_ok=True)
@@ -933,7 +934,7 @@ def test_download_multiple_urls(
     zarr_dandiset = sample_dandiset_factory.mkdandiset("Sample Zarr Dandiset")
     zarr_local = zarr_dandiset.dspath / "sample.zarr"
     zarr.save(zarr_local, np.arange(1000), np.arange(1000, 0, -1))
-    layout = _TWO_ARRAY_ZARR_LAYOUT[zarr_format_of(zarr_local)]
+    layout = TWO_ARRAY_ZARR_LAYOUT[zarr_format_of(zarr_local)]
     zarr_dandiset.upload()
 
     download([text_dandiset.dandiset.api_url, zarr_dandiset.dandiset.api_url], tmp_path)

--- a/dandi/tests/test_download.py
+++ b/dandi/tests/test_download.py
@@ -27,6 +27,7 @@ import zarr
 
 from .fixtures import SampleDandiset, SampleDandisetFactory
 from .skip import mark
+from .test_files import _TWO_ARRAY_ZARR_LAYOUT, zarr_format_of
 from .test_helpers import assert_dirtrees_eq
 from ..consts import DRAFT, dandiset_metadata_file
 from ..dandiarchive import DandisetURL
@@ -460,6 +461,12 @@ def test_download_different_zarr_onto_excluded_dotfiles(
     dd.mkdir()
     zarr_path = dd / "sample.zarr"
     zarr.save(zarr_path, np.eye(5))
+    # `zarr_dandiset` was uploaded with default ``zarr.save`` — its on-disk
+    # layout (and therefore the layout we expect to see after download) is
+    # V2 for zarr-python 2.x, V3 for zarr-python 3.x.
+    layout = _TWO_ARRAY_ZARR_LAYOUT[
+        zarr_format_of(zarr_dandiset.dspath / "sample.zarr")
+    ]
     (zarr_path / ".git").touch()
     (zarr_path / ".dandi").mkdir()
     (zarr_path / ".dandi" / "somefile.txt").touch()
@@ -472,21 +479,18 @@ def test_download_different_zarr_onto_excluded_dotfiles(
         tmp_path,
         existing=DownloadExisting.OVERWRITE_DIFFERENT,
     )
-    assert list_paths(zarr_path, dirs=True, exclude_vcs=False) == [
+    dotfile_paths = [
         zarr_path / ".dandi",
         zarr_path / ".dandi" / "somefile.txt",
         zarr_path / ".datalad",
         zarr_path / ".git",
         zarr_path / ".gitattributes",
-        zarr_path / ".zgroup",
-        zarr_path / "arr_0",
         zarr_path / "arr_0" / ".gitmodules",
-        zarr_path / "arr_0" / ".zarray",
-        zarr_path / "arr_0" / "0",
-        zarr_path / "arr_1",
-        zarr_path / "arr_1" / ".zarray",
-        zarr_path / "arr_1" / "0",
     ]
+    zarr_paths = [zarr_path / p for p in layout["files_and_dirs"]]
+    assert list_paths(zarr_path, dirs=True, exclude_vcs=False) == sorted(
+        set(dotfile_paths + zarr_paths)
+    )
 
 
 def test_download_different_zarr_delete_dir(
@@ -495,7 +499,12 @@ def test_download_different_zarr_delete_dir(
     d = new_dandiset.dandiset
     dspath = new_dandiset.dspath
     zarr.save(dspath / "sample.zarr", np.eye(5))
-    assert not any(p.is_dir() for p in (dspath / "sample.zarr").iterdir())
+    # The single-array ``np.eye(5)`` Zarr is flat (no subdirs) in V2; V3
+    # adds a ``c/`` chunk directory. The two-array Zarr below always has
+    # ``arr_0/`` and ``arr_1/`` subdirs in both V2 and V3, which is the
+    # contrast this test exercises.
+    if zarr_format_of(dspath / "sample.zarr") == "2":
+        assert not any(p.is_dir() for p in (dspath / "sample.zarr").iterdir())
     new_dandiset.upload()
     dd = tmp_path / d.identifier
     dd.mkdir(parents=True, exist_ok=True)
@@ -922,12 +931,13 @@ def test_download_multiple_urls(
     # end up using the same `new_dandiset`.  Hence, we need to fall back to
     # using `sample_dandiset_factory` here.
     zarr_dandiset = sample_dandiset_factory.mkdandiset("Sample Zarr Dandiset")
-    zarr.save(
-        zarr_dandiset.dspath / "sample.zarr", np.arange(1000), np.arange(1000, 0, -1)
-    )
+    zarr_local = zarr_dandiset.dspath / "sample.zarr"
+    zarr.save(zarr_local, np.arange(1000), np.arange(1000, 0, -1))
+    layout = _TWO_ARRAY_ZARR_LAYOUT[zarr_format_of(zarr_local)]
     zarr_dandiset.upload()
 
     download([text_dandiset.dandiset.api_url, zarr_dandiset.dandiset.api_url], tmp_path)
+    zarr_root = tmp_path / zarr_dandiset.dandiset_id / "sample.zarr"
     assert list_paths(tmp_path) == [
         tmp_path / text_dandiset.dandiset_id / "dandiset.yaml",
         tmp_path / text_dandiset.dandiset_id / "file.txt",
@@ -935,16 +945,7 @@ def test_download_multiple_urls(
         tmp_path / text_dandiset.dandiset_id / "subdir2" / "banana.txt",
         tmp_path / text_dandiset.dandiset_id / "subdir2" / "coconut.txt",
         tmp_path / zarr_dandiset.dandiset_id / "dandiset.yaml",
-        tmp_path
-        / zarr_dandiset.dandiset_id
-        / tmp_path
-        / zarr_dandiset.dandiset_id
-        / "sample.zarr"
-        / ".zgroup",
-        tmp_path / zarr_dandiset.dandiset_id / "sample.zarr" / "arr_0" / ".zarray",
-        tmp_path / zarr_dandiset.dandiset_id / "sample.zarr" / "arr_0" / "0",
-        tmp_path / zarr_dandiset.dandiset_id / "sample.zarr" / "arr_1" / ".zarray",
-        tmp_path / zarr_dandiset.dandiset_id / "sample.zarr" / "arr_1" / "0",
+        *[zarr_root / p for p in layout["files"]],
     ]
 
 

--- a/dandi/tests/test_files.py
+++ b/dandi/tests/test_files.py
@@ -4,6 +4,7 @@ from operator import attrgetter
 import os
 from pathlib import Path
 import subprocess
+from typing import TypedDict
 from unittest.mock import ANY
 
 from dandischema.models import get_schema_version
@@ -32,6 +33,73 @@ from ..files import (
 from ..files.zarr import get_zarr_format_version
 
 lgr = get_logger()
+
+
+def zarr_format_of(path: Path) -> str:
+    """
+    Return the Zarr serialisation format ("2" or "3") of the tree at ``path``.
+
+    Thin test-only wrapper around `get_zarr_format_version` that asserts the
+    format could be determined — used by tests that have just called
+    ``zarr.save(...)`` and so know the path is a valid Zarr store.
+    """
+    fmt = get_zarr_format_version(path)
+    assert fmt is not None, f"Path {path} is not a recognised Zarr store"
+    return fmt
+
+
+class _TwoArrayLayout(TypedDict):
+    files: list[str]
+    files_and_dirs: list[str]
+    root_meta: str
+
+
+# Per-Zarr-format expected on-disk paths for the canonical
+# ``zarr.save(p, arr_0, arr_1)`` two-array sample used by upload/download
+# tests. V2 writes ``.zgroup`` / ``arr_X/.zarray`` / ``arr_X/0``; V3 writes
+# ``zarr.json`` / ``arr_X/zarr.json`` / ``arr_X/c/0``.
+_TWO_ARRAY_ZARR_LAYOUT: dict[str, _TwoArrayLayout] = {
+    "2": {
+        "files": [
+            ".zgroup",
+            "arr_0/.zarray",
+            "arr_0/0",
+            "arr_1/.zarray",
+            "arr_1/0",
+        ],
+        "files_and_dirs": [
+            ".zgroup",
+            "arr_0",
+            "arr_0/.zarray",
+            "arr_0/0",
+            "arr_1",
+            "arr_1/.zarray",
+            "arr_1/0",
+        ],
+        "root_meta": ".zgroup",
+    },
+    "3": {
+        "files": [
+            "arr_0/c/0",
+            "arr_0/zarr.json",
+            "arr_1/c/0",
+            "arr_1/zarr.json",
+            "zarr.json",
+        ],
+        "files_and_dirs": [
+            "arr_0",
+            "arr_0/c",
+            "arr_0/c/0",
+            "arr_0/zarr.json",
+            "arr_1",
+            "arr_1/c",
+            "arr_1/c/0",
+            "arr_1/zarr.json",
+            "zarr.json",
+        ],
+        "root_meta": "zarr.json",
+    },
+}
 
 
 def mkpaths(root: Path, *paths: str) -> None:
@@ -408,6 +476,8 @@ def test_validate_bogus(tmp_path):
 def test_upload_zarr(new_dandiset, tmp_path):
     filepath = tmp_path / "example.zarr"
     zarr.save(filepath, np.arange(1000), np.arange(1000, 0, -1))
+    layout = _TWO_ARRAY_ZARR_LAYOUT[zarr_format_of(filepath)]
+    root_meta = layout["root_meta"]
     zf = dandi_file(filepath)
     assert isinstance(zf, ZarrAsset)
     asset = zf.upload(new_dandiset.dandiset, {"description": "A test Zarr"})
@@ -423,33 +493,23 @@ def test_upload_zarr(new_dandiset, tmp_path):
     assert md["description"] == "A modified Zarr"
 
     entries = sorted(asset.iterfiles(), key=attrgetter("parts"))
-    assert [str(e) for e in entries] == [
-        ".zgroup",
-        "arr_0/.zarray",
-        "arr_0/0",
-        "arr_1/.zarray",
-        "arr_1/0",
-    ]
+    assert [str(e) for e in entries] == layout["files"]
 
     entries = sorted(zf.iterfiles(include_dirs=True), key=attrgetter("parts"))
-    assert [str(e) for e in entries] == [
-        ".zgroup",
-        "arr_0",
-        "arr_0/.zarray",
-        "arr_0/0",
-        "arr_1",
-        "arr_1/.zarray",
-        "arr_1/0",
-    ]
-    assert (zf.filetree / ".zgroup").exists()
-    assert (zf.filetree / ".zgroup").is_file()
-    assert not (zf.filetree / ".zgroup").is_dir()
+    assert [str(e) for e in entries] == layout["files_and_dirs"]
+    # The root group metadata file is ``.zgroup`` in V2 and ``zarr.json`` in
+    # V3; either way it must be a real file at the Zarr root.
+    assert (zf.filetree / root_meta).exists()
+    assert (zf.filetree / root_meta).is_file()
+    assert not (zf.filetree / root_meta).is_dir()
     assert (zf.filetree / "arr_0").exists()
     assert not (zf.filetree / "arr_0").is_file()
     assert (zf.filetree / "arr_0").is_dir()
     assert not (zf.filetree / "0").exists()
     assert not (zf.filetree / "0").is_file()
     assert not (zf.filetree / "0").is_dir()
+    # ``arr_0/.zgroup`` never exists: in V2 ``arr_0`` is an array (uses
+    # ``.zarray``); in V3 ``.zgroup`` is not used at all.
     assert not (zf.filetree / "arr_0" / ".zgroup").exists()
     assert not (zf.filetree / "arr_0" / ".zgroup").is_file()
     assert not (zf.filetree / "arr_0" / ".zgroup").is_dir()
@@ -504,8 +564,7 @@ def test_zarr_properties(tmp_path: Path) -> None:
     filepath = tmp_path / "example.zarr"
     dt = np.dtype("<i8")
     zarr.save(filepath, np.arange(1000, dtype=dt), np.arange(1000, 0, -1, dtype=dt))
-    fmt = get_zarr_format_version(filepath)
-    expected = _ZARR_PROPERTIES_EXPECTED[fmt]
+    expected = _ZARR_PROPERTIES_EXPECTED[zarr_format_of(filepath)]
     zf = dandi_file(filepath)
     assert isinstance(zf, ZarrAsset)
     assert zf.filetree.size == expected["total_size"]
@@ -528,6 +587,7 @@ def test_upload_zarr_with_excluded_dotfiles(
 ) -> None:
     filepath = tmp_path / "example.zarr"
     zarr.save(filepath, np.arange(1000), np.arange(1000, 0, -1))
+    layout = _TWO_ARRAY_ZARR_LAYOUT[zarr_format_of(filepath)]
     subprocess.run(["git", "init"], cwd=str(filepath), check=True)
     (filepath / ".dandi").mkdir()
     (filepath / ".dandi" / "somefile.txt").write_text("Hello world!\n")
@@ -540,33 +600,20 @@ def test_upload_zarr_with_excluded_dotfiles(
     asset = zf.upload(new_dandiset.dandiset, {})
     assert isinstance(asset, RemoteZarrAsset)
     local_entries = sorted(zf.iterfiles(include_dirs=True), key=attrgetter("parts"))
-    assert [str(e) for e in local_entries] == [
-        ".zgroup",
-        "arr_0",
-        "arr_0/.zarray",
-        "arr_0/0",
-        "arr_1",
-        "arr_1/.zarray",
-        "arr_1/0",
-    ]
+    assert [str(e) for e in local_entries] == layout["files_and_dirs"]
     remote_entries = sorted(asset.iterfiles(), key=attrgetter("parts"))
-    assert [str(e) for e in remote_entries] == [
-        ".zgroup",
-        "arr_0/.zarray",
-        "arr_0/0",
-        "arr_1/.zarray",
-        "arr_1/0",
-    ]
+    assert [str(e) for e in remote_entries] == layout["files"]
 
 
 def test_upload_zarr_entry_content_type(new_dandiset, tmp_path):
     filepath = tmp_path / "example.zarr"
     zarr.save(filepath, np.arange(1000), np.arange(1000, 0, -1))
+    root_meta = _TWO_ARRAY_ZARR_LAYOUT[zarr_format_of(filepath)]["root_meta"]
     zf = dandi_file(filepath)
     assert isinstance(zf, ZarrAsset)
     asset = zf.upload(new_dandiset.dandiset, {"description": "A test Zarr"})
     assert isinstance(asset, RemoteZarrAsset)
-    e = asset.get_entry_by_path(".zgroup")
+    e = asset.get_entry_by_path(root_meta)
     r = new_dandiset.client.get(e.download_url, json_resp=False)
     assert r.headers["Content-Type"] == "application/json"
 

--- a/dandi/tests/test_files.py
+++ b/dandi/tests/test_files.py
@@ -29,6 +29,7 @@ from ..files import (
     dandi_file,
     find_dandi_files,
 )
+from ..files.zarr import get_zarr_format_version
 
 lgr = get_logger()
 
@@ -460,29 +461,63 @@ def test_upload_zarr(new_dandiset, tmp_path):
     assert not (zf.filetree / "arr_2" / "0").is_dir()
 
 
+# V2 (``.zgroup`` / ``.zarray``) and V3 (``zarr.json``, ``c/<chunk>`` layout,
+# different default compressor) Zarr serialisations have different on-disk
+# byte layouts and therefore different digests. Key expected values on the
+# format that was *actually* produced rather than on ``zarr.__version__``:
+# zarr-python 3.x can still write V2 via ``zarr_format=2``.
+_ZARR_PROPERTIES_EXPECTED = {
+    "2": {
+        "total_size": 1516,
+        "total_digest": "4313ab36412db2981c3ed391b38604d6-5--1516",
+        "entries": [
+            (".zgroup", 24, "e20297935e73dd0154104d4ea53040ab"),
+            ("arr_0", 746, "51c74ec257069ce3a555bdddeb50230a-2--746"),
+            ("arr_0/.zarray", 315, "9e30a0a1a465e24220d4132fdd544634"),
+            ("arr_0/0", 431, "ed4e934a474f1d2096846c6248f18c00"),
+            ("arr_1", 746, "7b99a0ad9bd8bb3331657e54755b1a31-2--746"),
+            ("arr_1/.zarray", 315, "9e30a0a1a465e24220d4132fdd544634"),
+            ("arr_1/0", 431, "fba4dee03a51bde314e9713b00284a93"),
+        ],
+    },
+    "3": {
+        "total_size": 3935,
+        "total_digest": "00157f091c9a6295e89eb3c4c2efaeff-5--3935",
+        "entries": [
+            ("arr_0", 2192, "ae16256ae750e4303674ccf1e23fa3c6-2--2192"),
+            ("arr_0/c", 1573, "93912a45f2107a08090f7b283297d662-1--1573"),
+            ("arr_0/c/0", 1573, "6c237f8d2d4a41bc1e26e31518dafd9e"),
+            ("arr_0/zarr.json", 619, "850fae056c97aa9c76df0a52411f4086"),
+            ("arr_1", 1677, "debc9ca4b2184a6ef1a3d6fcf7d79fd9-2--1677"),
+            ("arr_1/c", 1058, "2642f5d2df2cddf469313abd9910b371-1--1058"),
+            ("arr_1/c/0", 1058, "084d662af7251a807649fb48edc36e95"),
+            ("arr_1/zarr.json", 619, "850fae056c97aa9c76df0a52411f4086"),
+            ("zarr.json", 66, "457126c0639af2eba0140851c39c1aad"),
+        ],
+    },
+}
+
+
 def test_zarr_properties(tmp_path: Path) -> None:
-    # This test assumes that the Zarr serialization format never changes
+    # Expected sizes and digests are selected by the Zarr serialisation
+    # format ``zarr.save`` actually produced (V2 vs V3 layouts differ).
     filepath = tmp_path / "example.zarr"
     dt = np.dtype("<i8")
     zarr.save(filepath, np.arange(1000, dtype=dt), np.arange(1000, 0, -1, dtype=dt))
+    fmt = get_zarr_format_version(filepath)
+    expected = _ZARR_PROPERTIES_EXPECTED[fmt]
     zf = dandi_file(filepath)
     assert isinstance(zf, ZarrAsset)
-    assert zf.filetree.size == 1516
-    assert zf.filetree.get_digest().value == "4313ab36412db2981c3ed391b38604d6-5--1516"
+    assert zf.filetree.size == expected["total_size"]
+    assert zf.filetree.get_digest().value == expected["total_digest"]
     entries = sorted(zf.iterfiles(include_dirs=True), key=attrgetter("parts"))
-    assert [(str(e), e.size, e.get_digest().value) for e in entries] == [
-        (".zgroup", 24, "e20297935e73dd0154104d4ea53040ab"),
-        ("arr_0", 746, "51c74ec257069ce3a555bdddeb50230a-2--746"),
-        ("arr_0/.zarray", 315, "9e30a0a1a465e24220d4132fdd544634"),
-        ("arr_0/0", 431, "ed4e934a474f1d2096846c6248f18c00"),
-        ("arr_1", 746, "7b99a0ad9bd8bb3331657e54755b1a31-2--746"),
-        ("arr_1/.zarray", 315, "9e30a0a1a465e24220d4132fdd544634"),
-        ("arr_1/0", 431, "fba4dee03a51bde314e9713b00284a93"),
+    assert [(str(e), e.size, e.get_digest().value) for e in entries] == expected[
+        "entries"
     ]
-    assert zf.get_digest().value == "4313ab36412db2981c3ed391b38604d6-5--1516"
+    assert zf.get_digest().value == expected["total_digest"]
     stat = zf.stat()
-    assert stat.size == 1516
-    assert stat.digest.value == "4313ab36412db2981c3ed391b38604d6-5--1516"
+    assert stat.size == expected["total_size"]
+    assert stat.digest.value == expected["total_digest"]
     assert sorted(stat.files, key=attrgetter("parts")) == [
         e for e in entries if e.is_file()
     ]

--- a/dandi/tests/test_files.py
+++ b/dandi/tests/test_files.py
@@ -4,7 +4,6 @@ from operator import attrgetter
 import os
 from pathlib import Path
 import subprocess
-from typing import TypedDict
 from unittest.mock import ANY
 
 from dandischema.models import get_schema_version
@@ -13,6 +12,7 @@ import pytest
 import zarr
 
 from .fixtures import SampleDandiset
+from .test_helpers import TWO_ARRAY_ZARR_LAYOUT, zarr_format_of
 from .. import get_logger
 from ..consts import ZARR_MIME_TYPE, dandiset_metadata_file
 from ..dandiapi import AssetType, RemoteZarrAsset
@@ -30,76 +30,8 @@ from ..files import (
     dandi_file,
     find_dandi_files,
 )
-from ..files.zarr import get_zarr_format_version
 
 lgr = get_logger()
-
-
-def zarr_format_of(path: Path) -> str:
-    """
-    Return the Zarr serialisation format ("2" or "3") of the tree at ``path``.
-
-    Thin test-only wrapper around `get_zarr_format_version` that asserts the
-    format could be determined — used by tests that have just called
-    ``zarr.save(...)`` and so know the path is a valid Zarr store.
-    """
-    fmt = get_zarr_format_version(path)
-    assert fmt is not None, f"Path {path} is not a recognised Zarr store"
-    return fmt
-
-
-class _TwoArrayLayout(TypedDict):
-    files: list[str]
-    files_and_dirs: list[str]
-    root_meta: str
-
-
-# Per-Zarr-format expected on-disk paths for the canonical
-# ``zarr.save(p, arr_0, arr_1)`` two-array sample used by upload/download
-# tests. V2 writes ``.zgroup`` / ``arr_X/.zarray`` / ``arr_X/0``; V3 writes
-# ``zarr.json`` / ``arr_X/zarr.json`` / ``arr_X/c/0``.
-_TWO_ARRAY_ZARR_LAYOUT: dict[str, _TwoArrayLayout] = {
-    "2": {
-        "files": [
-            ".zgroup",
-            "arr_0/.zarray",
-            "arr_0/0",
-            "arr_1/.zarray",
-            "arr_1/0",
-        ],
-        "files_and_dirs": [
-            ".zgroup",
-            "arr_0",
-            "arr_0/.zarray",
-            "arr_0/0",
-            "arr_1",
-            "arr_1/.zarray",
-            "arr_1/0",
-        ],
-        "root_meta": ".zgroup",
-    },
-    "3": {
-        "files": [
-            "arr_0/c/0",
-            "arr_0/zarr.json",
-            "arr_1/c/0",
-            "arr_1/zarr.json",
-            "zarr.json",
-        ],
-        "files_and_dirs": [
-            "arr_0",
-            "arr_0/c",
-            "arr_0/c/0",
-            "arr_0/zarr.json",
-            "arr_1",
-            "arr_1/c",
-            "arr_1/c/0",
-            "arr_1/zarr.json",
-            "zarr.json",
-        ],
-        "root_meta": "zarr.json",
-    },
-}
 
 
 def mkpaths(root: Path, *paths: str) -> None:
@@ -476,7 +408,7 @@ def test_validate_bogus(tmp_path):
 def test_upload_zarr(new_dandiset, tmp_path):
     filepath = tmp_path / "example.zarr"
     zarr.save(filepath, np.arange(1000), np.arange(1000, 0, -1))
-    layout = _TWO_ARRAY_ZARR_LAYOUT[zarr_format_of(filepath)]
+    layout = TWO_ARRAY_ZARR_LAYOUT[zarr_format_of(filepath)]
     root_meta = layout["root_meta"]
     zf = dandi_file(filepath)
     assert isinstance(zf, ZarrAsset)
@@ -587,7 +519,7 @@ def test_upload_zarr_with_excluded_dotfiles(
 ) -> None:
     filepath = tmp_path / "example.zarr"
     zarr.save(filepath, np.arange(1000), np.arange(1000, 0, -1))
-    layout = _TWO_ARRAY_ZARR_LAYOUT[zarr_format_of(filepath)]
+    layout = TWO_ARRAY_ZARR_LAYOUT[zarr_format_of(filepath)]
     subprocess.run(["git", "init"], cwd=str(filepath), check=True)
     (filepath / ".dandi").mkdir()
     (filepath / ".dandi" / "somefile.txt").write_text("Hello world!\n")
@@ -608,7 +540,7 @@ def test_upload_zarr_with_excluded_dotfiles(
 def test_upload_zarr_entry_content_type(new_dandiset, tmp_path):
     filepath = tmp_path / "example.zarr"
     zarr.save(filepath, np.arange(1000), np.arange(1000, 0, -1))
-    root_meta = _TWO_ARRAY_ZARR_LAYOUT[zarr_format_of(filepath)]["root_meta"]
+    root_meta = TWO_ARRAY_ZARR_LAYOUT[zarr_format_of(filepath)]["root_meta"]
     zf = dandi_file(filepath)
     assert isinstance(zf, ZarrAsset)
     asset = zf.upload(new_dandiset.dandiset, {"description": "A test Zarr"})

--- a/dandi/tests/test_helpers.py
+++ b/dandi/tests/test_helpers.py
@@ -1,5 +1,8 @@
 from operator import attrgetter
 from pathlib import Path
+from typing import TypedDict
+
+from ..files.zarr import get_zarr_format_version
 
 
 # This needs to be in a file named "test_*.py" so that pytest performs its
@@ -21,3 +24,70 @@ def assert_dirtrees_eq(tree1: Path, tree2: Path) -> None:
             assert p1.read_text() == p2.read_text()
         else:
             assert p1.read_bytes() == p2.read_bytes()
+
+
+def zarr_format_of(path: Path) -> str:
+    """
+    Return the Zarr serialisation format ("2" or "3") of the tree at ``path``.
+
+    Thin test-only wrapper around `get_zarr_format_version` that asserts the
+    format could be determined — used by tests that have just called
+    ``zarr.save(...)`` and so know the path is a valid Zarr store.
+    """
+    fmt = get_zarr_format_version(path)
+    assert fmt is not None, f"Path {path} is not a recognised Zarr store"
+    return fmt
+
+
+class TwoArrayZarrLayout(TypedDict):
+    files: list[str]
+    files_and_dirs: list[str]
+    root_meta: str
+
+
+# Per-Zarr-format expected on-disk paths for the canonical
+# ``zarr.save(p, arr_0, arr_1)`` two-array sample used by upload/download
+# tests. V2 writes ``.zgroup`` / ``arr_X/.zarray`` / ``arr_X/0``; V3 writes
+# ``zarr.json`` / ``arr_X/zarr.json`` / ``arr_X/c/0``.
+TWO_ARRAY_ZARR_LAYOUT: dict[str, TwoArrayZarrLayout] = {
+    "2": {
+        "files": [
+            ".zgroup",
+            "arr_0/.zarray",
+            "arr_0/0",
+            "arr_1/.zarray",
+            "arr_1/0",
+        ],
+        "files_and_dirs": [
+            ".zgroup",
+            "arr_0",
+            "arr_0/.zarray",
+            "arr_0/0",
+            "arr_1",
+            "arr_1/.zarray",
+            "arr_1/0",
+        ],
+        "root_meta": ".zgroup",
+    },
+    "3": {
+        "files": [
+            "arr_0/c/0",
+            "arr_0/zarr.json",
+            "arr_1/c/0",
+            "arr_1/zarr.json",
+            "zarr.json",
+        ],
+        "files_and_dirs": [
+            "arr_0",
+            "arr_0/c",
+            "arr_0/c/0",
+            "arr_0/zarr.json",
+            "arr_1",
+            "arr_1/c",
+            "arr_1/c/0",
+            "arr_1/zarr.json",
+            "zarr.json",
+        ],
+        "root_meta": "zarr.json",
+    },
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,6 +217,18 @@ module = [
 ]
 ignore_missing_imports = true
 
+# `zarr.*` ships its own type stubs in zarr-python 3.x but they reject
+# `numpy.ndarray` as a value for the `NDArrayLike` protocol because of
+# minor `ndarray.reshape` overload divergence. This surfaces as ~30
+# `arg-type` errors on every `zarr.save(path, np.arange(...))` call in
+# the test suite. zarr-python 2.x has no stubs and the same calls are
+# untyped, so CI typing (which currently resolves to zarr 2.18) passes.
+# Skip following zarr imports so behaviour is consistent regardless of
+# the installed zarr-python version.
+[[tool.mypy.overrides]]
+module = ["zarr.*"]
+follow_imports = "skip"
+
 [tool.pydantic-mypy]
 init_forbid_extra = true
 


### PR DESCRIPTION
We (me with @kabilar ) did raise upper version for zarr but it was not in effect due to hdmf-zarr blocking it via nwbexpector dependency for us. That was addressed and thus we started to upgrade into that zarr 3.

zarr-python 3.x changed both the public API and on-disk format:

* `zarr.errors.PathNotFoundError` was removed; missing-metadata errors are now `GroupNotFoundError` / `ArrayNotFoundError` / `NodeNotFoundError`.
* `bool(group)` / `len(group)` eagerly iterate members and raise on non-Zarr files (e.g. an arbitrary `a/b/c/...` tree) or arrays with metadata the new library cannot parse (e.g. legacy `>u1` dtypes).
* `zarr.open()` can partially succeed on malformed V3 stores where root metadata is valid but child metadata is not, which would bypass the tensorstore-based V3 validator.
* Default serialisation is now V3 (`zarr.json`, `c/<chunk>` layout, different default compressor), so on-disk digests of "the same" data differ between V2 and V3 outputs.

`dandi/files/zarr.py`:

* Detect the Zarr format version from disk up front and always route V3 stores through `_ts_validate_zarr3`, regardless of zarr-python version.
* Add `_is_empty_group` helper that swallows exceptions from zarr-python 3.x's eager member iteration — there is *some* content, even if it's not a valid Zarr member, so don't spuriously report `dandi_zarr.empty_group`.
* Drop the explicit `zarr.errors.PathNotFoundError` clause (which only exists in 2.x) in favour of a single generic `except Exception` after the V3 fast-path.

Tests:

* `test_digest_zarr`, `test_digest_zarr_with_excluded_dotfiles` and `test_zarr_properties` now key their expected digests/sizes on the Zarr serialisation format actually produced (`get_zarr_format_version` on the written tree) rather than on `zarr.__version__`. This stays correct if zarr-python 3.x is later configured to write `zarr_format=2`.

Verified against zarr 2.18.7 and zarr 3.1.5.

- Closes #1856 