### PR TITLE
Build expected metadata with the server's DANDI schema version

### DIFF
--- a/dandi/cli/tests/test_service_scripts.py
+++ b/dandi/cli/tests/test_service_scripts.py
@@ -9,7 +9,6 @@ import sys
 
 import anys
 from click.testing import CliRunner
-from dandischema.consts import DANDI_SCHEMA_VERSION
 from dandischema.models import ID_PATTERN
 import pytest
 
@@ -104,18 +103,21 @@ def test_update_dandiset_from_doi(
         )
     assert r.exit_code == 0
     metadata = new_dandiset.dandiset.get_raw_metadata()
+    # The DANDI schema version in the metadata under test is the server's,
+    # not this client's.
+    server_schema_version = new_dandiset.client.get("/info/")["schema_version"]
     with (DATA_DIR / "update_dandiset_from_doi" / f"{name}.json").open() as fp:
         expected = json.load(fp)
     expected["id"] = anys.AnyFullmatch(rf"{ID_PATTERN}:{dandiset_id}/draft")
     expected["url"] = f"{repository}/dandiset/{dandiset_id}/draft"
     expected["@context"] = (
         "https://raw.githubusercontent.com/dandi/schema/master/releases"
-        f"/{DANDI_SCHEMA_VERSION}/context.json"
+        f"/{server_schema_version}/context.json"
     )
     expected["identifier"] = anys.AnyFullmatch(rf"{ID_PATTERN}:{dandiset_id}")
     expected["repository"] = repository
     expected["dateCreated"] = anys.ANY_AWARE_DATETIME_STR
-    expected["schemaVersion"] = DANDI_SCHEMA_VERSION
+    expected["schemaVersion"] = server_schema_version
     expected["wasGeneratedBy"][0]["id"] = anys.AnyFullmatch(
         r"urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
     )


### PR DESCRIPTION
## Problem

`test_update_dandiset_from_doi` fills the `schemaVersion` and `@context` of its expected metadata from the `DANDI_SCHEMA_VERSION` of the client's `dandischema`, but in the served metadata under test both carry the server's. While dandi-cli and the dandi-archive instance are built against the same `dandischema` the two coincide and the test passes; once they differ, every parametrization fails on those two fields even when the DOI-derived metadata the test exists to check is correct. The test thus asserts something it was never meant to: that both sides run the same `DANDI_SCHEMA_VERSION`.

## Fix

Build those two fields from the schema version reported by the server's `/info/`, as the test already does for the other instance-dependent fields (`url`, `repository`, `manifestLocation`).

<details>
<summary>Where this surfaced</summary>

dandi/dandi-schema#419 bumps `DANDI_SCHEMA_VERSION` to `0.8.0`. In that repo's `test-dandi-cli` matrix, the `schema_install: server` job installs the branch into the API image only, leaving a released client against a `0.8.0` server. All five parametrizations then fail, while the other 1001 tests in the job pass:

```
{'schemaVersion': '0.8.0'} != {'schemaVersion': '0.7.0'}
{'@context': '.../releases/0.8.0/context.json'} != {'.../releases/0.7.0/context.json'}
```
</details>

## Test plan

- [x] pre-commit hooks pass
- [x] CI, as a no-regression check. It cannot show the benefit, since both sides there run the same released `dandischema`; that is verified by re-running the `server` job of dandi/dandi-schema#419 once this is merged.