### PR TITLE
Add aiohttp dependency with version constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
+    "aiohttp < 3.14",
     "bidsschematools ~= 1.0",
     "bids-validator-deno >= 2.0.5",
     # >=8.2.0: https://github.com/pallets/click/issues/2911

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-    "aiohttp < 3.14",
     "bidsschematools ~= 1.0",
     "bids-validator-deno >= 2.0.5",
     # >=8.2.0: https://github.com/pallets/click/issues/2911
@@ -52,7 +51,6 @@ dependencies = [
     "click-didyoumean",
     "dandischema ~= 0.12.0",
     "etelemetry >= 0.2.2",
-
     "fasteners",
     "fscacher >= 0.3.0",
     # 3.14.4: https://github.com/hdmf-dev/hdmf/issues/1186
@@ -101,6 +99,7 @@ style = [
     "pre-commit",
 ]
 test = [
+    "aiohttp < 3.14",  # See https://github.com/kevin1024/vcrpy/issues/995
     "anys ~= 0.2",
     "coverage",
     # Workaround for VideoWriter regression in 4.13.0.90 on Intel macOS


### PR DESCRIPTION
Looks like dailies started failing just now, noticed it on #1871 

This quickly patches it to get things working again; the true issue seems to be something in a nested depency (not fixable on our side)

Various errors of the form

```
    with ctx:
         ^^^
/opt/hostedtoolcache/Python/3.14.5/x64/lib/python3.14/site-packages/vcr/cassette.py:84: in __enter__
    return next(self.__finish)
           ^^^^^^^^^^^^^^^^^^^
/opt/hostedtoolcache/Python/3.14.5/x64/lib/python3.14/site-packages/vcr/cassette.py:58: in _patch_generator
    for patcher in CassettePatcherBuilder(cassette).build():
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/opt/hostedtoolcache/Python/3.14.5/x64/lib/python3.14/site-packages/vcr/patch.py:129: in _build_patchers_from_mock_triples
    for args in mock_triples:
                ^^^^^^^^^^^^
/opt/hostedtoolcache/Python/3.14.5/x64/lib/python3.14/site-packages/vcr/patch.py:301: in _aiohttp
    from .stubs.aiohttp_stubs import vcr_request
/opt/hostedtoolcache/Python/3.14.5/x64/lib/python3.14/site-packages/vcr/stubs/aiohttp_stubs.py:21: in <module>
    class MockStream(asyncio.StreamReader, streams.AsyncStreamReaderMixin):
                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   AttributeError: module 'aiohttp.streams' has no attribute 'AsyncStreamReaderMixin'
```