### PR TITLE
Stop using deprecated Click test/version APIs

### DIFF
--- a/dandi/cli/cmd_shell_completion.py
+++ b/dandi/cli/cmd_shell_completion.py
@@ -2,7 +2,6 @@ import os
 from os.path import basename, normcase, splitext
 
 import click
-from packaging.version import Version
 
 SHELLS = ["bash", "zsh", "fish"]
 
@@ -42,11 +41,7 @@ def shell_completion(shell):
             shell = stem
         if shell not in SHELLS:
             raise click.UsageError(f"Unsupported/unrecognized shell {shell!r}")
-    if Version(click.__version__) < Version("8.0.0"):
-        varfmt = "source_{shell}"
-    else:
-        varfmt = "{shell}_source"
-    os.environ["_DANDI_COMPLETE"] = varfmt.format(shell=shell)
+    os.environ["_DANDI_COMPLETE"] = f"{shell}_source"
 
     # Avoid circular import by importing within function:
     from .command import main

--- a/dandi/cli/tests/test_command.py
+++ b/dandi/cli/tests/test_command.py
@@ -12,7 +12,7 @@ from ..command import __all_commands__
 
 
 @pytest.mark.parametrize("command", (ls, validate))
-def test_smoke(organized_nwb_dir, command):
+def test_smoke(organized_nwb_dir, command, tmp_path, monkeypatch):
     runner = CliRunner()
     r = runner.invoke(command, [str(organized_nwb_dir)])
     assert r.exit_code == 0, f"Exited abnormally. out={r.stdout}"
@@ -23,7 +23,8 @@ def test_smoke(organized_nwb_dir, command):
     # have all kinds of files which could trip the command, e.g. validate
     # could find some broken test files in the code base
     if command is not validate:
-        with runner.isolated_filesystem():
+        with monkeypatch.context() as m:
+            m.chdir(tmp_path)
             r = runner.invoke(command, [])
         assert r.exit_code == 0, f"Exited abnormally. out={r.stdout}"
 

--- a/dandi/cli/tests/test_digest.py
+++ b/dandi/cli/tests/test_digest.py
@@ -22,13 +22,13 @@ _EXPECTED_SAMPLE_ZARR_DIGEST_BY_FORMAT = {
 }
 
 
-def test_digest_default():
+def test_digest_default(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     runner = CliRunner()
-    with runner.isolated_filesystem():
-        Path("file.txt").write_bytes(b"123")
-        r = runner.invoke(digest, ["file.txt"])
-        assert r.exit_code == 0
-        assert r.output == "file.txt: d022646351048ac0ba397d12dfafa304-1\n"
+    monkeypatch.chdir(tmp_path)
+    Path("file.txt").write_bytes(b"123")
+    r = runner.invoke(digest, ["file.txt"])
+    assert r.exit_code == 0
+    assert r.output == "file.txt: d022646351048ac0ba397d12dfafa304-1\n"
 
 
 @pytest.mark.parametrize(
@@ -46,59 +46,63 @@ def test_digest_default():
         ),
     ],
 )
-def test_digest(alg, filehash):
+def test_digest(
+    alg: str, filehash: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     runner = CliRunner()
-    with runner.isolated_filesystem():
-        Path("file.txt").write_bytes(b"123")
-        r = runner.invoke(digest, ["--digest", alg, "file.txt"])
-        assert r.exit_code == 0
-        assert r.output == f"file.txt: {filehash}\n"
+    monkeypatch.chdir(tmp_path)
+    Path("file.txt").write_bytes(b"123")
+    r = runner.invoke(digest, ["--digest", alg, "file.txt"])
+    assert r.exit_code == 0
+    assert r.output == f"file.txt: {filehash}\n"
 
 
-def test_digest_zarr():
+def test_digest_zarr(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     # Expected digest is selected by the Zarr serialisation format that
     # ``zarr.save`` actually produced (V2 vs V3 layouts have different digests).
     runner = CliRunner()
-    with runner.isolated_filesystem():
-        dt = np.dtype("<i8")
-        zarr.save(
-            "sample.zarr", np.arange(1000, dtype=dt), np.arange(1000, 0, -1, dtype=dt)
-        )
-        expected = _EXPECTED_SAMPLE_ZARR_DIGEST_BY_FORMAT[
-            zarr_format_of(Path("sample.zarr"))
-        ]
-        r = runner.invoke(digest, ["--digest", "zarr-checksum", "sample.zarr"])
-        assert r.exit_code == 0
-        assert r.output == f"sample.zarr: {expected}\n"
+    monkeypatch.chdir(tmp_path)
+    dt = np.dtype("<i8")
+    zarr.save(
+        "sample.zarr", np.arange(1000, dtype=dt), np.arange(1000, 0, -1, dtype=dt)
+    )
+    expected = _EXPECTED_SAMPLE_ZARR_DIGEST_BY_FORMAT[
+        zarr_format_of(Path("sample.zarr"))
+    ]
+    r = runner.invoke(digest, ["--digest", "zarr-checksum", "sample.zarr"])
+    assert r.exit_code == 0
+    assert r.output == f"sample.zarr: {expected}\n"
 
 
-def test_digest_empty_zarr(tmp_path: Path) -> None:
+def test_digest_empty_zarr(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     runner = CliRunner()
-    with runner.isolated_filesystem():
-        os.mkdir("empty.zarr")
-        r = runner.invoke(digest, ["--digest", "zarr-checksum", "empty.zarr"])
-        assert r.exit_code == 0
-        assert r.output == "empty.zarr: 481a2f77ab786a0f45aafd5db0971caa-0--0\n"
+    monkeypatch.chdir(tmp_path)
+    os.mkdir("empty.zarr")
+    r = runner.invoke(digest, ["--digest", "zarr-checksum", "empty.zarr"])
+    assert r.exit_code == 0
+    assert r.output == "empty.zarr: 481a2f77ab786a0f45aafd5db0971caa-0--0\n"
 
 
-def test_digest_zarr_with_excluded_dotfiles():
+def test_digest_zarr_with_excluded_dotfiles(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     # See comment in `test_digest_zarr` regarding V2 vs V3 serialisation.
     runner = CliRunner()
-    with runner.isolated_filesystem():
-        dt = np.dtype("<i8")
-        zarr.save(
-            "sample.zarr", np.arange(1000, dtype=dt), np.arange(1000, 0, -1, dtype=dt)
-        )
-        expected = _EXPECTED_SAMPLE_ZARR_DIGEST_BY_FORMAT[
-            zarr_format_of(Path("sample.zarr"))
-        ]
-        subprocess.run(["git", "init"], cwd="sample.zarr", check=True)
-        os.mkdir("sample.zarr/.dandi")
-        Path("sample.zarr", ".dandi", "somefile.txt").touch()
-        Path("sample.zarr", ".gitattributes").touch()
-        Path("sample.zarr", "arr_0", ".gitmodules").touch()
-        Path("sample.zarr", "arr_1", ".datalad").mkdir()
-        Path("sample.zarr", "arr_1", ".datalad", "config").touch()
-        r = runner.invoke(digest, ["--digest", "zarr-checksum", "sample.zarr"])
-        assert r.exit_code == 0
-        assert r.output == f"sample.zarr: {expected}\n"
+    monkeypatch.chdir(tmp_path)
+    dt = np.dtype("<i8")
+    zarr.save(
+        "sample.zarr", np.arange(1000, dtype=dt), np.arange(1000, 0, -1, dtype=dt)
+    )
+    expected = _EXPECTED_SAMPLE_ZARR_DIGEST_BY_FORMAT[
+        zarr_format_of(Path("sample.zarr"))
+    ]
+    subprocess.run(["git", "init"], cwd="sample.zarr", check=True)
+    os.mkdir("sample.zarr/.dandi")
+    Path("sample.zarr", ".dandi", "somefile.txt").touch()
+    Path("sample.zarr", ".gitattributes").touch()
+    Path("sample.zarr", "arr_0", ".gitmodules").touch()
+    Path("sample.zarr", "arr_1", ".datalad").mkdir()
+    Path("sample.zarr", "arr_1", ".datalad", "config").touch()
+    r = runner.invoke(digest, ["--digest", "zarr-checksum", "sample.zarr"])
+    assert r.exit_code == 0
+    assert r.output == f"sample.zarr: {expected}\n"

--- a/dandi/cli/tests/test_download.py
+++ b/dandi/cli/tests/test_download.py
@@ -98,10 +98,11 @@ def test_download_bad_type(mocker):
     mock_download.assert_not_called()
 
 
-def test_download_gui_instance_in_dandiset(mocker):
+def test_download_gui_instance_in_dandiset(mocker, tmp_path, monkeypatch):
     mock_download = mocker.patch("dandi.download.download")
     runner = CliRunner()
-    with runner.isolated_filesystem():
+    with monkeypatch.context() as m:
+        m.chdir(tmp_path)
         Path(dandiset_metadata_file).write_text("identifier: '123456'\n")
         r = runner.invoke(download, ["-i", "dandi"])
     assert r.exit_code == 0
@@ -124,10 +125,11 @@ def test_download_gui_instance_in_dandiset(mocker):
     bool(known_instances["dandi-api-local-docker-tests"].gui),
     reason="this instance now has GUI URL",
 )
-def test_download_api_instance_in_dandiset(mocker):
+def test_download_api_instance_in_dandiset(mocker, tmp_path, monkeypatch):
     mock_download = mocker.patch("dandi.download.download")
     runner = CliRunner()
-    with runner.isolated_filesystem():
+    with monkeypatch.context() as m:
+        m.chdir(tmp_path)
         Path(dandiset_metadata_file).write_text("identifier: '123456'\n")
         r = runner.invoke(download, ["-i", "dandi-api-local-docker-tests"])
     assert r.exit_code == 0


### PR DESCRIPTION
## Problem

The daily test runs started failing across macOS and Windows (e.g. [run 33012624230](https://github.com/dandi/dandi-cli/actions/runs/33012624230)) with 11 failures per job, all of the same shape:

```
DeprecationWarning: 'isolated_filesystem' is deprecated and will be removed in
Click 9.0. Use 'tempfile.TemporaryDirectory' or pytest's 'tmp_path' fixture
with absolute paths instead.
```

Click 8.3 deprecated `CliRunner.isolated_filesystem()`, and `tox.ini` sets `filterwarnings = error`, so every test using it now errors out. Nothing in this repo changed — the new Click release did.

Affected tests: `test_command.py::test_smoke[command0]`, all of `test_digest.py`'s `isolated_filesystem` users, and `test_download.py::test_download_gui_instance_in_dandiset` (plus `test_download_api_instance_in_dandiset`, which is skipped in that matrix).

## Changes

- Replace `runner.isolated_filesystem()` with `monkeypatch.chdir(tmp_path)` in `dandi/cli/tests/test_digest.py`, `test_command.py`, and `test_download.py`. Where the isolation only needs to cover part of the test, `monkeypatch.context()` scopes the `chdir` the same way the context manager did.
- Drop the `Version(click.__version__) < Version("8.0.0")` check in `dandi/cli/cmd_shell_completion.py`. `click.__version__` is itself deprecated in Click 8.2+ (removed in 9.1) and would trip the same warning-as-error if that code ever ran in-process; since `pyproject.toml` already requires `click >= 8.2`, the pre-8.0 branch was dead code.

### A note on `chdir` vs. absolute paths

Click's [upgrade guide](https://github.com/pallets/click/blob/68e7ea7228ca144c52e4d1d282cc09da59f7771f/docs/upgrade-guides.md) deprecated the helper specifically because it "relies on `os.chdir`, which mutates process-global state and is therefore not thread-safe", and recommends `tmp_path` **with absolute paths** rather than changing directory at all.

This PR keeps a `chdir` (via `monkeypatch`, so it is undone at teardown) rather than going all the way to absolute paths, because two of the three files are testing cwd-dependent behaviour and cannot use absolute paths:

- `test_command.py::test_smoke` invokes the command with **no arguments** — the point is that a bare invocation in an empty directory does not crash.
- `test_download.py` writes `dandiset.yaml` into the cwd and invokes `download -i dandi` with no path, so the command discovers the dandiset from the cwd.

`test_digest.py` *could* be converted to pass absolute paths (the expected output would become `f"{path}: {hash}"`), which would drop `chdir` from six more tests. Happy to do that here if preferred — it is left out for now to keep this focused on unbreaking the daily runs.

## Verification

Against Click 8.5.0 locally:

- Before the change: `pytest dandi/cli/tests/test_digest.py` → `9 failed`, reproducing the CI `DeprecationWarning`.
- After: `pytest dandi/cli/tests/test_digest.py dandi/cli/tests/test_download.py dandi/cli/tests/test_command.py dandi/cli/tests/test_shell_completion.py` → `33 passed, 1 skipped`.
- `black --check`, `flake8`, and `mypy` are clean on the touched files (mypy error count unchanged from the pre-change baseline).

The 7 unrelated failures in `test_cmd_ls.py` / `test_cmd_validate.py` seen locally reproduce identically on `master` in this sandbox (network-dependent URL tests and BIDS data) and are not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mGcaCZQifniKkPUJnPDWv