### PR TITLE
Drop python 3.10 and simplify for  click 8.2 enum choice 

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,8 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - '3.10'
-          #- 3.11
+          - '3.11'
     steps:
     - name: Check out repository
       uses: actions/checkout@v7

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install build & twine
         run: python -m pip install build twine

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -34,8 +34,7 @@ jobs:
           - macos-latest  # M1 architecture
           - macos-15-intel  # non-M1 architecture
         python:
-          - '3.10'  # Needs quotes so YAML doesn't think it's 3.1
-          - '3.11'
+          - '3.11'  # Needs quotes so YAML doesn't think it's 3.1
           - '3.12'
           - '3.13'
           - '3.14'
@@ -48,10 +47,10 @@ jobs:
           - default
         include:
           - os: ubuntu-latest
-            python: '3.10'
+            python: '3.11'
             mode: dandi-api
           - os: ubuntu-latest
-            python: '3.10'
+            python: '3.11'
             mode: dandi-api
             vendored_dandiapi: ember-dandi
             instance_name: EMBER-DANDI
@@ -61,13 +60,13 @@ jobs:
             python: 3.14
             mode: obolibrary-only
           - os: ubuntu-latest
-            python: '3.10'
+            python: '3.11'
             mode: dev-deps
           - os: ubuntu-latest
             python: 3.14
             mode: dev-deps
           - os: ubuntu-latest
-            python: '3.10'
+            python: '3.11'
             mode: nfs
 
     steps:

--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install dependencies
         run: |

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,7 +2,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.11"
 python:
     install:
         - requirements: docs/requirements.txt

--- a/dandi/cli/base.py
+++ b/dandi/cli/base.py
@@ -31,21 +31,17 @@ class IntColonInt(click.ParamType):
 
 
 class EnumChoice(click.Choice):
-    """A ``click.Choice`` over a ``str``-valued ``Enum``, matched on member values.
+    """A ``click.Choice`` over an ``Enum``, matched on member values.
 
-    The available choices presented on the command line are the enum member
-    values (e.g. ``error``, ``skip``), and ``convert`` returns the corresponding
-    enum member. A string default is converted to its member as well.
+    ``click >= 8.2`` matches ``Enum`` members on ``.name`` by default; this
+    subclass overrides :meth:`click.Choice.normalize_choice` to match on
+    ``.value`` instead, so command-line tokens stay the lowercase enum values
+    (``error``, ``skip``, ...). ``click.Choice.convert`` then returns the
+    matched enum member.
     """
 
-    def __init__(self, enum_cls: type[Enum], case_sensitive: bool = True) -> None:
-        self.enum_cls = enum_cls
-        super().__init__([e.value for e in enum_cls], case_sensitive=case_sensitive)
-
-    def convert(self, value, param, ctx):
-        if value is None or isinstance(value, self.enum_cls):
-            return value
-        return self.enum_cls(super().convert(value, param, ctx))
+    def normalize_choice(self, choice, ctx=None):
+        return choice.value if isinstance(choice, Enum) else str(choice)
 
 
 class ChoiceList(click.ParamType):

--- a/dandi/cli/tests/test_base.py
+++ b/dandi/cli/tests/test_base.py
@@ -1,4 +1,4 @@
-from enum import Enum
+from enum import StrEnum
 
 import click
 from click.testing import CliRunner
@@ -7,13 +7,10 @@ import pytest
 from ..base import EnumChoice
 
 
-class _Existing(str, Enum):
+class _Existing(StrEnum):
     ERROR = "error"
     SKIP = "skip"
     OVERWRITE = "overwrite-different"
-
-    def __str__(self) -> str:
-        return self.value
 
 
 def _make_command(**option_kwargs):

--- a/dandi/consts.py
+++ b/dandi/consts.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from dataclasses import dataclass
-from enum import Enum
+from enum import Enum, StrEnum
 import os
 
 #: A list of metadata fields which dandi extracts from .nwb files.
@@ -101,12 +101,9 @@ class EmbargoStatus(Enum):
     EMBARGOED = "EMBARGOED"
 
 
-class SyncMode(str, Enum):
+class SyncMode(StrEnum):
     ASK = "ask"
     DO = "do"
-
-    def __str__(self) -> str:
-        return self.value
 
 
 dandiset_metadata_file = "dandiset.yaml"

--- a/dandi/download.py
+++ b/dandi/download.py
@@ -14,7 +14,7 @@ from collections import Counter, deque
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from dataclasses import InitVar, dataclass, field
 from datetime import datetime
-from enum import Enum
+from enum import Enum, StrEnum
 from functools import partial
 import hashlib
 import inspect
@@ -69,31 +69,22 @@ from .utils import (
 lgr = get_logger()
 
 
-class DownloadExisting(str, Enum):
+class DownloadExisting(StrEnum):
     ERROR = "error"
     SKIP = "skip"
     OVERWRITE = "overwrite"
     OVERWRITE_DIFFERENT = "overwrite-different"
     REFRESH = "refresh"
 
-    def __str__(self) -> str:
-        return self.value
 
-
-class DownloadFormat(str, Enum):
+class DownloadFormat(StrEnum):
     PYOUT = "pyout"
     DEBUG = "debug"
 
-    def __str__(self) -> str:
-        return self.value
 
-
-class PathType(str, Enum):
+class PathType(StrEnum):
     EXACT = "exact"
     GLOB = "glob"
-
-    def __str__(self) -> str:
-        return self.value
 
 
 def download(

--- a/dandi/move.py
+++ b/dandi/move.py
@@ -15,7 +15,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from contextlib import ExitStack
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import StrEnum
 from itertools import zip_longest
 import os.path
 from pathlib import Path, PurePosixPath
@@ -35,23 +35,17 @@ from .support import pyout as pyouts
 lgr = get_logger()
 
 
-class MoveExisting(str, Enum):
+class MoveExisting(StrEnum):
     ERROR = "error"
     SKIP = "skip"
     OVERWRITE = "overwrite"
 
-    def __str__(self) -> str:
-        return self.value
 
-
-class MoveWorkOn(str, Enum):
+class MoveWorkOn(StrEnum):
     AUTO = "auto"
     BOTH = "both"
     LOCAL = "local"
     REMOTE = "remote"
-
-    def __str__(self) -> str:
-        return self.value
 
 
 #: A /-separated path to an asset, relative to the root of the Dandiset

--- a/dandi/organize.py
+++ b/dandi/organize.py
@@ -15,11 +15,11 @@ import binascii
 from collections import Counter
 from collections.abc import Sequence
 from copy import deepcopy
-from enum import Enum
+from enum import StrEnum
 import os
 import os.path as op
-import posixpath
 from pathlib import Path, PurePosixPath
+import posixpath
 import re
 import traceback
 import uuid
@@ -54,7 +54,7 @@ from .validate._types import (
 lgr = get_logger()
 
 
-class FileOperationMode(str, Enum):
+class FileOperationMode(StrEnum):
     DRY = "dry"
     SIMULATE = "simulate"
     COPY = "copy"
@@ -63,22 +63,16 @@ class FileOperationMode(str, Enum):
     SYMLINK = "symlink"
     AUTO = "auto"
 
-    def __str__(self) -> str:
-        return self.value
-
     def as_copy_mode(self) -> CopyMode:
         # Raises ValueError if the mode can't be mapped to a CopyMode
         return CopyMode(self.value)
 
 
-class CopyMode(str, Enum):
+class CopyMode(StrEnum):
     SYMLINK = "symlink"
     COPY = "copy"
     MOVE = "move"
     HARDLINK = "hardlink"
-
-    def __str__(self) -> str:
-        return self.value
 
     def copy(self, old_path: AnyPath, new_path: AnyPath) -> None:
         if self is CopyMode.SYMLINK:
@@ -93,12 +87,9 @@ class CopyMode(str, Enum):
             raise AssertionError(f"Unhandled CopyMode member: {self!r}")
 
 
-class OrganizeInvalid(str, Enum):
+class OrganizeInvalid(StrEnum):
     FAIL = "fail"
     WARN = "warn"
-
-    def __str__(self) -> str:
-        return self.value
 
 
 dandi_path = op.join("sub-{subject_id}", "{dandi_filename}")

--- a/dandi/upload.py
+++ b/dandi/upload.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Iterator, Sequence
 from contextlib import ExitStack
-from enum import Enum
+from enum import StrEnum
 import io
 import os.path
 from pathlib import Path
@@ -83,24 +83,18 @@ class Uploaded(TypedDict):
     errors: list[str]
 
 
-class UploadExisting(str, Enum):
+class UploadExisting(StrEnum):
     ERROR = "error"
     SKIP = "skip"
     FORCE = "force"
     OVERWRITE = "overwrite"
     REFRESH = "refresh"
 
-    def __str__(self) -> str:
-        return self.value
 
-
-class UploadValidation(str, Enum):
+class UploadValidation(StrEnum):
     REQUIRE = "require"
     SKIP = "skip"
     IGNORE = "ignore"
-
-    def __str__(self) -> str:
-        return self.value
 
 
 def upload(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = 'setuptools.build_meta'
 name = "dandi"
 description = "Command line client for interaction with DANDI instances"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 license = {file = "LICENSE"}
 authors = [
     {name = "DANDI developers", email = "team@dandiarchive.org"},
@@ -36,7 +36,6 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -237,7 +236,7 @@ init_forbid_extra = true
 
 [tool.hatch.envs.default]
 installer = "uv"
-python = "3.10"
+python = "3.11"
 
 [tool.hatch.envs.test]
 features = ["test"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ classifiers = [
 dependencies = [
     "bidsschematools ~= 1.0",
     "bids-validator-deno >= 2.0.5",
-    "click >= 7.1",
+    "click >= 8.2",
     "click-didyoumean",
     "dandischema ~= 0.12.0",
     "etelemetry >= 0.2.2",

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,6 @@ skip_install = true
 deps =
     codespell~=2.4.1
     flake8
-    tomli; python_version < '3.11'
 commands =
     codespell dandi docs tools setup.py
     flake8 --config=setup.cfg {posargs} dandi setup.py


### PR DESCRIPTION
## Summary

Follow-up to #1883 that collapses the click-8.2 compatibility shim
and rebases the CLI enums on the standard-library `enum.StrEnum`
(Python 3.11+). No behavior change — same command-line surface,
same `--help` output, same accept/reject semantics.

Two independent commits:

1. **click 8.2 exposes `Choice.normalize_choice`** as the explicit hook
   for choice-string normalization. Overriding it to return `.value`
   for `Enum` members (instead of the default `.name`) is *all* that
   is needed to preserve the pre-8.2 CLI surface, because
   `Choice.convert` then matches by normalized string and returns the
   matched enum member automatically. The custom `__init__` +
   `convert` + `self.enum_cls` bookkeeping in #1883's `EnumChoice`
   become unnecessary. Bumps the `click` floor from `>= 7.1` to
   `>= 8.2` — the earlier bound predates `normalize_choice`.

2. **Migrate the 11 CLI-facing `(str, Enum)` classes to
   `enum.StrEnum`** and drop their hand-written
   `__str__ -> self.value` overrides. `StrEnum` was introduced in
   Python 3.11 and provides exactly these semantics natively. This
   requires bumping the minimum Python from 3.10 (EOL 2026-10-04)
   to 3.11: `pyproject.toml`, `tox.ini`, and 5 GitHub Actions
   workflows are updated accordingly (matrix drops the 3.10 leg;
   pinned single-Python `include:` entries move to 3.11).

Net change vs merged #1883: **+39 / −83** across 14 files.

## Commits

- b2d3c648 `Simplify EnumChoice via click 8.2 normalize_choice hook`
- 5d2cec5e `Adopt enum.StrEnum for CLI choice enums; drop Python 3.10`

<details><summary>Per-commit details</summary>

### b2d3c648 `Simplify EnumChoice via click 8.2 normalize_choice hook`

`EnumChoice` shrinks from ~15 lines (custom `__init__`, `convert`,
`self.enum_cls`, defensive `None`/`isinstance` guards) to a single
3-line `normalize_choice` override. Callsites are unchanged —
iterating an Enum class yields members, and `click.Choice.__init__`
already does `tuple(choices)` on any iterable, so
`EnumChoice(DownloadExisting)` still works verbatim.

`pyproject.toml`: `click >= 7.1` → `click >= 8.2`. The
`normalize_choice` hook is documented "added in 8.2.0" upstream;
retaining a lower bound would just be dead compatibility.

### 5d2cec5e `Adopt enum.StrEnum for CLI choice enums; drop Python 3.10`

Migrated: `SyncMode` (`consts.py`), `DownloadExisting` /
`DownloadFormat` / `PathType` (`download.py`), `UploadExisting` /
`UploadValidation` (`upload.py`), `MoveExisting` / `MoveWorkOn`
(`move.py`), `FileOperationMode` / `CopyMode` / `OrganizeInvalid`
(`organize.py`). Each gets its `(str, Enum)` base changed to
`StrEnum` and its `__str__ -> self.value` override deleted.

`_Existing` in `dandi/cli/tests/test_base.py` also migrated for
consistency.

`EnumChoice` itself is unchanged — `StrEnum` still exposes distinct
`.name` and `.value`, and click 8.2 still defaults to matching on
`.name`, so the `normalize_choice` override remains necessary.

Python floor moves from 3.10 to 3.11 to unlock `enum.StrEnum`:

- `pyproject.toml`: `requires-python = ">=3.11"`, drop the 3.10
  classifier, `[tool.hatch.envs.default] python = "3.11"`.
- `tox.ini`: drop the `tomli; python_version < '3.11'` conditional
  from the lint env (unreachable under the new floor).
- `.github/workflows/run-tests.yml`: matrix drops `3.10`; the five
  `include:` entries pinned to `'3.10'` (`dandi-api`, `dandi-api` +
  `ember-dandi`, `dev-deps`, `nfs`, and the `ember-dandi` sandbox
  vendored config) move to `'3.11'`.
- `.github/workflows/{lint,docs,release,typing}.yml`: single
  `python-version` bumps to `'3.11'`.

**Intentionally not migrated**: `dandi/utils.py:StrEnum` (a
`(str, Enum)` shim used by `dandi/validate/_types.py` and
`dandi/bids_validator_deno/_models.py`). Its
`_generate_next_value_` returns `name` (case-preserving), while
`enum.StrEnum._generate_next_value_` returns `name.lower()`.
Migrating it would change every `auto()`-derived value that appears
in serialized `ValidationResult` output (`Standard.BIDS` → `"BIDS"`
vs `"bids"`, etc.) — a separate audit worth its own PR.

</details>

## Test plan

- [x] `pytest dandi/cli/tests/{test_base,test_command,test_move,test_download}.py` — all pass on click 8.4.2 + Python 3.13
- [x] Broader `dandi/cli/tests/ + dandi/tests/test_organize.py` — 154 pass (only pre-existing `bids-validator-deno`-binary-dependent tests skipped in local env)
- [x] `dandi organize --files-mode SIMULATE` still rejected; lowercase `simulate` still accepted
- [x] `dandi {download,upload,organize,move} --help` render lowercase choice lists unchanged
- [x] Pre-commit hooks (black, isort, codespell, flake8, reuse) pass on both commits
- [x] Test locally interactively
- [x] CI green on the PR (Ubuntu / macOS / Windows × Python 3.11–3.14)
