### PR TITLE
Point failed uploads to validation report

### DIFF
--- a/dandi/cli/cmd_upload.py
+++ b/dandi/cli/cmd_upload.py
@@ -11,6 +11,7 @@ from .base import (
     map_to_click_exceptions,
 )
 from ..consts import SyncMode
+from ..exceptions import UploadValidationError
 from ..upload import UploadExisting, UploadValidation
 
 
@@ -119,16 +120,19 @@ def upload(
         validation_companion_path(ctx.obj.logfile) if ctx.obj is not None else None
     )
 
-    upload_(
-        paths,
-        existing=existing,
-        validation=validation,
-        dandi_instance=dandi_instance,
-        allow_any_path=allow_any_path,
-        upload_dandiset_metadata=upload_dandiset_metadata,
-        devel_debug=devel_debug,
-        jobs=jobs,
-        jobs_per_file=jobs_per_file,
-        sync=SyncMode(sync) if sync is not None else None,
-        validation_log_path=companion,
-    )
+    try:
+        upload_(
+            paths,
+            existing=existing,
+            validation=validation,
+            dandi_instance=dandi_instance,
+            allow_any_path=allow_any_path,
+            upload_dandiset_metadata=upload_dandiset_metadata,
+            devel_debug=devel_debug,
+            jobs=jobs,
+            jobs_per_file=jobs_per_file,
+            sync=SyncMode(sync) if sync is not None else None,
+            validation_log_path=companion,
+        )
+    except UploadValidationError as exc:
+        raise click.ClickException(str(exc))

--- a/dandi/cli/tests/test_cmd_upload.py
+++ b/dandi/cli/tests/test_cmd_upload.py
@@ -2,12 +2,14 @@ from click.testing import CliRunner
 import pytest
 from pytest_mock import MockerFixture
 
+from ..base import map_to_click_exceptions
 from ..cmd_upload import upload
 from ...exceptions import UploadValidationError
 
 
 @pytest.mark.ai_generated
 def test_upload_validation_error_has_no_traceback(mocker: MockerFixture) -> None:
+    mocker.patch.object(map_to_click_exceptions, "_do_map", False)
     mocker.patch(
         "dandi.upload.upload",
         side_effect=UploadValidationError("failed validation"),

--- a/dandi/cli/tests/test_cmd_upload.py
+++ b/dandi/cli/tests/test_cmd_upload.py
@@ -1,0 +1,20 @@
+from click.testing import CliRunner
+import pytest
+from pytest_mock import MockerFixture
+
+from ..cmd_upload import upload
+from ...exceptions import UploadValidationError
+
+
+@pytest.mark.ai_generated
+def test_upload_validation_error_has_no_traceback(mocker: MockerFixture) -> None:
+    mocker.patch(
+        "dandi.upload.upload",
+        side_effect=UploadValidationError("failed validation"),
+    )
+
+    result = CliRunner().invoke(upload)
+
+    assert result.exit_code == 1
+    assert result.output == "Error: failed validation\n"
+    assert "Traceback" not in result.output

--- a/dandi/exceptions.py
+++ b/dandi/exceptions.py
@@ -91,3 +91,9 @@ class HTTP404Error(requests.HTTPError):
 
 class UploadError(Exception):
     pass
+
+
+class UploadValidationError(UploadError):
+    """An upload could not proceed because an asset failed validation."""
+
+    pass

--- a/dandi/tests/fixtures.py
+++ b/dandi/tests/fixtures.py
@@ -592,18 +592,13 @@ class SampleDandiset:
     def client(self) -> DandiAPIClient:
         return self.api.client
 
-    def upload(
-        self,
-        paths: list[str | Path] | None = None,
-        devel_debug: bool = True,
-        **kwargs: Any,
-    ) -> None:
+    def upload(self, paths: list[str | Path] | None = None, **kwargs: Any) -> None:
         with pytest.MonkeyPatch().context() as m:
             self.api.monkeypatch_set_api_key_env(m)
             upload(
                 paths=paths or [self.dspath],
                 dandi_instance=self.api.instance_id,
-                devel_debug=devel_debug,
+                devel_debug=True,
                 **{**self.upload_kwargs, **kwargs},
             )
 

--- a/dandi/tests/fixtures.py
+++ b/dandi/tests/fixtures.py
@@ -592,13 +592,18 @@ class SampleDandiset:
     def client(self) -> DandiAPIClient:
         return self.api.client
 
-    def upload(self, paths: list[str | Path] | None = None, **kwargs: Any) -> None:
+    def upload(
+        self,
+        paths: list[str | Path] | None = None,
+        devel_debug: bool = True,
+        **kwargs: Any,
+    ) -> None:
         with pytest.MonkeyPatch().context() as m:
             self.api.monkeypatch_set_api_key_env(m)
             upload(
                 paths=paths or [self.dspath],
                 dandi_instance=self.api.instance_id,
-                devel_debug=True,
+                devel_debug=devel_debug,
                 **{**self.upload_kwargs, **kwargs},
             )
 

--- a/dandi/tests/test_upload.py
+++ b/dandi/tests/test_upload.py
@@ -220,6 +220,7 @@ def test_upload_bids_invalid(
         bids_dandiset_invalid.upload(
             existing=UploadExisting.FORCE,
             validation_log_path=validation_log,
+            devel_debug=False,
         )
     iter_upload_spy.assert_not_called()
     assert (

--- a/dandi/tests/test_upload.py
+++ b/dandi/tests/test_upload.py
@@ -220,7 +220,6 @@ def test_upload_bids_invalid(
         bids_dandiset_invalid.upload(
             existing=UploadExisting.FORCE,
             validation_log_path=validation_log,
-            devel_debug=False,
         )
     iter_upload_spy.assert_not_called()
     assert (

--- a/dandi/tests/test_upload.py
+++ b/dandi/tests/test_upload.py
@@ -207,13 +207,25 @@ def test_upload_sync_do(mocker: MockerFixture, text_dandiset: SampleDandiset) ->
         text_dandiset.dandiset.get_asset_by_path("file.txt")
 
 
+@pytest.mark.ai_generated
 def test_upload_bids_invalid(
-    mocker: MockerFixture, bids_dandiset_invalid: SampleDandiset
+    caplog: pytest.LogCaptureFixture,
+    mocker: MockerFixture,
+    bids_dandiset_invalid: SampleDandiset,
+    tmp_path: Path,
 ) -> None:
     iter_upload_spy = mocker.spy(LocalFileAsset, "iter_upload")
+    validation_log = tmp_path / "upload_validation.jsonl"
     with pytest.raises(UploadError):
-        bids_dandiset_invalid.upload(existing=UploadExisting.FORCE)
+        bids_dandiset_invalid.upload(
+            existing=UploadExisting.FORCE,
+            validation_log_path=validation_log,
+        )
     iter_upload_spy.assert_not_called()
+    assert (
+        f"Use `dandi validate --load {validation_log}` to review the saved results."
+        in caplog.text
+    )
     # Does validation ignoring work?
     bids_dandiset_invalid.upload(
         existing=UploadExisting.FORCE, validation=UploadValidation.IGNORE

--- a/dandi/upload.py
+++ b/dandi/upload.py
@@ -451,40 +451,41 @@ def upload(
             style=pyout_style, columns=rec_fields, max_workers=jobs or 5
         )
 
-        with out:
-            for dfile in dandi_files:
-                while len(process_paths) >= 10:
-                    lgr.log(2, "Sleep waiting for some paths to finish processing")
-                    time.sleep(0.5)
+        try:
+            with out:
+                for dfile in dandi_files:
+                    while len(process_paths) >= 10:
+                        lgr.log(2, "Sleep waiting for some paths to finish processing")
+                        time.sleep(0.5)
 
-                process_paths.add(str(dfile.filepath))
+                    process_paths.add(str(dfile.filepath))
 
-                rec: dict[Any, Any]
-                if isinstance(dfile, DandisetMetadataFile):
-                    rec = {"path": dandiset_metadata_file}
-                else:
-                    assert isinstance(dfile, LocalAsset)
-                    rec = {"path": dfile.path}
-
-                try:
-                    if devel_debug:
-                        # DEBUG: do serially
-                        for v in process_path(dfile):
-                            print(str(v), flush=True)
+                    rec: dict[Any, Any]
+                    if isinstance(dfile, DandisetMetadataFile):
+                        rec = {"path": dandiset_metadata_file}
                     else:
-                        rec[tuple(rec_fields[1:])] = process_path(dfile)
-                except ValueError as exc:
-                    rec.update(error_file(exc))
-                out(rec)
+                        assert isinstance(dfile, LocalAsset)
+                        rec = {"path": dfile.path}
 
-        if not validate_ok:
-            msg = "One or more assets failed validation."
-            if validation_log_path is not None:
-                msg += (
-                    f" Use `dandi validate --load {validation_log_path}`"
-                    " to review the saved results."
-                )
-            lgr.warning(msg)
+                    try:
+                        if devel_debug:
+                            # DEBUG: do serially
+                            for v in process_path(dfile):
+                                print(str(v), flush=True)
+                        else:
+                            rec[tuple(rec_fields[1:])] = process_path(dfile)
+                    except ValueError as exc:
+                        rec.update(error_file(exc))
+                    out(rec)
+        finally:
+            if not validate_ok:
+                msg = "One or more assets failed validation."
+                if validation_log_path is not None:
+                    msg += (
+                        f" Use `dandi validate --load {validation_log_path}`"
+                        " to review the saved results."
+                    )
+                lgr.warning(msg)
         if upload_err is not None:
             try:
                 import etelemetry

--- a/dandi/upload.py
+++ b/dandi/upload.py
@@ -38,7 +38,7 @@ from .consts import (
 )
 from .dandiapi import DandiAPIClient, RemoteAsset
 from .dandiset import Dandiset
-from .exceptions import NotFoundError, UploadError
+from .exceptions import NotFoundError, UploadError, UploadValidationError
 from .files import (
     DandiFile,
     DandisetMetadataFile,
@@ -318,7 +318,7 @@ def upload(
                             for i, e in enumerate(validation_errors, start=1):
                                 lgr.warning(" Error %d: %s", i, e)
                             validate_ok = False
-                            raise UploadError("failed validation")
+                            raise UploadValidationError("failed validation")
                     else:
                         yield {"status": "validated"}
                 else:
@@ -478,10 +478,14 @@ def upload(
                 out(rec)
 
         if not validate_ok:
-            lgr.warning(
-                "One or more assets failed validation.  Consult the logfile for"
-                " details."
-            )
+            if validation_log_path is None:
+                lgr.warning("One or more assets failed validation.")
+            else:
+                lgr.warning(
+                    "One or more assets failed validation.  Use"
+                    " `dandi validate --load %s` to review the saved results.",
+                    validation_log_path,
+                )
         if upload_err is not None:
             try:
                 import etelemetry

--- a/dandi/upload.py
+++ b/dandi/upload.py
@@ -451,33 +451,7 @@ def upload(
             style=pyout_style, columns=rec_fields, max_workers=jobs or 5
         )
 
-        try:
-            with out:
-                for dfile in dandi_files:
-                    while len(process_paths) >= 10:
-                        lgr.log(2, "Sleep waiting for some paths to finish processing")
-                        time.sleep(0.5)
-
-                    process_paths.add(str(dfile.filepath))
-
-                    rec: dict[Any, Any]
-                    if isinstance(dfile, DandisetMetadataFile):
-                        rec = {"path": dandiset_metadata_file}
-                    else:
-                        assert isinstance(dfile, LocalAsset)
-                        rec = {"path": dfile.path}
-
-                    try:
-                        if devel_debug:
-                            # DEBUG: do serially
-                            for v in process_path(dfile):
-                                print(str(v), flush=True)
-                        else:
-                            rec[tuple(rec_fields[1:])] = process_path(dfile)
-                    except ValueError as exc:
-                        rec.update(error_file(exc))
-                    out(rec)
-        finally:
+        def report_validation_failure() -> None:
             if not validate_ok:
                 msg = "One or more assets failed validation."
                 if validation_log_path is not None:
@@ -486,6 +460,33 @@ def upload(
                         " to review the saved results."
                     )
                 lgr.warning(msg)
+
+        with ExitStack() as warning_stack, out:
+            warning_stack.callback(report_validation_failure)
+            for dfile in dandi_files:
+                while len(process_paths) >= 10:
+                    lgr.log(2, "Sleep waiting for some paths to finish processing")
+                    time.sleep(0.5)
+
+                process_paths.add(str(dfile.filepath))
+
+                rec: dict[Any, Any]
+                if isinstance(dfile, DandisetMetadataFile):
+                    rec = {"path": dandiset_metadata_file}
+                else:
+                    assert isinstance(dfile, LocalAsset)
+                    rec = {"path": dfile.path}
+
+                try:
+                    if devel_debug:
+                        # DEBUG: do serially
+                        for v in process_path(dfile):
+                            print(str(v), flush=True)
+                    else:
+                        rec[tuple(rec_fields[1:])] = process_path(dfile)
+                except ValueError as exc:
+                    rec.update(error_file(exc))
+                out(rec)
         if upload_err is not None:
             try:
                 import etelemetry

--- a/dandi/upload.py
+++ b/dandi/upload.py
@@ -478,14 +478,13 @@ def upload(
                 out(rec)
 
         if not validate_ok:
-            if validation_log_path is None:
-                lgr.warning("One or more assets failed validation.")
-            else:
-                lgr.warning(
-                    "One or more assets failed validation.  Use"
-                    " `dandi validate --load %s` to review the saved results.",
-                    validation_log_path,
+            msg = "One or more assets failed validation."
+            if validation_log_path is not None:
+                msg += (
+                    f" Use `dandi validate --load {validation_log_path}`"
+                    " to review the saved results."
                 )
+            lgr.warning(msg)
         if upload_err is not None:
             try:
                 import etelemetry


### PR DESCRIPTION
## Summary

- point failed uploads to the saved validation report with a ready-to-run `dandi validate --load` command
- handle validation failures as normal CLI errors, including when development options are enabled
- cover the report guidance and no-traceback behavior with regression tests

Closes #1859.

## Testing

- `python -m pytest dandi/cli/tests/test_cmd_upload.py -q`
- Black, isort, flake8, and codespell on the changed files
- `python -m mypy dandi` (93 source files)
- full CLI suite: 118 passed, 8 skipped, 1 xpassed; 7 environment-dependent failures on Windows from a missing Deno executable and unavailable symlink privileges
