### PR TITLE
Fix dev-deps CI failures: detect pynwb num_samples support via __docval__

### DIFF
--- a/dandi/tests/fixtures.py
+++ b/dandi/tests/fixtures.py
@@ -42,6 +42,11 @@ from ..upload import upload
 
 lgr = get_logger()
 
+# TODO: simply always inject this when minimal supported pynwb is above 3.1.3
+_imgseries_takes_num_samples = any(
+    arg["name"] == "num_samples"
+    for arg in getattr(ImageSeries.__init__, "__docval__", {}).get("args", [])
+)
 
 BIDS_TESTDATA_SELECTION = [
     "asl003",
@@ -812,7 +817,7 @@ def _create_nwb_files(video_list: list[tuple[Path, Path]]) -> Path:
             devices=[device],
         )
 
-        image_series = ImageSeries(
+        imgseries_kwargs: dict[str, Any] = dict(
             name=f"MouseWhiskers{i}",
             format="external",
             external_file=[str(vid_1), str(vid_2)],
@@ -820,6 +825,9 @@ def _create_nwb_files(video_list: list[tuple[Path, Path]]) -> Path:
             starting_time=0.0,
             rate=150.0,
         )
+        if _imgseries_takes_num_samples:
+            imgseries_kwargs["num_samples"] = 4
+        image_series = ImageSeries(**imgseries_kwargs)
         nwbfile.add_acquisition(image_series)
 
         nwbfile_path = base_nwb_path / f"{name}.nwb"


### PR DESCRIPTION
## Summary

Fix failing `dev-deps` CI jobs (ubuntu-latest, Python 3.10 and 3.14) caused by pynwb dev (post-3.1.3) adding `num_samples` as a required parameter for `ImageSeries` when `format='external'` and rate-based timing is used.

## Root cause

The test fixture in `dandi/tests/fixtures.py` creates `ImageSeries` objects without `num_samples`, which pynwb dev now requires. A simple version check via `inspect.signature()` doesn't work because hdmf's `@docval` decorator wraps `__init__` and hides parameters from Python's inspection machinery. Instead, the parameter list is stored in `ImageSeries.__init__.__docval__["args"]`.

## Changes

- `dandi/tests/fixtures.py`: Detect `num_samples` support by inspecting `__docval__["args"]` and conditionally pass `num_samples=4` when creating `ImageSeries` fixtures. Includes a TODO to simplify once the minimum supported pynwb is bumped above 3.1.3.