### PR TITLE
ci(fix): do not smoke test docs examples in lowest-deps env

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -154,7 +154,9 @@ jobs:
         python -m pytest -s -v -m obolibrary dandi
 
     - name: Smoke test example code in docs
-      if: matrix.mode != 'dandi-api' && github.event_name == 'schedule'
+      # Skipped in lowest-deps mode: that mode installs no dependencies into
+      # the job interpreter, so `dandi` is only importable inside the tox env.
+      if: matrix.mode != 'dandi-api' && matrix.mode != 'lowest-deps' && github.event_name == 'schedule'
       run: |
         set -ex
         cd docs/source/examples


### PR DESCRIPTION
The `Tests` workflow has failed on master on every scheduled run since 7d21e3b added `lowest-deps` on 2026-08-04: 22 consecutive nightlies, latest [run 32815583678](https://github.com/dandi/dandi-cli/actions/runs/32815583678). That leg is the only failing job in each.

`Install dependencies` is guarded by `matrix.mode != 'lowest-deps'`, so the leg installs only tox and `dandi` resolves inside the tox venv alone. `Smoke test example code in docs` has no such guard and runs `python docs/source/examples/*.py` against the job interpreter, raising `ModuleNotFoundError: No module named 'dandi'`. The step fires only on `schedule`, so PR runs stay green.

Rejected alternative: preserve the coverage by running the examples through a tox env, so the lower bounds get exercised via `as_readable()` and fsspec, not by pytest alone. That is a decision about what the nightly should cover, not a fix for a red default branch, so this adds the guard only, matching #1770.

Residual limitation: docs examples are no longer smoke tested under lowest resolution.

Measurement: expanding the matrix from the YAML and evaluating both step conditions over all 27 legs by 3 event names, the smoke step is selected without the install on one combination before the change (`ubuntu-latest, 3.11, lowest-deps, schedule`) and none after, while remaining selected on 24 scheduled legs covering `normal`, `dev-deps`, `nfs` and `obolibrary-only`.

`Check PR Labels` needs a maintainer label; `tests` looks right.
