### PR TITLE
Document validation caveats of the `get_metadata` methods

### DIFF
--- a/dandi/dandiapi.py
+++ b/dandi/dandiapi.py
@@ -1167,6 +1167,15 @@ class RemoteDandiset:
             Only published Dandiset versions can be expected to have valid
             metadata.  Consider using `get_raw_metadata()` instead in order to
             fetch unstructured, possibly-invalid metadata.
+
+            Even a published version's metadata can fail to validate.  The
+            fetched metadata is validated against the `Dandiset` model of the installed
+            `dandischema`, not against the version of `Dandiset` model that the metadata
+            was published under, so drift between the two can render
+            previously-valid metadata invalid.
+
+        :raises pydantic.ValidationError: if the fetched metadata does not
+            validate against `dandischema.models.Dandiset`
         """
         return models.Dandiset.model_validate(self.get_raw_metadata())
 
@@ -1575,6 +1584,15 @@ class BaseRemoteAsset(ABC, APIBase):
             Only assets in published Dandiset versions can be expected to have
             valid metadata.  Consider using `get_raw_metadata()` instead in
             order to fetch unstructured, possibly-invalid metadata.
+
+            Even a published version's asset metadata can fail to validate.  The
+            fetched metadata is validated against the `Asset` model of the installed
+            `dandischema`, not against the version of `Asset` model that the metadata
+            was published under, so drift between the two can render
+            previously-valid metadata invalid.
+
+        :raises pydantic.ValidationError: if the fetched metadata does not
+            validate against `dandischema.models.Asset`
         """
         return models.Asset.model_validate(self.get_raw_metadata())
 


### PR DESCRIPTION
Docstring-only change to `RemoteDandiset.get_metadata()` and `BaseRemoteAsset.get_metadata()`. No behavior change.

Both methods validate fetched metadata against the `Dandiset`/`Asset` model of the **installed** `dandischema`, not against the version of that model the metadata was published under. The existing note only warns that unpublished versions may have invalid metadata, which leaves two things unstated:

- **Even a published version's metadata can fail to validate**, because of drift between the model in the installed `dandischema` and the version of the model the metadata was published under.
- **The methods can raise `pydantic.ValidationError`** when the fetched metadata does not validate against `dandischema.models.Dandiset` / `dandischema.models.Asset`.

Both are now documented, the latter as a `:raises:` field matching the convention already used elsewhere in `dandiapi.py`.

## Test plan

- [x] pre-commit hooks pass (black, isort, flake8, codespell, reuse lint)
- [x] `flake8` and `black --check` clean on `dandi/dandiapi.py`
