### PR TITLE
Tolerate coarse filesystem mtimes in `download -e refresh` with a fixed 2 s window

### DIFF
--- a/dandi/download.py
+++ b/dandi/download.py
@@ -68,6 +68,21 @@ from .utils import (
 
 lgr = get_logger()
 
+#: Tolerance (in seconds) for comparing a local file's mtime against the mtime
+#: recorded for the asset when deciding whether ``DownloadExisting.REFRESH``
+#: may skip a redownload.  The local mtime is one we set ourselves via
+#: `os.utime()` at the end of the previous download, so the comparison is
+#: really a filesystem round trip — and not every filesystem stores mtimes at
+#: the resolution `os.stat()` reports them at: mounted Windows volumes,
+#: FAT/exFAT and some network filesystems truncate or round the value, by up
+#: to FAT's 2 s granularity.  Tolerate that coarsest known granularity
+#: everywhere (cf. rsync's ``--modify-window``) instead of assuming the value
+#: round-trips exactly.  A skip additionally requires an exact size match, and
+#: the recorded mtime only moves when the asset is actually replaced, so the
+#: widened window cannot in practice mistake an updated asset for an unchanged
+#: one.  https://github.com/dandi/dandi-cli/issues/1907
+REFRESH_MTIME_TOLERANCE = 2.0
+
 
 class DownloadExisting(StrEnum):
     ERROR = "error"
@@ -702,7 +717,9 @@ def _download_file(
             else:
                 stat = os.stat(op.realpath(path))
                 same = []
-                if is_same_time(stat.st_mtime, mtime):
+                if is_same_time(
+                    stat.st_mtime, mtime, tolerance=REFRESH_MTIME_TOLERANCE
+                ):
                     same.append("mtime")
                 if size is not None and stat.st_size == size:
                     same.append("size")
@@ -712,7 +729,21 @@ def _download_file(
                     # TODO: add recording and handling of .nwb object_id
                     yield _skip_file("same time and size", size=size)
                     return
-                lgr.debug(f"{path!r} - same attributes: {same}.  Redownloading")
+                lgr.debug(
+                    "%r - same attributes: %s.  Redownloading.  "
+                    "Local mtime: %s (%.6f), record mtime: %s (%.6f), "
+                    "delta: %.6f s, tolerance: %g s, local size: %s, record size: %s",
+                    str(path),
+                    same,
+                    ensure_datetime(stat.st_mtime),
+                    stat.st_mtime,
+                    mtime,
+                    mtime.timestamp(),
+                    abs(stat.st_mtime - mtime.timestamp()),
+                    REFRESH_MTIME_TOLERANCE,
+                    stat.st_size,
+                    size,
+                )
 
     if size is not None:
         yield {"size": size}

--- a/dandi/tests/fixtures.py
+++ b/dandi/tests/fixtures.py
@@ -71,6 +71,36 @@ def capture_all_logs(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG, logger="dandi")
 
 
+@pytest.fixture()
+def coarse_mtime_fs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[Callable[[float], None]]:
+    """Simulate a filesystem that does not store sub-second mtimes
+
+    Yields a callable taking the granularity (in seconds) with which mtimes
+    should henceforth be stored; until it is called, mtimes are stored as
+    given.  This is done by patching `os.utime()` to quantize the times it is
+    asked to set, which is what filesystems such as those on mounted Windows
+    volumes, FAT and exFAT effectively do — real (ext4/XFS/tmpfs) temporary
+    directories store mtimes with nanosecond resolution and so cannot exercise
+    this behavior.
+    """
+    real_utime = os.utime
+    granularity = 0.0
+
+    def quantizing_utime(path: Any, times: Any = None, **kwargs: Any) -> None:
+        if granularity and times is not None:
+            times = tuple(t // granularity * granularity for t in times)
+        real_utime(path, times, **kwargs)
+
+    def set_granularity(value: float) -> None:
+        nonlocal granularity
+        granularity = value
+
+    monkeypatch.setattr(os, "utime", quantizing_utime)
+    yield set_granularity
+
+
 # TODO: move into some common fixtures.  We might produce a number of files
 #       and also carry some small ones directly in git for regression testing
 @pytest.fixture(scope="session")

--- a/dandi/tests/test_download.py
+++ b/dandi/tests/test_download.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from contextlib import nullcontext
+from datetime import datetime, timedelta, timezone
 from email.utils import parsedate_to_datetime
 from functools import partial
 from glob import glob
@@ -13,6 +14,7 @@ import os.path
 from pathlib import Path
 import re
 from shutil import rmtree
+from threading import Lock
 import time
 from unittest import mock
 
@@ -39,6 +41,7 @@ from ..download import (
     ProgressCombiner,
     PYOUTHelper,
     _check_attempts_and_sleep,
+    _download_file,
     download,
 )
 from ..exceptions import NotFoundError
@@ -168,6 +171,104 @@ def test_download_000027_resume(
         assert digester(str(nwb)) != digests
     else:
         assert digester(str(nwb)) == digests
+
+
+#: An arbitrary asset mtime with a non-zero sub-second component, i.e. one that
+#: does not survive a round trip through a filesystem storing whole seconds only
+COARSE_MTIME_RECORD = datetime(2026, 8, 22, 15, 21, 20, 651000, tzinfo=timezone.utc)
+
+COARSE_MTIME_CONTENT = b"This is test text.\n"
+
+
+@pytest.mark.ai_generated
+@pytest.mark.parametrize("granularity", [0.0, 1.0, 2.0])
+def test_download_file_refresh_coarse_mtime_fs(
+    tmp_path: Path, coarse_mtime_fs: Callable[[float], None], granularity: float
+) -> None:
+    """`existing=refresh` must skip an unchanged file no matter how coarsely the
+    filesystem stores the mtime that we ourselves set after downloading it.
+
+    Regression test for https://github.com/dandi/dandi-cli/issues/1907 , where
+    every file of a dandiset was redownloaded on every run whenever the
+    destination did not store sub-second mtimes (a mounted Windows volume,
+    FAT/exFAT, some network filesystems).
+    """
+    coarse_mtime_fs(granularity)
+    path = tmp_path / "file.txt"
+    downloads = 0
+
+    def downloader(start_at: int = 0) -> Iterator[bytes]:
+        nonlocal downloads
+        downloads += 1
+        yield COARSE_MTIME_CONTENT[start_at:]
+
+    def download_it(existing: DownloadExisting) -> list[dict]:
+        return list(
+            _download_file(
+                downloader,
+                path,
+                tmp_path,
+                Lock(),
+                size=len(COARSE_MTIME_CONTENT),
+                mtime=COARSE_MTIME_RECORD,
+                existing=existing,
+            )
+        )
+
+    assert {"status": "setting mtime"} in download_it(DownloadExisting.ERROR)
+    assert path.read_bytes() == COARSE_MTIME_CONTENT
+    assert downloads == 1
+
+    # The refresh pass must not transfer anything at all, however coarsely the
+    # filesystem happened to store the mtime just set
+    downloads = 0
+    assert download_it(DownloadExisting.REFRESH) == [
+        {
+            "status": "skipped",
+            "message": "same time and size",
+            "size": len(COARSE_MTIME_CONTENT),
+        }
+    ]
+    assert downloads == 0
+
+
+@pytest.mark.ai_generated
+def test_download_file_refresh_reports_mtime_mismatch(
+    tmp_path: Path,
+    coarse_mtime_fs: Callable[[float], None],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A genuinely out-of-date file is still redownloaded, and the rejected skip
+    reports both timestamps, their delta, and the tolerance applied."""
+    coarse_mtime_fs(1.0)
+    path = tmp_path / "file.txt"
+    path.write_bytes(COARSE_MTIME_CONTENT)
+    # The local copy is an hour older than the record
+    stale = COARSE_MTIME_RECORD - timedelta(hours=1)
+    os.utime(path, (time.time(), stale.timestamp()))
+
+    def downloader(start_at: int = 0) -> Iterator[bytes]:
+        yield COARSE_MTIME_CONTENT[start_at:]
+
+    statuses = list(
+        _download_file(
+            downloader,
+            path,
+            tmp_path,
+            Lock(),
+            size=len(COARSE_MTIME_CONTENT),
+            mtime=COARSE_MTIME_RECORD,
+            existing=DownloadExisting.REFRESH,
+        )
+    )
+    assert {"status": "downloading"} in statuses
+
+    (msg,) = [
+        r.getMessage() for r in caplog.records if "Redownloading" in r.getMessage()
+    ]
+    assert "same attributes: ['size']" in msg
+    assert "delta: 3600.65" in msg
+    assert "tolerance: 2 s" in msg
 
 
 def test_download_newest_version(text_dandiset: SampleDandiset, tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #1907.  Simpler alternative to #1908.

## Problem

`dandi download -e refresh` never skips anything on a filesystem that does not store sub-second mtimes, so it re-transfers every asset of every dandiset on every invocation.

The refresh branch of `_download_file()` compares the asset's recorded mtime against the mtime read back from the local file — but that mtime is one dandi set itself with `os.utime()` at the end of the previous download, so the comparison is really a filesystem round trip.  It was performed with `is_same_time()`'s default `tolerance` of one microsecond, i.e. it assumed the value round-trips exactly.  ext4/XFS/tmpfs store nanosecond mtimes, so the bug is invisible to most developers and to CI; a filesystem that truncates or rounds mtimes (a mounted Windows volume, FAT/exFAT, some network mounts) reads back a value up to 1–2 s off, so the skip check fails for every file, every time, permanently.  See #1907 for the full mechanism and reproducer.

## Approach: a fixed modify-window instead of per-filesystem probing

#1908 resolves this by measuring each destination filesystem's actual mtime granularity at runtime (probe with a temp file, cache per `st_dev`) and using the measured value as the tolerance.  This PR instead compares with a fixed tolerance of **2 s** — the coarsest mtime granularity a filesystem is known to use (FAT) — the same approach as rsync's `--modify-window` and rclone's `--modify-window`.

The precision that probing buys is protection against a scenario the rest of the check already covers:

- The local mtime being compared is not an organic "was this file touched" signal — it is a marker dandi itself stamped from the very record value it later compares against.  The comparison's only job is "did our own stamp survive the filesystem round trip?".
- A skip additionally requires an **exact size match**, and the recorded mtime (`blobDateModified`) only moves when the asset is actually replaced on the server.  A false skip under a 2 s window therefore requires a same-size re-upload whose recorded mtime moved by less than 2 s — not a case that occurs in practice.
- Widening the tolerance can only convert redownloads into skips, never the reverse.
- On the coarse filesystems that actually exhibit the bug, the probe converges on 1–2 s anyway; its hard-coded granularity table already concedes 2 s as the ceiling.  A fixed window is the same fix minus the measurement apparatus.

Compared to probing, this drops ~120 lines of machinery and its operational failure modes: temp-file writes inside the user's dandiset (with stray probe files left behind if the process dies mid-probe), warnings on read-only destinations where an all-skipped refresh would otherwise work silently, a per-device cache and lock, and the assumption that quantization is one of a few known schemes.  There is also codebase precedent for treating mtimes as coarse: `_populate_dandiset_yaml()` compares at whole-second `>=` semantics and leans on content equality.

## Changes

**`dandi/download.py`** — the refresh comparison now passes `REFRESH_MTIME_TOLERANCE = 2.0` as `is_same_time()`'s `tolerance`, with the rationale documented on the constant.

The rejected-skip debug message now reports both timestamps, their delta, the tolerance applied and both sizes, instead of only naming which attributes matched (the diagnosability half of #1907):

```
'/mnt/g/000027/sub-RAT123/sub-RAT123.nwb' - same attributes: ['size'].  Redownloading.
Local mtime: 2026-08-22 15:21:20+00:00 (1787412080.000000),
record mtime: 2026-08-22 15:21:20.651000+00:00 (1787412080.651000),
delta: 0.651000 s, tolerance: 2 s, local size: 19, record size: 19
```

## Tests

A real ext4 temp dir cannot exercise this class of bug, so a new `coarse_mtime_fs` fixture patches `os.utime()` to quantize the times it is asked to set — which is what a coarse-granularity filesystem effectively does.

- `test_download_file_refresh_coarse_mtime_fs[0.0/1.0/2.0]` downloads a file through `_download_file()` and then refreshes it, asserting the second pass is `skipped / same time and size` and that the downloader is not called again.  This exercises the full write-then-compare round trip rather than a synthetic mtime.
- `test_download_file_refresh_reports_mtime_mismatch` asserts a genuinely out-of-date file is still redownloaded and that the debug message carries the timestamps, delta and tolerance.

All new tests carry `@pytest.mark.ai_generated`.  Verified that the `[1.0]` and `[2.0]` cases and the mismatch test fail on the pre-fix code and pass after; the `[0.0]` (ext4 baseline) case passes both ways, as expected.

`black`/`isort` (at the pinned pre-commit versions), `flake8`, `codespell` and `mypy` are clean, the full suite still collects, and the offline download unit tests pass.  Test failures in this environment were limited to pre-existing network/proxy-dependent ones in `test_utils.py`, which fail identically on an unmodified tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TarBMUbTumRRVoSSgRoDCs

---
_Generated by [Claude Code](https://claude.ai/code/session_01TarBMUbTumRRVoSSgRoDCs)_