### PR TITLE
Set uploaded asset metadata schemaKey to "Asset"

### DIFF
--- a/dandi/dandiapi.py
+++ b/dandi/dandiapi.py
@@ -70,6 +70,20 @@ if TYPE_CHECKING:
 lgr = get_logger()
 
 
+def set_asset_schema_key(metadata: dict[str, Any]) -> None:
+    """
+    Set ``schemaKey`` to ``"Asset"`` on metadata bound for the server as asset metadata.
+
+    However the metadata was gathered (e.g. as a ``BareAsset``), if it is to be uploaded
+    to the server to populate, in part, an ``Asset`` instance, set the ``schemaKey`` of
+    the metadata to ``"Asset"`` here. The server expects the uploaded metadata to carry
+    ``"Asset"`` as its ``schemaKey``.
+
+    The metadata is modified in place.
+    """
+    metadata["schemaKey"] = "Asset"
+
+
 class AssetType(Enum):
     """
     .. versionadded:: 0.36.0
@@ -1993,11 +2007,7 @@ class RemoteBlobAsset(RemoteAsset, BaseRemoteBlobAsset):
         Set the metadata for the asset on the server to the given value and
         update the `RemoteBlobAsset` in place.
         """
-        # Whatever the metadata was gathered as (e.g. a ``BareAsset``),
-        # what is being created on the server is an ``Asset`` as result of the upload.
-        # The server stores ``schemaKey`` verbatim, so set it
-        # here, at the point of upload, rather than relying on the caller.
-        metadata["schemaKey"] = "Asset"
+        set_asset_schema_key(metadata)
         data = self.client.put(
             self.api_path, json={"metadata": metadata, "blob_id": self.blob}
         )
@@ -2021,11 +2031,7 @@ class RemoteZarrAsset(RemoteAsset, BaseRemoteZarrAsset):
         Set the metadata for the asset on the server to the given value and
         update the `RemoteZarrAsset` in place.
         """
-        # Whatever the metadata was gathered as (e.g. a ``BareAsset``),
-        # what is being created on the server is an ``Asset`` as result of the upload.
-        # The server stores ``schemaKey`` verbatim, so set it
-        # here, at the point of upload, rather than relying on the caller.
-        metadata["schemaKey"] = "Asset"
+        set_asset_schema_key(metadata)
         data = self.client.put(
             self.api_path, json={"metadata": metadata, "zarr_id": self.zarr}
         )

--- a/dandi/dandiapi.py
+++ b/dandi/dandiapi.py
@@ -1993,6 +1993,11 @@ class RemoteBlobAsset(RemoteAsset, BaseRemoteBlobAsset):
         Set the metadata for the asset on the server to the given value and
         update the `RemoteBlobAsset` in place.
         """
+        # Whatever the metadata was gathered as (e.g. a ``BareAsset``),
+        # what is being created on the server is an ``Asset`` as result of the upload.
+        # The server stores ``schemaKey`` verbatim, so set it
+        # here, at the point of upload, rather than relying on the caller.
+        metadata["schemaKey"] = "Asset"
         data = self.client.put(
             self.api_path, json={"metadata": metadata, "blob_id": self.blob}
         )
@@ -2016,6 +2021,11 @@ class RemoteZarrAsset(RemoteAsset, BaseRemoteZarrAsset):
         Set the metadata for the asset on the server to the given value and
         update the `RemoteZarrAsset` in place.
         """
+        # Whatever the metadata was gathered as (e.g. a ``BareAsset``),
+        # what is being created on the server is an ``Asset`` as result of the upload.
+        # The server stores ``schemaKey`` verbatim, so set it
+        # here, at the point of upload, rather than relying on the caller.
+        metadata["schemaKey"] = "Asset"
         data = self.client.put(
             self.api_path, json={"metadata": metadata, "zarr_id": self.zarr}
         )

--- a/dandi/files/bases.py
+++ b/dandi/files/bases.py
@@ -25,7 +25,12 @@ from pydantic_core import ErrorDetails
 import requests
 
 import dandi
-from dandi.dandiapi import RemoteAsset, RemoteDandiset, RESTFullAPIClient
+from dandi.dandiapi import (
+    RemoteAsset,
+    RemoteDandiset,
+    RESTFullAPIClient,
+    set_asset_schema_key,
+)
 from dandi.metadata.core import get_default_metadata
 from dandi.misctypes import DUMMY_DANDI_ETAG, Digest, LocalReadableFile, P
 from dandi.utils import post_upload_size_check, pre_upload_size_check, yaml_load
@@ -363,11 +368,7 @@ class LocalFileAsset(LocalAsset):
         from dandi.support.digests import get_dandietag
 
         asset_path = metadata.setdefault("path", self.path)
-        # Whatever the metadata was gathered as (e.g. a ``BareAsset``),
-        # what is being created on the server is an ``Asset`` as result of the upload.
-        # The server stores ``schemaKey`` verbatim, so set it
-        # here, at the point of upload, rather than relying on the caller.
-        metadata["schemaKey"] = "Asset"
+        set_asset_schema_key(metadata)
         client = dandiset.client
         yield {"status": "calculating etag"}
         etagger = get_dandietag(self.filepath)

--- a/dandi/files/bases.py
+++ b/dandi/files/bases.py
@@ -363,6 +363,11 @@ class LocalFileAsset(LocalAsset):
         from dandi.support.digests import get_dandietag
 
         asset_path = metadata.setdefault("path", self.path)
+        # Whatever the metadata was gathered as (e.g. a ``BareAsset``),
+        # what is being created on the server is an ``Asset`` as result of the upload.
+        # The server stores ``schemaKey`` verbatim, so set it
+        # here, at the point of upload, rather than relying on the caller.
+        metadata["schemaKey"] = "Asset"
         client = dandiset.client
         yield {"status": "calculating etag"}
         etagger = get_dandietag(self.filepath)

--- a/dandi/files/zarr.py
+++ b/dandi/files/zarr.py
@@ -580,6 +580,11 @@ class ZarrAsset(LocalDirectoryAsset[LocalZarrEntry]):
             `RemoteAsset`.
         """
         asset_path = metadata.setdefault("path", self.path)
+        # Whatever the metadata was gathered as (e.g. a ``BareAsset``),
+        # what is being created on the server is an ``Asset`` as result of the upload.
+        # The server stores ``schemaKey`` verbatim, so set it
+        # here, at the point of upload, rather than relying on the caller.
+        metadata["schemaKey"] = "Asset"
         client = dandiset.client
         lgr.debug("%s: Producing asset", asset_path)
         yield {"status": "producing asset"}

--- a/dandi/files/zarr.py
+++ b/dandi/files/zarr.py
@@ -38,6 +38,7 @@ from dandi.dandiapi import (
     RemoteZarrAsset,
     RemoteZarrEntry,
     RESTFullAPIClient,
+    set_asset_schema_key,
 )
 from dandi.exceptions import UploadError
 from dandi.metadata.core import get_default_metadata
@@ -580,11 +581,7 @@ class ZarrAsset(LocalDirectoryAsset[LocalZarrEntry]):
             `RemoteAsset`.
         """
         asset_path = metadata.setdefault("path", self.path)
-        # Whatever the metadata was gathered as (e.g. a ``BareAsset``),
-        # what is being created on the server is an ``Asset`` as result of the upload.
-        # The server stores ``schemaKey`` verbatim, so set it
-        # here, at the point of upload, rather than relying on the caller.
-        metadata["schemaKey"] = "Asset"
+        set_asset_schema_key(metadata)
         client = dandiset.client
         lgr.debug("%s: Producing asset", asset_path)
         yield {"status": "producing asset"}

--- a/dandi/tests/data/metadata/metadata2asset.json
+++ b/dandi/tests/data/metadata/metadata2asset.json
@@ -1,6 +1,6 @@
 {
   "id": "dandiasset:0b0a1a0b-e3ea-4cf6-be94-e02c830d54be",
-  "schemaKey": "TO BE SPECIFIED DYNAMICALLY",
+  "schemaKey": "ANYTHING GOOD NOW -- `schemaKey` of a `BareAsset` instance will be adjusted to the default value of the `schemaKey` field in the Pydantic `BareAsset` model",
   "schemaVersion": "0.4.1",
   "keywords": [
     "test",

--- a/dandi/tests/data/metadata/metadata2asset.json
+++ b/dandi/tests/data/metadata/metadata2asset.json
@@ -1,6 +1,6 @@
 {
   "id": "dandiasset:0b0a1a0b-e3ea-4cf6-be94-e02c830d54be",
-  "schemaKey": "Asset",
+  "schemaKey": "TO BE SPECIFIED DYNAMICALLY",
   "schemaVersion": "0.4.1",
   "keywords": [
     "test",

--- a/dandi/tests/data/metadata/metadata2asset_3.json
+++ b/dandi/tests/data/metadata/metadata2asset_3.json
@@ -1,6 +1,6 @@
 {
   "id": "dandiasset:0b0a1a0b-e3ea-4cf6-be94-e02c830d54be",
-  "schemaKey": "TO BE SPECIFIED DYNAMICALLY",
+  "schemaKey": "ANYTHING GOOD NOW -- `schemaKey` of a `BareAsset` instance will be adjusted to the default value of the `schemaKey` field in the Pydantic `BareAsset` model",
   "schemaVersion": "0.4.1",
   "keywords": [
     "test",

--- a/dandi/tests/data/metadata/metadata2asset_3.json
+++ b/dandi/tests/data/metadata/metadata2asset_3.json
@@ -1,6 +1,6 @@
 {
   "id": "dandiasset:0b0a1a0b-e3ea-4cf6-be94-e02c830d54be",
-  "schemaKey": "Asset",
+  "schemaKey": "TO BE SPECIFIED DYNAMICALLY",
   "schemaVersion": "0.4.1",
   "keywords": [
     "test",

--- a/dandi/tests/data/metadata/metadata2asset_cellline.json
+++ b/dandi/tests/data/metadata/metadata2asset_cellline.json
@@ -1,6 +1,6 @@
 {
   "id": "dandiasset:0b0a1a0b-e3ea-4cf6-be94-e02c830d54be",
-  "schemaKey": "TO BE SPECIFIED DYNAMICALLY",
+  "schemaKey": "ANYTHING GOOD NOW -- `schemaKey` of a `BareAsset` instance will be adjusted to the default value of the `schemaKey` field in the Pydantic `BareAsset` model",
   "schemaVersion": "0.4.1",
   "keywords": [
     "test",

--- a/dandi/tests/data/metadata/metadata2asset_cellline.json
+++ b/dandi/tests/data/metadata/metadata2asset_cellline.json
@@ -1,6 +1,6 @@
 {
   "id": "dandiasset:0b0a1a0b-e3ea-4cf6-be94-e02c830d54be",
-  "schemaKey": "Asset",
+  "schemaKey": "TO BE SPECIFIED DYNAMICALLY",
   "schemaVersion": "0.4.1",
   "keywords": [
     "test",

--- a/dandi/tests/data/metadata/metadata2asset_simple1.json
+++ b/dandi/tests/data/metadata/metadata2asset_simple1.json
@@ -1,6 +1,6 @@
 {
   "id": "dandiasset:bfc23fb6192b41c083a7257e09a3702b",
-  "schemaKey": "TO BE SPECIFIED DYNAMICALLY",
+  "schemaKey": "ANYTHING GOOD NOW -- `schemaKey` of a `BareAsset` instance will be adjusted to the default value of the `schemaKey` field in the Pydantic `BareAsset` model",
   "schemaVersion": "0.4.1",
   "keywords": [
     "keyword1",

--- a/dandi/tests/data/metadata/metadata2asset_simple1.json
+++ b/dandi/tests/data/metadata/metadata2asset_simple1.json
@@ -1,6 +1,6 @@
 {
   "id": "dandiasset:bfc23fb6192b41c083a7257e09a3702b",
-  "schemaKey": "Asset",
+  "schemaKey": "TO BE SPECIFIED DYNAMICALLY",
   "schemaVersion": "0.4.1",
   "keywords": [
     "keyword1",

--- a/dandi/tests/test_metadata.py
+++ b/dandi/tests/test_metadata.py
@@ -1135,7 +1135,6 @@ def test_nwb2asset(simple2_nwb: Path) -> None:
     # Classes with ANY_AWARE_DATETIME fields need to be constructed with
     # model_construct()
     assert nwb2asset(simple2_nwb, digest=DUMMY_DANDI_ETAG) == BareAsset.model_construct(
-        schemaKey="Asset",
         schemaVersion=DANDI_SCHEMA_VERSION,
         keywords=["keyword1", "keyword 2"],
         access=[
@@ -1218,7 +1217,6 @@ def test_nwb2asset_remote_asset(nwb_dandiset: SampleDandiset) -> None:
     # Classes with ANY_AWARE_DATETIME fields need to be constructed with
     # model_construct()
     assert nwb2asset(r, digest=digest) == BareAsset.model_construct(
-        schemaKey="Asset",
         schemaVersion=DANDI_SCHEMA_VERSION,
         keywords=["keyword1", "keyword 2"],
         access=[

--- a/dandi/tests/test_metadata.py
+++ b/dandi/tests/test_metadata.py
@@ -418,11 +418,22 @@ def test_prepare_metadata(filename: str, metadata: dict[str, Any]) -> None:
     with (METADATA_DIR / filename).open() as fp:
         data_as_dict = json.load(fp)
     data_as_dict["schemaVersion"] = DANDI_SCHEMA_VERSION
+    # `prepare_metadata()` returns a `BareAsset`, so the top-level `schemaKey`
+    # of `data` is the default of the `schemaKey` field of `BareAsset` of the
+    # installed dandischema: "Asset" historically, but "BareAsset" once
+    # https://github.com/dandi/dandi-schema/pull/419 lands, which pins
+    # `BareAsset.schemaKey` to its own class name.  The JSON files store a
+    # placeholder for this field, so set it to the current default here to keep
+    # the comparison independent of the installed dandischema version.
+    data_as_dict["schemaKey"] = BareAsset.model_fields["schemaKey"].default
     assert data == data_as_dict
+
+    # `data_as_dict` is a BareAsset; the following lines turn it into an Asset
+    # instance so that `validate()` below checks it against the Asset class: set
+    # its `schemaKey`, and add the Asset-only fields `identifier` and (as of
+    # schema-0.5.0, https://github.com/dandi/dandischema/pull/52) `contentUrl`.
+    data_as_dict["schemaKey"] = "Asset"
     data_as_dict["identifier"] = "0b0a1a0b-e3ea-4cf6-be94-e02c830d54be"
-    # as of schema-0.5.0 (https://github.com/dandi/dandischema/pull/52)
-    # contentUrl is required, and validate below would map into Asset,
-    # due to schemaKey
     if Version(DANDI_SCHEMA_VERSION) >= Version("0.5.0"):
         data_as_dict["contentUrl"] = ["http://example.com"]
     validate(data_as_dict)

--- a/dandi/tests/test_upload.py
+++ b/dandi/tests/test_upload.py
@@ -50,6 +50,10 @@ def test_upload_download(
     (dspath / parent).mkdir()
     copyfile(nwb_file, dspath / parent / name)
     new_dandiset.upload()
+    # The uploaded asset's metadata is derived from a ``BareAsset``, but it must
+    # be uploaded and stored with a ``schemaKey`` of `"Asset"`
+    (asset,) = d.get_assets()
+    assert asset.get_raw_metadata()["schemaKey"] == "Asset"
     download(d.version_api_url, tmp_path)
     assert list_paths(tmp_path) == [
         tmp_path / d.identifier / dandiset_metadata_file,


### PR DESCRIPTION
## Summary

Pin `schemaKey` to `"Asset"` on every metadata dict written to an asset endpoint. This is the lockstep client change for dandi/dandi-schema#419, which changes `BareAsset.schemaKey` from `"Asset"` to `"BareAsset"`.

Whatever the metadata was gathered as (e.g. a `BareAsset`), what is created on the server is an `Asset`. The archive stores `schemaKey` verbatim and does not normalize it, so once `BareAsset.schemaKey` becomes `"BareAsset"`, `BareAsset`-derived metadata would be stored with the wrong `schemaKey`. Setting it at the point of upload keeps this correct regardless of how the metadata was gathered.

It is a **no-op against the current dandi-schema release** (where `BareAsset.schemaKey` is still `"Asset"`), so it can merge and release ahead of the dandi-schema change.

<details>
<summary>What changed</summary>

`schemaKey` is set to `"Asset"` at every sink that writes to an asset create/update endpoint:

- `LocalFileAsset.iter_upload` and `ZarrAsset.iter_upload` (POST create / PUT replace), next to the existing `metadata.setdefault("path", ...)` step. Covers the normal CLI upload, the deprecated `upload_raw_asset` / `iter_upload_raw_asset`, and direct `LocalAsset.upload()` / `iter_upload()` API use.
- `RemoteBlobAsset.set_raw_metadata` and `RemoteZarrAsset.set_raw_metadata` (PUT update). The `reextract` service command reaches these with `BareAsset`-derived metadata (`nwb2asset` returns a `BareAsset`) without going through `iter_upload`.

`RemoteDandisetVersion.set_raw_metadata` is left untouched: it writes Dandiset metadata, not an asset.
</details>

<details>
<summary>Test adaptations for the <code>BareAsset.schemaKey</code> change</summary>

Two metadata tests hard-coded the top-level `schemaKey` of a `BareAsset` as `"Asset"`, which becomes `"BareAsset"` under dandi/dandi-schema#419. Both now track the default of the `schemaKey` field in `BareAsset` rather than a literal, so they pass against the current dandischema and #419 alike:

- `test_nwb2asset` / `test_nwb2asset_remote_asset`: drop the redundant explicit `schemaKey="Asset"`, which merely restated the field default.
- `test_prepare_metadata`: set the expected `schemaKey` to the default of the `schemaKey` field in `BareAsset` before the comparison (the four `metadata2asset*.json` files now store a placeholder for it), and promote the object to an `Asset` before the `validate()` call that checks it against the `Asset` class.
</details>

## Test plan

- [x] `black --check` clean on the changed files (verified out-of-band; the repo's pinned black currently crashes under Python 3.14, unrelated to this change)
- [x] `test_upload_download` extended to assert the uploaded asset's stored `schemaKey == "Asset"` (needs the Docker-backed archive fixtures in CI)
- [x] Confirm against the consolidated schema (`BareAsset.schemaKey == "BareAsset"`) via #1888, which repoints the `dandischema` dependency at the dandi/dandi-schema#419 branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
