### PR TITLE
Fix two recurring CI failures in daily scheduled runs

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -154,7 +154,7 @@ jobs:
         python -m pytest -s -v -m obolibrary dandi
 
     - name: Smoke test example code in docs
-      if: matrix.mode != 'dandi-api' && github.event_name == 'schedule'
+      if: matrix.mode != 'dandi-api' && matrix.mode != 'lowest-deps' && github.event_name == 'schedule'
       run: |
         set -ex
         cd docs/source/examples

--- a/dandi/metadata/util.py
+++ b/dandi/metadata/util.py
@@ -542,9 +542,9 @@ def parse_purlobourl(
 
     if url.startswith(NCBITAXON_URI_TEMPLATE.format("")):
         rdf_content_url = f"https://ontobee.org/ontology/rdf/NCBITaxon?iri={url}"
-        req = requests.get(rdf_content_url, allow_redirects=True)
+        req = requests.get(rdf_content_url, allow_redirects=True, timeout=30)
     else:
-        req = requests.get(url, allow_redirects=True)
+        req = requests.get(url, allow_redirects=True, timeout=30)
     req.raise_for_status()
     doc = parseString(req.text)
     for elfound in doc.getElementsByTagName("Class"):


### PR DESCRIPTION
1. Exclude `lowest-deps` from the smoke-test-docs step. That step runs `python "$f"` using the system Python, but in `lowest-deps` mode `dandi` is only installed inside the tox venv. Every scheduled run was failing with: ModuleNotFoundError: No module named 'dandi' Adding `matrix.mode != 'lowest-deps'` to the condition skips the step for that matrix entry (the tox run itself already validates the package under lowest-compatible dependency versions).

2. Add a 30 s timeout to the `requests.get()` calls in `parse_purlobourl`.  Without a timeout the function hangs indefinitely when ontobee/obolibrary is unreachable, and each test that calls it only terminates after the 300 s pytest-timeout fires. With timeout=30 the request raises `requests.exceptions.Timeout` (a `RequestException` subclass) quickly, so `mark_xfail_ontobee` can catch it in non-scheduled mode and the tenacity retries also abort fast instead of each waiting 300 s.