### PR TITLE
Support click >= 8.2.0

### DIFF
--- a/dandi/cli/base.py
+++ b/dandi/cli/base.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from functools import wraps
 import os
 
@@ -27,6 +28,24 @@ class IntColonInt(click.ParamType):
 
     def get_metavar(self, param, ctx=None):
         return "N[:M]"
+
+
+class EnumChoice(click.Choice):
+    """A ``click.Choice`` over a ``str``-valued ``Enum``, matched on member values.
+
+    The available choices presented on the command line are the enum member
+    values (e.g. ``error``, ``skip``), and ``convert`` returns the corresponding
+    enum member. A string default is converted to its member as well.
+    """
+
+    def __init__(self, enum_cls: type[Enum], case_sensitive: bool = True) -> None:
+        self.enum_cls = enum_cls
+        super().__init__([e.value for e in enum_cls], case_sensitive=case_sensitive)
+
+    def convert(self, value, param, ctx):
+        if value is None or isinstance(value, self.enum_cls):
+            return value
+        return self.enum_cls(super().convert(value, param, ctx))
 
 
 class ChoiceList(click.ParamType):

--- a/dandi/cli/cmd_download.py
+++ b/dandi/cli/cmd_download.py
@@ -5,7 +5,13 @@ import os
 
 import click
 
-from .base import ChoiceList, IntColonInt, instance_option, map_to_click_exceptions
+from .base import (
+    ChoiceList,
+    EnumChoice,
+    IntColonInt,
+    instance_option,
+    map_to_click_exceptions,
+)
 from ..consts import SyncMode
 from ..dandiarchive import _dandi_url_parser, parse_dandi_url
 from ..dandiset import Dandiset
@@ -63,7 +69,7 @@ Download files or entire folders from DANDI.
 @click.option(
     "-e",
     "--existing",
-    type=click.Choice(list(DownloadExisting)),
+    type=EnumChoice(DownloadExisting),
     # TODO: verify-reupload (to become default)
     help="How to handle paths that already exist locally. "
     "For 'error', if the local file exists, display an error and skip downloading that asset. "
@@ -80,12 +86,12 @@ Download files or entire folders from DANDI.
     "-f",
     "--format",
     help="Choose the format/frontend for output. TODO: support all of the ls",
-    type=click.Choice(list(DownloadFormat)),
+    type=EnumChoice(DownloadFormat),
     default="pyout",
 )
 @click.option(
     "--path-type",
-    type=click.Choice(list(PathType)),
+    type=EnumChoice(PathType),
     default="exact",
     help="Whether to interpret asset paths in URLs as exact matches or glob patterns",
     show_default=True,
@@ -121,7 +127,7 @@ Download files or entire folders from DANDI.
     is_flag=False,
     flag_value="ask",
     default=None,
-    type=click.Choice(list(SyncMode)),
+    type=EnumChoice(SyncMode),
     help="Delete local assets that do not exist on the server. "
     "With 'ask' (the default when --sync is passed without a value), prompt before "
     "deleting. With 'do', delete without prompting.",

--- a/dandi/cli/cmd_move.py
+++ b/dandi/cli/cmd_move.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 import click
 
-from .base import devel_debug_option, instance_option, map_to_click_exceptions
+from .base import (
+    EnumChoice,
+    devel_debug_option,
+    instance_option,
+    map_to_click_exceptions,
+)
 from ..move import MoveExisting, MoveWorkOn
 
 
@@ -16,7 +21,7 @@ from ..move import MoveExisting, MoveWorkOn
 @click.option(
     "-e",
     "--existing",
-    type=click.Choice(list(MoveExisting)),
+    type=EnumChoice(MoveExisting),
     default="error",
     help="How to handle assets that would be moved to a destination that already exists",
     show_default=True,
@@ -30,7 +35,7 @@ from ..move import MoveExisting, MoveWorkOn
 @click.option(
     "-w",
     "--work-on",
-    type=click.Choice(list(MoveWorkOn)),
+    type=EnumChoice(MoveWorkOn),
     default="auto",
     help=(
         "Whether to operate on the local Dandiset, remote Dandiset, or both;"

--- a/dandi/cli/cmd_organize.py
+++ b/dandi/cli/cmd_organize.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 import click
 
-from .base import dandiset_path_option, devel_debug_option, map_to_click_exceptions
+from .base import (
+    EnumChoice,
+    dandiset_path_option,
+    devel_debug_option,
+    map_to_click_exceptions,
+)
 from ..consts import dandi_layout_fields
 from ..organize import CopyMode, FileOperationMode, OrganizeInvalid
 
@@ -17,7 +22,7 @@ from ..organize import CopyMode, FileOperationMode, OrganizeInvalid
 @click.option(
     "--invalid",
     help="What to do if files without sufficient metadata are encountered.",
-    type=click.Choice(list(OrganizeInvalid)),
+    type=EnumChoice(OrganizeInvalid),
     default="fail",
     show_default=True,
 )
@@ -30,7 +35,7 @@ from ..organize import CopyMode, FileOperationMode, OrganizeInvalid
     "If 'auto' - whichever of symlink, hardlink, copy is allowed by system. "
     "The other modes (copy, move, symlink, hardlink) define how data files "
     "should be made available.",
-    type=click.Choice(list(FileOperationMode)),
+    type=EnumChoice(FileOperationMode),
     default="auto",
     show_default=True,
 )
@@ -45,7 +50,7 @@ from ..organize import CopyMode, FileOperationMode, OrganizeInvalid
 )
 @click.option(
     "--media-files-mode",
-    type=click.Choice(list(CopyMode)),
+    type=EnumChoice(CopyMode),
     default=None,
     help="How to relocate video files referenced by NWB files",
 )

--- a/dandi/cli/cmd_upload.py
+++ b/dandi/cli/cmd_upload.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import click
 
 from .base import (
+    EnumChoice,
     IntColonInt,
     devel_debug_option,
     devel_option,
@@ -17,7 +18,7 @@ from ..upload import UploadExisting, UploadValidation
 @click.option(
     "-e",
     "--existing",
-    type=click.Choice(list(UploadExisting)),
+    type=EnumChoice(UploadExisting),
     help="What to do if a file found existing on the server. 'skip' would skip"
     "the file, 'force' - force reupload, 'overwrite' - force upload if "
     "either size or modification time differs; 'refresh' - upload only if "
@@ -40,7 +41,7 @@ from ..upload import UploadExisting, UploadValidation
     is_flag=False,
     flag_value="ask",
     default=None,
-    type=click.Choice(list(SyncMode)),
+    type=EnumChoice(SyncMode),
     help="Delete assets on the server that do not exist locally. "
     "With 'ask' (the default when --sync is passed without a value), prompt before "
     "deleting. With 'do', delete without prompting.",
@@ -52,7 +53,7 @@ from ..upload import UploadExisting, UploadValidation
     "'require' - data must pass validation before upload; "
     "'skip' - no validation is performed on data before upload; "
     "'ignore' - data is validated but upload proceeds regardless of validation results.",
-    type=click.Choice(list(UploadValidation)),
+    type=EnumChoice(UploadValidation),
     default="require",
     show_default=True,
 )

--- a/dandi/cli/tests/test_base.py
+++ b/dandi/cli/tests/test_base.py
@@ -1,0 +1,74 @@
+from enum import Enum
+
+import click
+from click.testing import CliRunner
+import pytest
+
+from ..base import EnumChoice
+
+
+class _Existing(str, Enum):
+    ERROR = "error"
+    SKIP = "skip"
+    OVERWRITE = "overwrite-different"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+def _make_command(**option_kwargs):
+    @click.command()
+    @click.option("--existing", type=EnumChoice(_Existing), **option_kwargs)
+    def cmd(existing):
+        click.echo(f"{type(existing).__name__}:{existing!r}")
+
+    return cmd
+
+
+@pytest.mark.ai_generated
+def test_enum_choice_accepts_member_value():
+    captured = {}
+
+    @click.command()
+    @click.option("--existing", type=EnumChoice(_Existing), default="error")
+    def cmd(existing):
+        captured["existing"] = existing
+
+    r = CliRunner().invoke(cmd, ["--existing", "overwrite-different"])
+    assert r.exit_code == 0, r.output
+    assert captured["existing"] is _Existing.OVERWRITE
+
+
+@pytest.mark.ai_generated
+def test_enum_choice_rejects_member_name():
+    r = CliRunner().invoke(_make_command(default="error"), ["--existing", "SKIP"])
+    assert r.exit_code != 0
+    assert "'SKIP' is not one of" in r.output
+
+
+@pytest.mark.ai_generated
+def test_enum_choice_none_default_passes_through():
+    captured = {}
+
+    @click.command()
+    @click.option("--existing", type=EnumChoice(_Existing), default=None)
+    def cmd(existing):
+        captured["existing"] = existing
+
+    r = CliRunner().invoke(cmd, [])
+    assert r.exit_code == 0, r.output
+    assert captured["existing"] is None
+
+
+@pytest.mark.ai_generated
+def test_enum_choice_string_default_converted_to_member():
+    captured = {}
+
+    @click.command()
+    @click.option("--existing", type=EnumChoice(_Existing), default="skip")
+    def cmd(existing):
+        captured["existing"] = existing
+
+    r = CliRunner().invoke(cmd, [])
+    assert r.exit_code == 0, r.output
+    assert captured["existing"] is _Existing.SKIP

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,7 @@ classifiers = [
 dependencies = [
     "bidsschematools ~= 1.0",
     "bids-validator-deno >= 2.0.5",
-    # >=8.2.0: https://github.com/pallets/click/issues/2911
-    "click >= 7.1, <8.2.0",
+    "click >= 7.1",
     "click-didyoumean",
     "dandischema ~= 0.12.0",
     "etelemetry >= 0.2.2",


### PR DESCRIPTION
Closes #1631.

## Summary

Removes the `click < 8.2.0` upper bound so dandi-cli can be installed alongside packages that require newer click (for example `linkml-runtime >= 1.11`, which declares `click >= 8.2`). The bound guarded a behavior change in click 8.2's `Choice` rewrite; this PR adapts dandi's enum based options to that change while preserving the existing command line surface.

## Background

click 8.2 made `Choice` generic. For an `Enum`, `click.Choice(list(SomeEnum))` now matches on the enum member **names** instead of their values. dandi builds twelve options from `(str, Enum)` types whose values are the documented lowercase tokens (`error`, `skip`, `refresh`, ...), so under click 8.2+ those options accept `--existing SKIP` and reject `--existing skip`, breaking every documented invocation. The 8.2.2 release (referenced in click #2911) only changed how the default is rendered in `--help`; the matching behavior is unchanged and still reproduces on click 8.4.

## Changes

- Add `EnumChoice` to `dandi/cli/base.py`: a `click.Choice` subclass built from the enum member values that converts the matched value back to the enum member. This keeps the lowercase value tokens on the command line and passes the enum member to the command callback, matching pre 8.2 behavior on every supported click version.
- Migrate the twelve `click.Choice(list(SomeEnum))` options in `cmd_upload`, `cmd_download`, `cmd_organize`, and `cmd_move` to `EnumChoice(SomeEnum)`. `click.Choice(list(dandi_layout_fields))` is left as is because it is a dict of strings, unaffected by the enum change.
- Drop the `< 8.2.0` upper bound in `pyproject.toml`.
- Add `dandi/cli/tests/test_base.py`.

`EnumChoice` follows the approach already used for `--min-severity` in `cmd_validate.py`, which builds its `Choice` from a list of strings derived from `Severity` (`[i.name for i in Severity]`) rather than from enum members, and is therefore unaffected by the click 8.2 change. `EnumChoice` generalizes that into a reusable type that is value-based and returns the enum member, which the upload, download, organize, and move callbacks expect. (NOTE: there are now two enum-to-Choice idioms in the CLI (value-based `EnumChoice` for str-enums, inline `[i.name for i in …]` for Severity). I kept the change minimal; happy to unify them in a follow-up if preferred.)

## Compatibility

- Behavior is identical on click 8.1.8 and 8.4.2: lowercase value accepted and converted to the enum member, string default converted to the member, member name rejected, and `--help` lists the lowercase values.
- No use of other APIs removed in click 8.2 (`BaseCommand`, `MultiCommand`, the parser module, `split_arg_string`, `OptionParser`).

## Testing

- `dandi/cli/tests/test_base.py`, `test_command.py`, `test_move.py`, and the local `organize` choice mode tests pass on click 8.4.2; the new tests also pass on click 8.1.8.
- `black`, `isort`, `flake8`, and `mypy` pass on all changed files.
- Manual check of `upload`, `download`, `organize`, and `move` `--help` shows lowercase value choices; `--existing skip` resolves to the enum member and `--existing SKIP` is rejected as before.
