### PR TITLE
BF: remove duplicated definition for "Macaca radiata"

### DIFF
--- a/dandi/metadata/util.py
+++ b/dandi/metadata/util.py
@@ -401,12 +401,6 @@ species_map = [
         "Macaca radiata - Bonnet macaque",
     ),
     (
-        ["bonnet macaque", "bonnet monkey", "radiata"],
-        None,
-        NCBITAXON_URI_TEMPLATE.format("9548"),
-        "Macaca radiata - Bonnet macaque",
-    ),
-    (
         ["mongolian gerbil", "mongolian jird"],
         None,
         NCBITAXON_URI_TEMPLATE.format("10047"),


### PR DESCRIPTION
had two PRs, I guess with some rebase/squash we managed to resolve into duplication.  Should have no negative effect since we did unique over hits