### PR TITLE
Migrate style extra to a PEP 735 dependency group

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -7,7 +7,7 @@
 This project's hatch environments use [uv](https://github.com/astral-sh/uv)
 as the installer, which allows for significant improvements in environment
 setup speed. Each environment corresponds to a project
-extra (e.g., `test`, `style`, `tools`). To enter a shell in an environment:
+extra (e.g., `test`, `extras`, `tools`). To enter a shell in an environment:
 
 ```
 hatch shell <env-name>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,12 +240,6 @@ init_forbid_extra = true
 installer = "uv"
 python = "3.10"
 
-[tool.hatch.envs.extensions]
-features = ["extensions"]
-
-[tool.hatch.envs.extras]
-features = ["extras"]
-
 [tool.hatch.envs.test]
 features = ["test"]
 [tool.hatch.envs.test.env-vars]
@@ -255,8 +249,9 @@ DANDI_PAGINATION_DISABLE_FALLBACK = "1"
 [tool.hatch.envs.test.scripts]
 run = "pytest {args:dandi/tests}"
 
-[tool.hatch.envs.tools]
-features = ["tools"]
-
-[tool.hatch.envs.all]
+# Installs every project extra (via the `all` extra) plus the development-only
+# `style` dependency group: a single environment with all dependencies for
+# local development.
+[tool.hatch.envs.dev-all]
 features = ["all"]
+dependency-groups = ["style"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,10 +94,6 @@ extras = [
     "duecredit >= 0.6.0",
     "fsspec[http]",
 ]
-style = [
-    "flake8",
-    "pre-commit",
-]
 test = [
     "aiohttp < 3.14",  # See https://github.com/kevin1024/vcrpy/issues/995
     "anys ~= 0.2",
@@ -119,9 +115,16 @@ tools = [
 all = [
     "dandi[extensions]",
     "dandi[extras]",
-    "dandi[style]",
     "dandi[test]",
     "dandi[tools]",
+]
+
+# Development-only dependency sets, not published in built distributions.
+# See PEP 735.
+[dependency-groups]
+style = [
+    "flake8",
+    "pre-commit",
 ]
 
 [project.urls]
@@ -242,9 +245,6 @@ features = ["extensions"]
 
 [tool.hatch.envs.extras]
 features = ["extras"]
-
-[tool.hatch.envs.style]
-features = ["style"]
 
 [tool.hatch.envs.test]
 features = ["test"]


### PR DESCRIPTION
Migrate the `style` extra (`flake8`, `pre-commit`) to a PEP 735 `[dependency-groups]` table, since those are pure development tooling never installed by consumers of the published package. Also trims the hatch environments down to the ones actually used.

Closes the `style` part of #1873. The `test` extra is intentionally **not** migrated (it backs the shipped test suite that downstream repos run against released `dandi`, see [this comment](https://github.com/dandi/dandi-cli/issues/1873#issuecomment-4609935064)).

### Changes

Commit 1, migrate `style`:
- Move `style` out of `[project.optional-dependencies]` into `[dependency-groups]`.
- Drop `dandi[style]` from the `all` extra (extras cannot reference dependency groups).
- Remove `[tool.hatch.envs.style]` (the style deps were never used in an isolated env; lint runs via `tox -e lint`).
- Update the env-list example in `DEVELOPMENT.md`.

Commit 2, consolidate hatch envs:
- Remove the thin per-extra envs `extensions`, `extras`, `tools`, `all`.
- Keep `default`, `test`, and add `dev-all` (`features = ["all"]` + `dependency-groups = ["style"]`): one environment with every dependency for local development.

<details>
<summary>Verification that the <code>style</code> and <code>all</code> extras have no consumers</summary>

Searched this repo, every `dandi-*` sibling repo on `master`, and a workspace-wide literal sweep for `dandi[style]` / `dandi[all]`: the only reference anywhere was dandi-cli's own `pyproject.toml`. So dropping them breaks nothing downstream.

An isolated environment for an individual extra is still one command away when needed: `hatch shell`, then `uv pip install -e ".[<extra>]"`.

</details>

### Test plan

- [x] `hatch env show --json` lists user envs `default`, `test`, `dev-all`; `dev-all` resolves to `features: ['all']` + `dependency-groups: ['style']`.
- [x] `pyproject.toml` parses; `style` is gone from extras and present in `[dependency-groups]`; `all` extra no longer lists `dandi[style]`.
- [x] CI lint/typing/test jobs pass (they use tox, unaffected by these changes).
