### PR TITLE
Tolerate the filesystem's mtime granularity in `download -e refresh`

### DIFF
--- a/dandi/download.py
+++ b/dandi/download.py
@@ -59,6 +59,7 @@ from .utils import (
     ensure_datetime,
     exclude_from_zarr,
     flattened,
+    get_mtime_granularity,
     get_retry_after,
     is_same_time,
     path_is_subpath,
@@ -700,9 +701,20 @@ def _download_file(
                     f"{path!r} - no mtime or ctime in the record, redownloading"
                 )
             else:
-                stat = os.stat(op.realpath(path))
+                realpath = op.realpath(path)
+                stat = os.stat(realpath)
+                # The mtime we compare against is the one we set ourselves via
+                # os.utime() after the previous download, so the comparison is
+                # really a filesystem round trip.  Not every filesystem stores
+                # mtimes at the resolution os.stat() reports them at (mounted
+                # Windows volumes, FAT/exFAT and some network filesystems
+                # truncate or round), so tolerate whatever granularity the
+                # destination filesystem actually has instead of assuming that
+                # the value round-trips exactly.  See
+                # https://github.com/dandi/dandi-cli/issues/1907
+                tolerance = get_mtime_granularity(op.dirname(realpath))
                 same = []
-                if is_same_time(stat.st_mtime, mtime):
+                if is_same_time(stat.st_mtime, mtime, tolerance=tolerance):
                     same.append("mtime")
                 if size is not None and stat.st_size == size:
                     same.append("size")
@@ -712,7 +724,22 @@ def _download_file(
                     # TODO: add recording and handling of .nwb object_id
                     yield _skip_file("same time and size", size=size)
                     return
-                lgr.debug(f"{path!r} - same attributes: {same}.  Redownloading")
+                lgr.debug(
+                    "%r - same attributes: %s.  Redownloading.  "
+                    "Local mtime: %s (%.6f), record mtime: %s (%.6f), "
+                    "delta: %.6f s, tolerated mtime granularity: %g s, "
+                    "local size: %s, record size: %s",
+                    str(path),
+                    same,
+                    ensure_datetime(stat.st_mtime),
+                    stat.st_mtime,
+                    mtime,
+                    mtime.timestamp(),
+                    abs(stat.st_mtime - mtime.timestamp()),
+                    tolerance,
+                    stat.st_size,
+                    size,
+                )
 
     if size is not None:
         yield {"size": size}

--- a/dandi/tests/fixtures.py
+++ b/dandi/tests/fixtures.py
@@ -40,6 +40,7 @@ from ..consts import (
 from ..dandiapi import DandiAPIClient, RemoteDandiset
 from ..pynwb_utils import make_nwb_file
 from ..upload import upload
+from ..utils import _mtime_granularity_cache
 
 lgr = get_logger()
 
@@ -69,6 +70,44 @@ BIDS_ERROR_TESTDATA_SELECTION = ["invalid_asl003", "invalid_pet001"]
 @pytest.fixture(autouse=True)
 def capture_all_logs(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG, logger="dandi")
+
+
+@pytest.fixture()
+def coarse_mtime_fs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[Callable[[float], None]]:
+    """Simulate a filesystem that does not store sub-second mtimes
+
+    Yields a callable taking the granularity (in seconds) with which mtimes
+    should be stored; until it is called, mtimes are stored as given.  This is
+    done by patching `os.utime()` to quantize the times it is asked to set,
+    which is what filesystems such as those on mounted Windows volumes, FAT and
+    exFAT effectively do — real (ext4/XFS/tmpfs) temporary directories store
+    mtimes with nanosecond resolution and so cannot exercise this behavior.
+
+    Also clears `dandi.utils`'s cache of probed mtime granularities, both before
+    and after the test, since the patching changes what would be probed for an
+    already-visited filesystem.
+    """
+    real_utime = os.utime
+    granularity = 0.0
+
+    def quantizing_utime(path: Any, times: Any = None, **kwargs: Any) -> None:
+        if granularity and times is not None:
+            times = tuple(t // granularity * granularity for t in times)
+        real_utime(path, times, **kwargs)
+
+    def set_granularity(value: float) -> None:
+        nonlocal granularity
+        granularity = value
+        _mtime_granularity_cache.clear()
+
+    monkeypatch.setattr(os, "utime", quantizing_utime)
+    _mtime_granularity_cache.clear()
+    try:
+        yield set_granularity
+    finally:
+        _mtime_granularity_cache.clear()
 
 
 # TODO: move into some common fixtures.  We might produce a number of files

--- a/dandi/tests/test_download.py
+++ b/dandi/tests/test_download.py
@@ -219,6 +219,9 @@ def test_download_file_refresh_coarse_mtime_fs(
     assert path.read_bytes() == COARSE_MTIME_CONTENT
     assert downloads == 1
 
+    # The refresh pass must not transfer anything at all, however coarsely the
+    # filesystem happened to store the mtime just set
+    downloads = 0
     assert download_it(DownloadExisting.REFRESH) == [
         {
             "status": "skipped",
@@ -226,7 +229,7 @@ def test_download_file_refresh_coarse_mtime_fs(
             "size": len(COARSE_MTIME_CONTENT),
         }
     ]
-    assert downloads == 1
+    assert downloads == 0
 
 
 @pytest.mark.ai_generated

--- a/dandi/tests/test_download.py
+++ b/dandi/tests/test_download.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from contextlib import nullcontext
+from datetime import datetime, timedelta, timezone
 from email.utils import parsedate_to_datetime
 from functools import partial
 from glob import glob
@@ -13,6 +14,7 @@ import os.path
 from pathlib import Path
 import re
 from shutil import rmtree
+from threading import Lock
 import time
 from unittest import mock
 
@@ -39,6 +41,7 @@ from ..download import (
     ProgressCombiner,
     PYOUTHelper,
     _check_attempts_and_sleep,
+    _download_file,
     download,
 )
 from ..exceptions import NotFoundError
@@ -168,6 +171,101 @@ def test_download_000027_resume(
         assert digester(str(nwb)) != digests
     else:
         assert digester(str(nwb)) == digests
+
+
+#: An arbitrary asset mtime with a non-zero sub-second component, i.e. one that
+#: does not survive a round trip through a filesystem storing whole seconds only
+COARSE_MTIME_RECORD = datetime(2026, 8, 22, 15, 21, 20, 651000, tzinfo=timezone.utc)
+
+COARSE_MTIME_CONTENT = b"This is test text.\n"
+
+
+@pytest.mark.ai_generated
+@pytest.mark.parametrize("granularity", [0.0, 1.0, 2.0])
+def test_download_file_refresh_coarse_mtime_fs(
+    tmp_path: Path, coarse_mtime_fs: Callable[[float], None], granularity: float
+) -> None:
+    """`existing=refresh` must skip an unchanged file no matter how coarsely the
+    filesystem stores the mtime that we ourselves set after downloading it.
+
+    Regression test for https://github.com/dandi/dandi-cli/issues/1907 , where
+    every file of a dandiset was redownloaded on every run whenever the
+    destination did not store sub-second mtimes (a mounted Windows volume,
+    FAT/exFAT, some network filesystems).
+    """
+    coarse_mtime_fs(granularity)
+    path = tmp_path / "file.txt"
+    downloads = 0
+
+    def downloader(start_at: int = 0) -> Iterator[bytes]:
+        nonlocal downloads
+        downloads += 1
+        yield COARSE_MTIME_CONTENT[start_at:]
+
+    def download_it(existing: DownloadExisting) -> list[dict]:
+        return list(
+            _download_file(
+                downloader,
+                path,
+                tmp_path,
+                Lock(),
+                size=len(COARSE_MTIME_CONTENT),
+                mtime=COARSE_MTIME_RECORD,
+                existing=existing,
+            )
+        )
+
+    assert {"status": "setting mtime"} in download_it(DownloadExisting.ERROR)
+    assert path.read_bytes() == COARSE_MTIME_CONTENT
+    assert downloads == 1
+
+    assert download_it(DownloadExisting.REFRESH) == [
+        {
+            "status": "skipped",
+            "message": "same time and size",
+            "size": len(COARSE_MTIME_CONTENT),
+        }
+    ]
+    assert downloads == 1
+
+
+@pytest.mark.ai_generated
+def test_download_file_refresh_reports_mtime_mismatch(
+    tmp_path: Path,
+    coarse_mtime_fs: Callable[[float], None],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A genuinely out-of-date file is still redownloaded, and the rejected skip
+    reports both timestamps, their delta, and the tolerance applied."""
+    coarse_mtime_fs(1.0)
+    path = tmp_path / "file.txt"
+    path.write_bytes(COARSE_MTIME_CONTENT)
+    # The local copy is an hour older than the record
+    stale = COARSE_MTIME_RECORD - timedelta(hours=1)
+    os.utime(path, (time.time(), stale.timestamp()))
+
+    def downloader(start_at: int = 0) -> Iterator[bytes]:
+        yield COARSE_MTIME_CONTENT[start_at:]
+
+    statuses = list(
+        _download_file(
+            downloader,
+            path,
+            tmp_path,
+            Lock(),
+            size=len(COARSE_MTIME_CONTENT),
+            mtime=COARSE_MTIME_RECORD,
+            existing=DownloadExisting.REFRESH,
+        )
+    )
+    assert {"status": "downloading"} in statuses
+
+    (msg,) = [
+        r.getMessage() for r in caplog.records if "Redownloading" in r.getMessage()
+    ]
+    assert "same attributes: ['size']" in msg
+    assert "delta: 3600.65" in msg
+    assert "tolerated mtime granularity: 1 s" in msg
 
 
 def test_download_newest_version(text_dandiset: SampleDandiset, tmp_path: Path) -> None:

--- a/dandi/tests/test_utils.py
+++ b/dandi/tests/test_utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 import inspect
 import logging
 import os.path as op
@@ -26,6 +26,7 @@ from ..utils import (
     get_instance,
     get_mime_type,
     get_module_version,
+    get_mtime_granularity,
     get_utcnow_datetime,
     is_page2_url,
     is_same_time,
@@ -147,6 +148,37 @@ def test_times_manipulations() -> None:
     # milliseconds
     assert not is_same_time(t0, t1, tolerance=0)
     assert is_same_time(t0, t1_epoch + 100, tolerance=101)
+
+
+@pytest.mark.ai_generated
+def test_get_mtime_granularity_fine(
+    tmp_path: Path, coarse_mtime_fs: Callable[[float], None]
+) -> None:
+    # The fixture is requested (without setting a granularity) merely to get the
+    # granularity cache cleared around the test
+    assert get_mtime_granularity(tmp_path) == 1e-6
+    # A file may be passed in place of its directory
+    (tmp_path / "file.txt").write_text("hello")
+    assert get_mtime_granularity(tmp_path / "file.txt") == 1e-6
+    # ... as may a path that does not exist yet
+    assert get_mtime_granularity(tmp_path / "nonexistent.txt") == 1e-6
+
+
+@pytest.mark.ai_generated
+@pytest.mark.parametrize("granularity", [1.0, 2.0])
+def test_get_mtime_granularity_coarse(
+    tmp_path: Path, coarse_mtime_fs: Callable[[float], None], granularity: float
+) -> None:
+    coarse_mtime_fs(granularity)
+    assert get_mtime_granularity(tmp_path) == granularity
+
+
+@pytest.mark.ai_generated
+def test_get_mtime_granularity_unprobeable(
+    tmp_path: Path, coarse_mtime_fs: Callable[[float], None]
+) -> None:
+    # The fixture is requested merely to get the granularity cache cleared
+    assert get_mtime_granularity(tmp_path / "no" / "such" / "dir") == 1.0
 
 
 @pytest.mark.parametrize(

--- a/dandi/utils.py
+++ b/dandi/utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from bisect import bisect
 from collections.abc import Iterable, Iterator
+from contextlib import suppress
 import datetime
 from email.utils import parsedate_to_datetime
 from enum import Enum
@@ -21,6 +22,8 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
+import threading
 from time import sleep
 import traceback
 import types
@@ -155,6 +158,124 @@ def is_same_time(
         (t1 - t2 if t1 > t2 else t2 - t1) <= tolerance_dt
         for (t1, t2) in itertools.combinations(norm_times, 2)
     )
+
+
+#: mtime granularity (in seconds) assumed whenever the filesystem could not be
+#: probed by `get_mtime_granularity()`.  One second covers the common coarse
+#: cases (mounted Windows volumes, FAT/exFAT, some network filesystems) without
+#: being so wide that genuinely modified files would look unchanged.
+DEFAULT_MTIME_GRANULARITY = 1.0
+
+#: mtime granularities (in seconds) that filesystems are known to use, from
+#: finest to coarsest.  A probed deviation is rounded up to one of these.  The
+#: finest entry is 1 microsecond and not any finer since, at present-day epoch
+#: values, that is about the resolution a 64-bit float can represent anyway.
+_MTIME_GRANULARITIES = (1e-6, 1e-3, 1.0, 2.0)
+
+#: Probed mtime granularities, keyed by ``st_dev`` of the filesystem
+_mtime_granularity_cache: dict[int, float] = {}
+
+_mtime_granularity_lock = threading.Lock()
+
+
+def _probe_mtime_granularity(directory: Path) -> float:
+    """Measure the mtime granularity of the filesystem holding ``directory``
+
+    Done by writing a series of timestamps to a temporary file with
+    `os.utime()` and reading them back with `os.stat()`; the largest deviation
+    introduced by such a round trip is rounded up to one of
+    `_MTIME_GRANULARITIES`.
+    """
+    # An arbitrary, fixed timestamp of the present era (2023-11-14T22:13:20Z)
+    # with an even number of seconds.  Present-era rather than, say, 0 so that
+    # the floating point resolution of the probe matches that of the mtimes
+    # actually compared; even so that filesystems rounding to a multiple of two
+    # seconds (FAT) are detected by the offsets crossing a second boundary.
+    base = 1700000000.0
+    offsets = (0.0, 5e-7, 5e-4, 0.5, 1.0, 1.5)
+    tmpfile = None
+    try:
+        fd, tmpfile = tempfile.mkstemp(prefix=".dandi-mtime-probe-", dir=directory)
+        os.close(fd)
+        deviation = 0.0
+        for offset in offsets:
+            written = base + offset
+            os.utime(tmpfile, (written, written))
+            deviation = max(deviation, abs(os.stat(tmpfile).st_mtime - written))
+    except OSError as exc:
+        lgr.warning(
+            "Could not determine the mtime granularity of the filesystem "
+            "holding %s (%s); assuming %g second(s)",
+            directory,
+            exc,
+            DEFAULT_MTIME_GRANULARITY,
+        )
+        return DEFAULT_MTIME_GRANULARITY
+    finally:
+        if tmpfile is not None:
+            with suppress(OSError):
+                os.unlink(tmpfile)
+    for granularity in _MTIME_GRANULARITIES:
+        if deviation <= granularity:
+            break
+    else:
+        granularity = deviation
+    lgr.debug(
+        "Filesystem holding %s stores mtimes with a granularity of %g second(s) "
+        "(largest observed round-trip deviation: %g s)",
+        directory,
+        granularity,
+        deviation,
+    )
+    return granularity
+
+
+def get_mtime_granularity(path: str | Path) -> float:
+    """Determine how precisely a filesystem stores modification times
+
+    Not every filesystem records mtimes with the resolution that `os.stat()`
+    reports: mounted Windows volumes, FAT/exFAT and some network filesystems
+    truncate or round the value they are given, so a timestamp written with
+    `os.utime()` does not necessarily read back exactly.  The returned value is
+    the largest deviation that such a round trip may introduce, and is thus
+    usable as a tolerance (cf. `is_same_time()`) when comparing a stored mtime
+    against the value it was set from.
+
+    The result is cached per filesystem (as identified by ``st_dev``), so that
+    the probing is performed at most once per filesystem per process.
+
+    Parameters
+    ----------
+    path: str or Path
+      A path on the filesystem of interest.  If it is not a directory, its
+      parent directory is probed, which must exist and be writable.
+
+    Returns
+    -------
+    float
+      The granularity in seconds; `DEFAULT_MTIME_GRANULARITY` if the filesystem
+      could not be probed.
+    """
+    directory = Path(path)
+    if not directory.is_dir():
+        directory = directory.parent
+    try:
+        dev = os.stat(directory).st_dev
+    except OSError as exc:
+        lgr.warning(
+            "Could not stat %s (%s); assuming an mtime granularity of %g second(s)",
+            directory,
+            exc,
+            DEFAULT_MTIME_GRANULARITY,
+        )
+        return DEFAULT_MTIME_GRANULARITY
+    with _mtime_granularity_lock:
+        try:
+            return _mtime_granularity_cache[dev]
+        except KeyError:
+            granularity = _probe_mtime_granularity(directory)
+            _mtime_granularity_cache[dev] = granularity
+            return granularity
 
 
 def ensure_strtime(


### PR DESCRIPTION
Closes #1907.

## Problem

`dandi download -e refresh` never skips anything on a filesystem that does not store
sub-second mtimes, so it re-transfers every asset of every dandiset on every invocation.

The refresh branch of `_download_file()` compares the asset's recorded mtime against the
mtime read back from the local file — but that mtime is one dandi set itself with
`os.utime()` at the end of the previous download, so the comparison is really a
filesystem round trip.  It was performed with `is_same_time()`'s default `tolerance` of
one microsecond, i.e. it assumed the value round-trips exactly.

- ext4/XFS/tmpfs store nanosecond mtimes, so the round trip *is* exact and refresh
  works.  That is why the bug is invisible to most developers and to CI.
- A filesystem that truncates or rounds mtimes (a mounted Windows volume, FAT/exFAT,
  some network mounts) reads back a value up to a full second off — six orders of
  magnitude past the tolerance.  `same` ends up `["size"]`, the
  `same == ["mtime", "size"]` check fails, and the file is redownloaded.  Every file,
  every time, permanently.

Reported against a nightly cron job pulling four dandisets (~32 GB) into `/mnt/g/...`
under WSL2: ~16 minutes of re-transfer per run with nothing changed upstream.

## Approach

Three options were weighed (see the issue):

1. **Measure the destination filesystem's granularity and widen the tolerance to it** —
   chosen.
2. Compare with `>=` as `_populate_dandiset_yaml()` does — **rejected**: truncation
   makes the local mtime *smaller* than the record, so `local >= record` is false there
   too.  `dandiset.yaml` skips because of the content-equality check that precedes the
   `>=` branch (hence its `no change` message), not because of the comparison, so
   copying that comparison would not have fixed the asset path.  Rounding filesystems
   (FAT) can also err in either direction.
3. Size + digest fallback when mtime disagrees — correct, but pays a rehash of the whole
   dandiset on every run, and would mask rather than fix the granularity assumption.
   The existing `TODO` in that branch is left in place.

## Changes

**`dandi/utils.py`** — new `get_mtime_granularity(path)`.  It measures how precisely a
filesystem stores mtimes by writing a series of timestamps to a temporary file with
`os.utime()` and reading them back with `os.stat()`, then rounds the largest observed
round-trip deviation up to one of the granularities filesystems are known to use
(1 µs / 1 ms / 1 s / 2 s).  Results are cached per filesystem (keyed by `st_dev`), so
the probing happens at most once per filesystem per process, and `DEFAULT_MTIME_GRANULARITY`
(1 s) is returned with a warning if the filesystem cannot be probed.

The probe timestamps are anchored at a present-era epoch value so that the float
resolution of the probe matches that of the mtimes actually compared, and include
offsets crossing a second boundary so that filesystems rounding to a multiple of two
seconds are detected too.

**`dandi/download.py`** — the refresh comparison now passes that granularity as
`is_same_time()`'s `tolerance`.  This is self-correcting across filesystems: it resolves
to the current 1 µs tolerance on ext4/XFS/tmpfs and widens only where the filesystem
genuinely cannot do better.

The rejected-skip debug message now reports both timestamps, their delta, the tolerance
applied and both sizes, instead of only naming which attributes matched:

```
'/mnt/g/000027/sub-RAT123/sub-RAT123.nwb' - same attributes: ['size'].  Redownloading.
Local mtime: 2026-08-22 15:21:20+00:00 (1787412080.000000),
record mtime: 2026-08-22 15:21:20.651000+00:00 (1787412080.651000),
delta: 0.651000 s, tolerated mtime granularity: 1 s, local size: 19, record size: 19
```

## Tests

A real ext4 temp dir cannot exercise this class of bug, so a new `coarse_mtime_fs`
fixture patches `os.utime()` to quantize the times it is asked to set — which is what a
coarse-granularity filesystem effectively does — and clears the granularity cache around
the test.

- `test_download_file_refresh_coarse_mtime_fs[0.0/1.0/2.0]` downloads a file through
  `_download_file()` and then refreshes it, asserting the second pass is
  `skipped / same time and size` and that the downloader is not called again.  This
  exercises the full write-then-compare round trip rather than a synthetic mtime.
- `test_download_file_refresh_reports_mtime_mismatch` asserts a genuinely out-of-date
  file is still redownloaded and that the debug message carries the timestamps, delta
  and tolerance.
- `test_get_mtime_granularity_{fine,coarse,unprobeable}` cover the probe directly.

All new tests carry `@pytest.mark.ai_generated`.  Verified that the three
coarse-granularity tests fail on the pre-fix code and pass after; the `[0.0]`
(ext4 baseline) case passes both ways, as expected.

`black`/`isort` (at the pinned pre-commit versions), `flake8` and `mypy` are clean, and
the full suite still collects.  Test failures in this environment were limited to the
pre-existing network/proxy-dependent ones, which fail identically on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VGH4mHn6chhLQfGrAYgrBY

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGH4mHn6chhLQfGrAYgrBY)_