### PR TITLE
enh: add Macaca radiata (bonnet macaque) to species_map

### DIFF
--- a/dandi/metadata/util.py
+++ b/dandi/metadata/util.py
@@ -395,6 +395,12 @@ species_map = [
         "Macaca nemestrina",
     ),
     (
+        ["bonnet macaque", "bonnet monkey", "radiata"],
+        None,
+        NCBITAXON_URI_TEMPLATE.format("9548"),
+        "Macaca radiata - Bonnet macaque",
+    ),
+    (
         ["mongolian gerbil", "mongolian jird"],
         None,
         NCBITAXON_URI_TEMPLATE.format("10047"),


### PR DESCRIPTION
Adds NCBI taxon 9548 (Macaca radiata, common name "bonnet macaque") to the species lookup table so the species can be recognized by common name, "radiata", or its NCBITaxon URL.

Requested by a user via email.