### PR TITLE
DO NOT MERGE: check #1886 schemaKey handling against dandi-schema #419

### DIFF
--- a/dandi/dandiapi.py
+++ b/dandi/dandiapi.py
@@ -70,6 +70,20 @@ if TYPE_CHECKING:
 lgr = get_logger()
 
 
+def set_asset_schema_key(metadata: dict[str, Any]) -> None:
+    """
+    Set ``schemaKey`` to ``"Asset"`` on metadata bound for the server as asset metadata.
+
+    However the metadata was gathered (e.g. as a ``BareAsset``), if it is to be uploaded
+    to the server to populate, in part, an ``Asset`` instance, set the ``schemaKey`` of
+    the metadata to ``"Asset"`` here. The server expects the uploaded metadata to carry
+    ``"Asset"`` as its ``schemaKey``.
+
+    The metadata is modified in place.
+    """
+    metadata["schemaKey"] = "Asset"
+
+
 class AssetType(Enum):
     """
     .. versionadded:: 0.36.0
@@ -1993,11 +2007,7 @@ class RemoteBlobAsset(RemoteAsset, BaseRemoteBlobAsset):
         Set the metadata for the asset on the server to the given value and
         update the `RemoteBlobAsset` in place.
         """
-        # Whatever the metadata was gathered as (e.g. a ``BareAsset``),
-        # what is being created on the server is an ``Asset`` as result of the upload.
-        # The server stores ``schemaKey`` verbatim, so set it
-        # here, at the point of upload, rather than relying on the caller.
-        metadata["schemaKey"] = "Asset"
+        set_asset_schema_key(metadata)
         data = self.client.put(
             self.api_path, json={"metadata": metadata, "blob_id": self.blob}
         )
@@ -2021,11 +2031,7 @@ class RemoteZarrAsset(RemoteAsset, BaseRemoteZarrAsset):
         Set the metadata for the asset on the server to the given value and
         update the `RemoteZarrAsset` in place.
         """
-        # Whatever the metadata was gathered as (e.g. a ``BareAsset``),
-        # what is being created on the server is an ``Asset`` as result of the upload.
-        # The server stores ``schemaKey`` verbatim, so set it
-        # here, at the point of upload, rather than relying on the caller.
-        metadata["schemaKey"] = "Asset"
+        set_asset_schema_key(metadata)
         data = self.client.put(
             self.api_path, json={"metadata": metadata, "zarr_id": self.zarr}
         )

--- a/dandi/dandiapi.py
+++ b/dandi/dandiapi.py
@@ -1993,6 +1993,11 @@ class RemoteBlobAsset(RemoteAsset, BaseRemoteBlobAsset):
         Set the metadata for the asset on the server to the given value and
         update the `RemoteBlobAsset` in place.
         """
+        # Whatever the metadata was gathered as (e.g. a ``BareAsset``),
+        # what is being created on the server is an ``Asset`` as result of the upload.
+        # The server stores ``schemaKey`` verbatim, so set it
+        # here, at the point of upload, rather than relying on the caller.
+        metadata["schemaKey"] = "Asset"
         data = self.client.put(
             self.api_path, json={"metadata": metadata, "blob_id": self.blob}
         )
@@ -2016,6 +2021,11 @@ class RemoteZarrAsset(RemoteAsset, BaseRemoteZarrAsset):
         Set the metadata for the asset on the server to the given value and
         update the `RemoteZarrAsset` in place.
         """
+        # Whatever the metadata was gathered as (e.g. a ``BareAsset``),
+        # what is being created on the server is an ``Asset`` as result of the upload.
+        # The server stores ``schemaKey`` verbatim, so set it
+        # here, at the point of upload, rather than relying on the caller.
+        metadata["schemaKey"] = "Asset"
         data = self.client.put(
             self.api_path, json={"metadata": metadata, "zarr_id": self.zarr}
         )

--- a/dandi/files/bases.py
+++ b/dandi/files/bases.py
@@ -25,7 +25,12 @@ from pydantic_core import ErrorDetails
 import requests
 
 import dandi
-from dandi.dandiapi import RemoteAsset, RemoteDandiset, RESTFullAPIClient
+from dandi.dandiapi import (
+    RemoteAsset,
+    RemoteDandiset,
+    RESTFullAPIClient,
+    set_asset_schema_key,
+)
 from dandi.metadata.core import get_default_metadata
 from dandi.misctypes import DUMMY_DANDI_ETAG, Digest, LocalReadableFile, P
 from dandi.utils import post_upload_size_check, pre_upload_size_check, yaml_load
@@ -363,11 +368,7 @@ class LocalFileAsset(LocalAsset):
         from dandi.support.digests import get_dandietag
 
         asset_path = metadata.setdefault("path", self.path)
-        # Whatever the metadata was gathered as (e.g. a ``BareAsset``),
-        # what is being created on the server is an ``Asset`` as result of the upload.
-        # The server stores ``schemaKey`` verbatim, so set it
-        # here, at the point of upload, rather than relying on the caller.
-        metadata["schemaKey"] = "Asset"
+        set_asset_schema_key(metadata)
         client = dandiset.client
         yield {"status": "calculating etag"}
         etagger = get_dandietag(self.filepath)

--- a/dandi/files/bases.py
+++ b/dandi/files/bases.py
@@ -363,6 +363,11 @@ class LocalFileAsset(LocalAsset):
         from dandi.support.digests import get_dandietag
 
         asset_path = metadata.setdefault("path", self.path)
+        # Whatever the metadata was gathered as (e.g. a ``BareAsset``),
+        # what is being created on the server is an ``Asset`` as result of the upload.
+        # The server stores ``schemaKey`` verbatim, so set it
+        # here, at the point of upload, rather than relying on the caller.
+        metadata["schemaKey"] = "Asset"
         client = dandiset.client
         yield {"status": "calculating etag"}
         etagger = get_dandietag(self.filepath)

--- a/dandi/files/zarr.py
+++ b/dandi/files/zarr.py
@@ -580,6 +580,11 @@ class ZarrAsset(LocalDirectoryAsset[LocalZarrEntry]):
             `RemoteAsset`.
         """
         asset_path = metadata.setdefault("path", self.path)
+        # Whatever the metadata was gathered as (e.g. a ``BareAsset``),
+        # what is being created on the server is an ``Asset`` as result of the upload.
+        # The server stores ``schemaKey`` verbatim, so set it
+        # here, at the point of upload, rather than relying on the caller.
+        metadata["schemaKey"] = "Asset"
         client = dandiset.client
         lgr.debug("%s: Producing asset", asset_path)
         yield {"status": "producing asset"}

--- a/dandi/files/zarr.py
+++ b/dandi/files/zarr.py
@@ -38,6 +38,7 @@ from dandi.dandiapi import (
     RemoteZarrAsset,
     RemoteZarrEntry,
     RESTFullAPIClient,
+    set_asset_schema_key,
 )
 from dandi.exceptions import UploadError
 from dandi.metadata.core import get_default_metadata
@@ -580,11 +581,7 @@ class ZarrAsset(LocalDirectoryAsset[LocalZarrEntry]):
             `RemoteAsset`.
         """
         asset_path = metadata.setdefault("path", self.path)
-        # Whatever the metadata was gathered as (e.g. a ``BareAsset``),
-        # what is being created on the server is an ``Asset`` as result of the upload.
-        # The server stores ``schemaKey`` verbatim, so set it
-        # here, at the point of upload, rather than relying on the caller.
-        metadata["schemaKey"] = "Asset"
+        set_asset_schema_key(metadata)
         client = dandiset.client
         lgr.debug("%s: Producing asset", asset_path)
         yield {"status": "producing asset"}

--- a/dandi/tests/data/metadata/metadata2asset.json
+++ b/dandi/tests/data/metadata/metadata2asset.json
@@ -1,6 +1,6 @@
 {
   "id": "dandiasset:0b0a1a0b-e3ea-4cf6-be94-e02c830d54be",
-  "schemaKey": "TO BE SPECIFIED DYNAMICALLY",
+  "schemaKey": "ANYTHING GOOD NOW -- `schemaKey` of a `BareAsset` instance will be adjusted to the default value of the `schemaKey` field in the Pydantic `BareAsset` model",
   "schemaVersion": "0.4.1",
   "keywords": [
     "test",

--- a/dandi/tests/data/metadata/metadata2asset.json
+++ b/dandi/tests/data/metadata/metadata2asset.json
@@ -1,6 +1,6 @@
 {
   "id": "dandiasset:0b0a1a0b-e3ea-4cf6-be94-e02c830d54be",
-  "schemaKey": "Asset",
+  "schemaKey": "TO BE SPECIFIED DYNAMICALLY",
   "schemaVersion": "0.4.1",
   "keywords": [
     "test",

--- a/dandi/tests/data/metadata/metadata2asset_3.json
+++ b/dandi/tests/data/metadata/metadata2asset_3.json
@@ -1,6 +1,6 @@
 {
   "id": "dandiasset:0b0a1a0b-e3ea-4cf6-be94-e02c830d54be",
-  "schemaKey": "TO BE SPECIFIED DYNAMICALLY",
+  "schemaKey": "ANYTHING GOOD NOW -- `schemaKey` of a `BareAsset` instance will be adjusted to the default value of the `schemaKey` field in the Pydantic `BareAsset` model",
   "schemaVersion": "0.4.1",
   "keywords": [
     "test",

--- a/dandi/tests/data/metadata/metadata2asset_3.json
+++ b/dandi/tests/data/metadata/metadata2asset_3.json
@@ -1,6 +1,6 @@
 {
   "id": "dandiasset:0b0a1a0b-e3ea-4cf6-be94-e02c830d54be",
-  "schemaKey": "Asset",
+  "schemaKey": "TO BE SPECIFIED DYNAMICALLY",
   "schemaVersion": "0.4.1",
   "keywords": [
     "test",

--- a/dandi/tests/data/metadata/metadata2asset_cellline.json
+++ b/dandi/tests/data/metadata/metadata2asset_cellline.json
@@ -1,6 +1,6 @@
 {
   "id": "dandiasset:0b0a1a0b-e3ea-4cf6-be94-e02c830d54be",
-  "schemaKey": "TO BE SPECIFIED DYNAMICALLY",
+  "schemaKey": "ANYTHING GOOD NOW -- `schemaKey` of a `BareAsset` instance will be adjusted to the default value of the `schemaKey` field in the Pydantic `BareAsset` model",
   "schemaVersion": "0.4.1",
   "keywords": [
     "test",

--- a/dandi/tests/data/metadata/metadata2asset_cellline.json
+++ b/dandi/tests/data/metadata/metadata2asset_cellline.json
@@ -1,6 +1,6 @@
 {
   "id": "dandiasset:0b0a1a0b-e3ea-4cf6-be94-e02c830d54be",
-  "schemaKey": "Asset",
+  "schemaKey": "TO BE SPECIFIED DYNAMICALLY",
   "schemaVersion": "0.4.1",
   "keywords": [
     "test",

--- a/dandi/tests/data/metadata/metadata2asset_simple1.json
+++ b/dandi/tests/data/metadata/metadata2asset_simple1.json
@@ -1,6 +1,6 @@
 {
   "id": "dandiasset:bfc23fb6192b41c083a7257e09a3702b",
-  "schemaKey": "TO BE SPECIFIED DYNAMICALLY",
+  "schemaKey": "ANYTHING GOOD NOW -- `schemaKey` of a `BareAsset` instance will be adjusted to the default value of the `schemaKey` field in the Pydantic `BareAsset` model",
   "schemaVersion": "0.4.1",
   "keywords": [
     "keyword1",

--- a/dandi/tests/data/metadata/metadata2asset_simple1.json
+++ b/dandi/tests/data/metadata/metadata2asset_simple1.json
@@ -1,6 +1,6 @@
 {
   "id": "dandiasset:bfc23fb6192b41c083a7257e09a3702b",
-  "schemaKey": "Asset",
+  "schemaKey": "TO BE SPECIFIED DYNAMICALLY",
   "schemaVersion": "0.4.1",
   "keywords": [
     "keyword1",

--- a/dandi/tests/test_metadata.py
+++ b/dandi/tests/test_metadata.py
@@ -1135,7 +1135,6 @@ def test_nwb2asset(simple2_nwb: Path) -> None:
     # Classes with ANY_AWARE_DATETIME fields need to be constructed with
     # model_construct()
     assert nwb2asset(simple2_nwb, digest=DUMMY_DANDI_ETAG) == BareAsset.model_construct(
-        schemaKey="Asset",
         schemaVersion=DANDI_SCHEMA_VERSION,
         keywords=["keyword1", "keyword 2"],
         access=[
@@ -1218,7 +1217,6 @@ def test_nwb2asset_remote_asset(nwb_dandiset: SampleDandiset) -> None:
     # Classes with ANY_AWARE_DATETIME fields need to be constructed with
     # model_construct()
     assert nwb2asset(r, digest=digest) == BareAsset.model_construct(
-        schemaKey="Asset",
         schemaVersion=DANDI_SCHEMA_VERSION,
         keywords=["keyword1", "keyword 2"],
         access=[

--- a/dandi/tests/test_metadata.py
+++ b/dandi/tests/test_metadata.py
@@ -418,11 +418,22 @@ def test_prepare_metadata(filename: str, metadata: dict[str, Any]) -> None:
     with (METADATA_DIR / filename).open() as fp:
         data_as_dict = json.load(fp)
     data_as_dict["schemaVersion"] = DANDI_SCHEMA_VERSION
+    # `prepare_metadata()` returns a `BareAsset`, so the top-level `schemaKey`
+    # of `data` is the default of the `schemaKey` field of `BareAsset` of the
+    # installed dandischema: "Asset" historically, but "BareAsset" once
+    # https://github.com/dandi/dandi-schema/pull/419 lands, which pins
+    # `BareAsset.schemaKey` to its own class name.  The JSON files store a
+    # placeholder for this field, so set it to the current default here to keep
+    # the comparison independent of the installed dandischema version.
+    data_as_dict["schemaKey"] = BareAsset.model_fields["schemaKey"].default
     assert data == data_as_dict
+
+    # `data_as_dict` is a BareAsset; the following lines turn it into an Asset
+    # instance so that `validate()` below checks it against the Asset class: set
+    # its `schemaKey`, and add the Asset-only fields `identifier` and (as of
+    # schema-0.5.0, https://github.com/dandi/dandischema/pull/52) `contentUrl`.
+    data_as_dict["schemaKey"] = "Asset"
     data_as_dict["identifier"] = "0b0a1a0b-e3ea-4cf6-be94-e02c830d54be"
-    # as of schema-0.5.0 (https://github.com/dandi/dandischema/pull/52)
-    # contentUrl is required, and validate below would map into Asset,
-    # due to schemaKey
     if Version(DANDI_SCHEMA_VERSION) >= Version("0.5.0"):
         data_as_dict["contentUrl"] = ["http://example.com"]
     validate(data_as_dict)

--- a/dandi/tests/test_upload.py
+++ b/dandi/tests/test_upload.py
@@ -50,6 +50,10 @@ def test_upload_download(
     (dspath / parent).mkdir()
     copyfile(nwb_file, dspath / parent / name)
     new_dandiset.upload()
+    # The uploaded asset's metadata is derived from a ``BareAsset``, but it must
+    # be uploaded and stored with a ``schemaKey`` of `"Asset"`
+    (asset,) = d.get_assets()
+    assert asset.get_raw_metadata()["schemaKey"] == "Asset"
     download(d.version_api_url, tmp_path)
     assert list_paths(tmp_path) == [
         tmp_path / d.identifier / dandiset_metadata_file,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,10 @@ dependencies = [
     "bids-validator-deno >= 2.0.5",
     "click >= 8.2",
     "click-didyoumean",
-    "dandischema ~= 0.12.0",
+    # Temporarily point at the dandi-schema #419 branch, where
+    # BareAsset.schemaKey is "BareAsset", so CI runs the client against the
+    # consolidated schema to check the schemaKey handling on this branch.
+    "dandischema @ git+https://github.com/dandi/dandi-schema.git@consolidate-models",
     "etelemetry >= 0.2.2",
     "fasteners",
     "fscacher >= 0.3.0",


### PR DESCRIPTION
## Not for merging

This PR exists only to check the test outcome for #1886 with the changes in the [dandi-schema #419](https://github.com/dandi/dandi-schema/pull/419) branch incorporated. It is not meant to be merged.

## What this does

Branches off #1886 and temporarily repoints the `dandischema` dependency at the [dandi-schema #419](https://github.com/dandi/dandi-schema/pull/419) `consolidate-models` branch, where `BareAsset.schemaKey` is `"BareAsset"` (instead of `"Asset"`).

That is the condition #1886 addresses. With the changes in the [dandi-schema #419](https://github.com/dandi/dandi-schema/pull/419) branch, metadata gathered as a `BareAsset` carries `schemaKey="BareAsset"`, and #1886 resets `schemaKey` to `"Asset"` before the metadata is written to an asset endpoint, allowing `test_upload_download` to pass with the changes in [dandi-schema #419](https://github.com/dandi/dandi-schema/pull/419).

<details>
<summary>Why the archive's dandischema version does not affect the test</summary>

In this PR's CI, only the client (dandi-cli) picks up the [dandi-schema #419](https://github.com/dandi/dandi-schema/pull/419) branch; the test archive is the stock `dandiarchive/dandiarchive-api` image (`dandischema==0.12.1`). (Eventually dandi-archive will adopt the dandi-schema #419 changes too.) That the archive still runs the older dandischema does not matter here: dandi-archive does not use `BareAsset`, and `Asset` / `PublishedAsset` behave the same under `dandischema==0.12.1` and the [dandi-schema #419](https://github.com/dandi/dandi-schema/pull/419) branch, so the archive treats the uploaded metadata identically either way. The branch also keeps `DANDI_SCHEMA_VERSION == "0.7.0"`, matching the archive, so the upload path is not disturbed.
</details>
